### PR TITLE
Improve fprem instruction implementation to update FPU status word's condition codes

### DIFF
--- a/src/fpu.js
+++ b/src/fpu.js
@@ -876,26 +876,20 @@ FPU.prototype.op_D9_reg = function(imm8)
                 case 0:
                     // fprem
                     var st1 = this.get_sti(1);
-                    // Math.trunc truncates towards 0 as we want
                     var fprem_quotient = Math.trunc(st0 / st1);
                     this.st[this.stack_ptr] = st0 % st1;
 
-                    // Reset C0, C1, C3
                     this.status_word &= ~(FPU_C0 | FPU_C1 | FPU_C3);
-                    // Set C1 = bit 0 of quotient
                     if (fprem_quotient & 1) {
                         this.status_word |= FPU_C1;
                     }
-                    // Set C3 = bit 1 of quotient
                     if (fprem_quotient & (1 << 1)) {
                         this.status_word |= FPU_C3;
                     }
-                    // Set C0 = bit 2 of quotient
                     if (fprem_quotient & (1 << 2)) {
                         this.status_word |= FPU_C0;
                     }
 
-                    // Reset C2 as the "reduction" is complete
                     this.status_word &= ~FPU_C2;
                     break;
                 case 1:

--- a/src/fpu.js
+++ b/src/fpu.js
@@ -875,7 +875,28 @@ FPU.prototype.op_D9_reg = function(imm8)
             {
                 case 0:
                     // fprem
-                    this.st[this.stack_ptr] = st0 % this.get_sti(1);
+                    var st1 = this.get_sti(1);
+                    // Math.trunc truncates towards 0 as we want
+                    var fprem_quotient = Math.trunc(st0 / st1);
+                    this.st[this.stack_ptr] = st0 % st1;
+
+                    // Reset C0, C1, C3
+                    this.status_word &= ~(FPU_C0 | FPU_C1 | FPU_C3);
+                    // Set C1 = bit 0 of quotient
+                    if (fprem_quotient & 1) {
+                        this.status_word |= FPU_C1;
+                    }
+                    // Set C3 = bit 1 of quotient
+                    if (fprem_quotient & (1 << 1)) {
+                        this.status_word |= FPU_C3;
+                    }
+                    // Set C0 = bit 2 of quotient
+                    if (fprem_quotient & (1 << 2)) {
+                        this.status_word |= FPU_C0;
+                    }
+
+                    // Reset C2 as the "reduction" is complete
+                    this.status_word &= ~FPU_C2;
                     break;
                 case 1:
                     // fyl2xp1: y * log2(x+1) and pop


### PR DESCRIPTION
This PR only aims to allow the `fprem` instruction to update the condition codes in the FPU status word. This allows the `fprem` instruction to actually complete instead of looping waiting for `C2` to be reset to `0`.

**Note:** Doesn't take into account exceptions, nor does it emulate the way `fprem` actually calculates the partial remainder (by iteration).
