### PR TITLE
Using Mcpp instead of cpp.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "images"]
 	path = images
 	url = https://github.com/copy/images/
+[submodule "mcpp"]
+	path = mcpp
+	url = git@github.com:h8liu/mcpp.git


### PR DESCRIPTION
Using mcpp instead of cpp, so that it does not rely on gcc. The mcpp source is cloned from the original sourceforge one, and also a bug on line comments is fixed. It will generate several warnings on empty char though.

To get mcpp working, you need to update the mcpp submodule, "./configure", and "make". I also changed the makefile, though I think it would be nice if it first checks if mcpp is available, and then fall back to cpp.

Result: now it (seems to) work on OSX as well.

Thanks.
