### PR TITLE
Fix docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -71,11 +71,11 @@ There are two ways to load images (`bios`, `vga_bios`, `cdrom`, `hda`, ...):
 
   ```javascript
   // download file before boot
-  options.bios = { 
+  bios: { 
       url: "bios/seabios.bin" 
   }
   // download file sectors as requested, size is required
-  options.hda = { 
+  hda: { 
       url: "disk/linux.iso",
       async: true,
       size: 16 * 1024 * 1024 
@@ -86,11 +86,11 @@ There are two ways to load images (`bios`, `vga_bios`, `cdrom`, `hda`, ...):
 
   ```javascript
   // use <input type=file>
-  options.bios = { 
+  bios: { 
       buffer: document.all.hd_image.files[0]
   }
   // start with empty hard drive
-  options.hda = { 
+  hda: { 
       buffer: new ArrayBuffer(16 * 1024 * 1024)
   }
   ```

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -7,9 +7,9 @@ and
 be enabled by passing the following options to `V86Starter`:
 
 ```javascript
-options.filesystem = {
-    basefs: "http://localhost/9p/fs.json",
-    baseurl: "http://localhost/9p/base/",
+filesystem: {
+    basefs: "../9p/fs.json",
+    baseurl: "../9p/base/",
 }
 ```
 

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -53,11 +53,11 @@
  *
  *   ```javascript
  *   // download file before boot
- *   options.bios = {
+ *   bios: {
  *       url: "bios/seabios.bin"
  *   }
  *   // download file sectors as requested, size is required
- *   options.hda = {
+ *   hda: {
  *       url: "disk/linux.iso",
  *       async: true,
  *       size: 16 * 1024 * 1024
@@ -68,11 +68,11 @@
  *
  *   ```javascript
  *   // use <input type=file>
- *   options.bios = {
+ *   bios: {
  *       buffer: document.all.hd_image.files[0]
  *   }
  *   // start with empty hard drive
- *   options.hda = {
+ *   hda: {
  *       buffer: new ArrayBuffer(16 * 1024 * 1024)
  *   }
  *   ```


### PR DESCRIPTION
It seems at some point the way API calls are made got change and left these docs outdated:
`options.bios =` becomes `bios: `

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/copy/v86/168)
<!-- Reviewable:end -->
