### PR TITLE
fix docs links to api.md

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,8 +1,8 @@
 Here is a list of events that can be listened to using
-[`add_listener`](docs/api.md#add_listenerstring-event-function-listener). These
+[`add_listener`](api.md#add_listenerstring-event-function-listener). These
 can be used to programtically control the emulator. Events cannot be sent to
 the emulator (although it is internally implemented that way), use the
-[API](docs/api.md) methods for that.
+[API](api.md) methods for that.
 
 ### Serial terminal
 

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -1,8 +1,9 @@
 A 9p filesystem is supported by the emulator, using a virtio transport. Using
 it, files can be exchanged with the guest OS, see
-[`create_file`](docs/api.md#create_filestring-file-uint8array-data-functionobject-callback)
+[`create_file`](api.md#create_filestring-file-uint8array-data-functionobject-callback)
+[`create_file`](api.md#create_filestring-file-uint8array-data-functionobject-callback)
 and
-[`read_file`](docs/api.md#read_filestring-file-functionobject-uint8array-callback). It can
+[`read_file`](api.md#read_filestring-file-functionobject-uint8array-callback). It can
 be enabled by passing the following options to `V86Starter`:
 
 ```javascript


### PR DESCRIPTION
points to `master/docs/docs/api.md` currently