### PR TITLE
isNaN optimizations

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -4488,7 +4488,7 @@ function FPU(io)
             {
                 tag_word |= 1 << (i << 1);
             }
-            else if(isNaN(value) || value === Infinity || value === -Infinity)
+            else if(!isFinite(value))
             {
                 tag_word |= 2 << (i << 1);
             }
@@ -5201,28 +5201,28 @@ function FPU(io)
             case 2:
                 // fist
                 var st0 = get_st0();
-                if(isNaN(st0) || st0 > 0x7FFFFFFF || st0 < -0x80000000)
-                {
-                    invalid_arithmatic();
-                    safe_write32(addr, 0x80000000);
-                }
-                else
+                if(st0 <= 0x7FFFFFFF && st0 >= -0x80000000)
                 {
                     // TODO: Invalid operation
                     safe_write32(addr, integer_round(st0));
+                }
+                else
+                {
+                    invalid_arithmatic();
+                    safe_write32(addr, 0x80000000);
                 }
                 break;
             case 3:
                 // fistp
                 var st0 = get_st0();
-                if(isNaN(st0) || st0 > 0x7FFFFFFF || st0 < -0x80000000)
+                if(st0 <= 0x7FFFFFFF && st0 >= -0x80000000)
                 {
-                    invalid_arithmatic();
-                    safe_write32(addr, 0x80000000);
+                    safe_write32(addr, integer_round(st0));
                 }
                 else
                 {
-                    safe_write32(addr, integer_round(st0));
+                    invalid_arithmatic();
+                    safe_write32(addr, 0x80000000);
                 }
                 pop();
                 break;
@@ -5557,27 +5557,27 @@ function FPU(io)
             case 2:
                 // fist
                 var st0 = get_st0();
-                if(isNaN(st0) || st0 > 0x7FFF || st0 < -0x8000)
+                if(st0 <= 0x7FFF || st0 >= -0x8000)
                 {
-                    invalid_arithmatic();
-                    safe_write16(addr, 0x8000);
+                    safe_write16(addr, integer_round(st0));
                 }
                 else
                 {
-                    safe_write16(addr, integer_round(st0));
+                    invalid_arithmatic();
+                    safe_write16(addr, 0x8000);
                 }
                 break;
             case 3:
                 // fistp
                 var st0 = get_st0();
-                if(isNaN(st0) || st0 > 0x7FFF || st0 < -0x8000)
+                if(st0 <= 0x7FFF || st0 >= -0x8000)
                 {
-                    invalid_arithmatic();
-                    safe_write16(addr, 0x8000);
+                    safe_write16(addr, integer_round(st0));
                 }
                 else
                 {
-                    safe_write16(addr, integer_round(st0));
+                    invalid_arithmatic();
+                    safe_write16(addr, 0x8000);
                 }
                 pop();
                 break;
@@ -5595,7 +5595,7 @@ function FPU(io)
             case 7:
                 // fistp
                 var st0 = integer_round(get_st0());
-                if(isNaN(st0) || st0 > 0x7FFFFFFFFFFFFFFF || st0 < -0x8000000000000000)
+                if(!(st0 <= 0x7FFFFFFFFFFFFFFF && st0 >= -0x8000000000000000))
                 {
                     st0 = 0x8000000000000000;
                     invalid_arithmatic();

--- a/src/fpu.macro.js
+++ b/src/fpu.macro.js
@@ -396,7 +396,7 @@ function FPU(io)
             {
                 tag_word |= 1 << (i << 1);
             }
-            else if(isNaN(value) || value === Infinity || value === -Infinity)
+            else if(!isFinite(value))
             {
                 tag_word |= 2 << (i << 1);
             }
@@ -1205,28 +1205,28 @@ function FPU(io)
             case 2:
                 // fist
                 var st0 = get_st0();
-                if(isNaN(st0) || st0 > 0x7FFFFFFF || st0 < -0x80000000)
+                if(st0 <= 0x7FFFFFFF && st0 >= -0x80000000)
+                {
+                    // TODO: Invalid operation
+                    safe_write32(addr, integer_round(st0));
+                }
+                else
                 {
                     invalid_arithmatic();
                     safe_write32(addr, 0x80000000);
-                }
-                else
-                {   
-                    // TODO: Invalid operation
-                    safe_write32(addr, integer_round(st0));
                 }
                 break;
             case 3:
                 // fistp
                 var st0 = get_st0();
-                if(isNaN(st0) || st0 > 0x7FFFFFFF || st0 < -0x80000000)
+                if(st0 <= 0x7FFFFFFF && st0 >= -0x80000000)
+                {
+                    safe_write32(addr, integer_round(st0));
+                }
+                else
                 {
                     invalid_arithmatic();
                     safe_write32(addr, 0x80000000);
-                }
-                else
-                {   
-                    safe_write32(addr, integer_round(st0));
                 }
                 pop();
                 break;
@@ -1590,27 +1590,27 @@ function FPU(io)
             case 2:
                 // fist
                 var st0 = get_st0();
-                if(isNaN(st0) || st0 > 0x7FFF || st0 < -0x8000)
+                if(st0 <= 0x7FFF && st0 >= -0x8000)
+                {
+                    safe_write16(addr, integer_round(st0));
+                }
+                else
                 {
                     invalid_arithmatic();
                     safe_write16(addr, 0x8000);
-                }
-                else
-                {   
-                    safe_write16(addr, integer_round(st0));
                 }
                 break;
             case 3:
                 // fistp
                 var st0 = get_st0();
-                if(isNaN(st0) || st0 > 0x7FFF || st0 < -0x8000)
+                if(st0 <= 0x7FFF && st0 >= -0x8000)
+                {
+                    safe_write16(addr, integer_round(st0));
+                }
+                else
                 {
                     invalid_arithmatic();
                     safe_write16(addr, 0x8000);
-                }
-                else
-                {   
-                    safe_write16(addr, integer_round(st0));
                 }
                 pop();
                 break;
@@ -1633,7 +1633,7 @@ function FPU(io)
                 // fistp
                 var st0 = integer_round(get_st0());
 
-                if(isNaN(st0) || st0 > 0x7FFFFFFFFFFFFFFF || st0 < -0x8000000000000000)
+                if(!(st0 <= 0x7FFFFFFFFFFFFFFF || st0 >= -0x8000000000000000))
                 {
                     st0 = 0x8000000000000000;
                     invalid_arithmatic();


### PR DESCRIPTION
This change goal is get rid of unneeded `isNaN` checks.
1. Change `isNaN(n) || n === Infinity || n === -Infinity` to `!isFinite(n)` as it actually does the same (see http://es5.github.io/#x15.1.2.5).
2. Rearrange

``` javascript
if (isNaN(n) || n < -128 || n > 127){
  doInvalidStuff();
} else {
  doStuff();
}
```

to

``` javascript
if (n >= -128 && n < 127){
  doStuff();
} else {
  doInvalidStuff();
}
```

as any comparison yields `false` if `n` is NaN, and whole statement without `isNaN` runs much faster (9 times faster in V8!), see http://jsperf.com/separate-isnan.
