### PR TITLE
MacOSX hack to use mcpp even if cpp is detecetd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,15 @@ BROWSER=chromium
 
 CPP_VERSION := $(shell cpp --version 2>/dev/null)
 
-ifdef CPP_VERSION
-	CPP=cpp -P -undef -Wundef -std=c99 -nostdinc -Wtrigraphs -fdollars-in-identifiers -C
-else
-	CPP=mcpp/src/mcpp -a -C -P 
+# MacosX Hack : 
+# "cpp" doesn't work as expected on MacosX
+# So we define mcpp as default, and cpp IF NOT "on MacosX" AND "CPP is defined"
+UNAME_S := $(shell uname -s)
+CPP=mcpp/src/mcpp -a -C -P 
+ifneq ($(UNAME_S),Darwin))
+        ifdef CPP_VERSION
+                CPP=cpp -P -undef -Wundef -std=c99 -nostdinc -Wtrigraphs -fdollars-in-identifiers -C
+        endif
 endif
 
 


### PR DESCRIPTION
the default llvm cpp doesn't work as expect on macosx, so we use mcpp on macosx even if cpp is detected.