### PR TITLE
fix unzip command in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,7 +108,7 @@ wget -P images/ https://copy.sh/v86/images/{linux.iso,linux3.iso,kolibri.img,win
 
 # grab closure compiler
 wget -P closure-compiler https://dl.google.com/closure-compiler/compiler-latest.zip
-unzip -d closure-compiler closure-compiler/compiler-latest.zip compiler.jar
+unzip -d closure-compiler closure-compiler/compiler-latest.zip *.jar
 
 # build the library
 make build/libv86.js


### PR DESCRIPTION
Looks like the file is now called `closure-compiler-v20170423.jar`
instead of `compiler.jar`. This appears to already have been corrected in
the Makefile [here](https://github.com/vdloo/v86/blob/master/Makefile#L142).