### PR TITLE
fix underscore not showing on Ubuntu

### DIFF
--- a/v86.css
+++ b/v86.css
@@ -29,7 +29,7 @@
     font-family: Liberation Mono, DejaVu Sans Mono, Courier New, monospace;
     font-weight: bold;
     font-size: 15px;
-    line-height: 1;
+    line-height: normal;
 }
 #screen, #vga {
     border: 1px solid #555;


### PR DESCRIPTION
Without this change, underscore (being under the baseline in Liberation Mono and Courier New), is not showing.