### PR TITLE
update linux 9p image mount hook doc

### DIFF
--- a/docs/linux-9p-image.md
+++ b/docs/linux-9p-image.md
@@ -31,7 +31,7 @@ run_hook() {
 
 mount_9p_root() {
     msg ":: mounting '$root' on real root (9p)"
-    if ! mount -t 9p "$root" "$1"; then
+    if ! mount -t 9p host9p "$1"; then
         echo "You are now being dropped into an emergency shell."
         launch_interactive_shell
         msg "Trying to continue (this will most likely fail) ..."


### PR DESCRIPTION
The "$root" should always be host9p if you want to boot with the root fs mounted over 9p, otherwise the initcpio hook will try to mount /dev/sda1 (or whatever you have configured) over /new_root as a 9p fs (which it maybe isn't) and the system will complain with "no channels available" and drop you in the emergency shell without any real clues about what is going on. I think you can probably achieve this with "$root" as well by grub installing 'host9p' as the root fs or doing what @ysangkok does https://github.com/copy/v86/issues/41 but I think that in the case of the specific linux-9p-image doc it makes more sense to hardcode it in  the hook since it should never be anything other than host9p. Took me a while to figure out this was what was causing my machine to fail to boot since the 'no channels available' error doesn't really give you much to go on.

Before:
![before](https://cloud.githubusercontent.com/assets/1437341/25567664/3aba97a0-2df3-11e7-8468-3bb71da88a87.png)

After:
![after](https://cloud.githubusercontent.com/assets/1437341/25567666/40650ba4-2df3-11e7-9da7-475030599acd.png)
