### PR TITLE
Set longer timeout for test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ deploy.sh
 screenshots/
 tests/qemu/test-i386
 *.map
+build/
+closure-compiler/
+images/

--- a/tests/full/run.js
+++ b/tests/full/run.js
@@ -56,7 +56,7 @@ var tests = [
     {
         name: "Linux",
         cdrom: root_path + "/images/linux.iso",
-        timeout: 30,
+        timeout: 70,
         expected_texts: [
             "/root%",
             "test passed",
@@ -71,7 +71,7 @@ var tests = [
     {
         name: "Linux 3",
         cdrom: root_path + "/images/linux3.iso",
-        timeout: 75,
+        timeout: 200,
         expected_texts: [
             "test passed",
         ],


### PR DESCRIPTION
Set longer timeout to prevent some test failures on some slower operating systems.
Additionally change .gitignore
