### PR TITLE
Implement VGA graphical behaviour on per-register basis

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root=true
+
+[*.js]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,6 +1,6 @@
 Here is a list of events that can be listened to using
 [`add_listener`](api.md#add_listenerstring-event-function-listener). These
-can be used to programtically control the emulator. Events cannot be sent to
+can be used to programmatically control the emulator. Events cannot be sent to
 the emulator (although it is internally implemented that way), use the
 [API](api.md) methods for that.
 
@@ -25,7 +25,7 @@ See also: [screen.js](src/browser/screen.js).
 - `screen-put-pixel-linear` - `[number addr, number value]`
 - `screen-put-pixel-linear32` - `[number addr, number value]`
 - `screen-set-size-text` - `[number cols_count, number rows_count]`
-- `screen-set-size-graphical` - `[number width, number height]`
+- `screen-set-size-graphical` - `[number width, number height, number virtual_width, number virtual_height, number bpp]`
 - `screen-update-cursor` - `[number row, number col]`
 - `screen-update-cursor-scanline` - `[number cursor_scanline_start, number cursor_scanline_end]`
 

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -972,7 +972,7 @@
         emulator.add_listener("screen-set-size-graphical", function(args)
         {
             $("info_res").textContent = args[0] + "x" + args[1];
-            $("info_bpp").textContent = args[2];
+            $("info_bpp").textContent = args[4];
         });
 
 

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -537,24 +537,33 @@ function ScreenAdapter(screen_container, bus)
             {
                 graphic_context.strokeRect(
                     layer.buffer_x,
-                    layer.buffer_y,
+                    layer.buffer_min_y,
                     layer.buffer_width,
-                    layer.buffer_height
+                    layer.buffer_max_y - layer.buffer_min_y
                 );
             });
             graphic_context.lineWidth = 1;
             return;
         }
+
+        var min_y = min / graphical_mode_width | 0;
+        var max_y = max / graphical_mode_width | 0;
+
         layers.forEach((layer) =>
         {
+            var buffer_min_y = Math.max(min_y, layer.buffer_min_y);
+            var buffer_max_y = Math.min(max_y, layer.buffer_max_y);
+
+            var buffer_height = Math.max(0, buffer_max_y - buffer_min_y);
+
             graphic_context.putImageData(
                 graphic_image_data,
                 layer.screen_x - layer.buffer_x,
-                layer.screen_y - layer.buffer_y,
+                layer.screen_y - layer.buffer_min_y,
                 layer.buffer_x,
-                layer.buffer_y,
+                layer.buffer_min_y,
                 layer.buffer_width,
-                layer.buffer_height
+                buffer_height
             );
         });
     };

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -176,6 +176,11 @@ function ScreenAdapter(screen_container, bus)
         layers_has_changed = true;
     }, this);
 
+    bus.register("screen-clear", function()
+    {
+        this.clear_screen();
+    }, this);
+
     bus.register("screen-set-size-text", function(data)
     {
         this.set_size_text(data[0], data[1]);
@@ -514,7 +519,6 @@ function ScreenAdapter(screen_container, bus)
 
         layers_has_changed = false;
 
-        this.clear_screen();
         if(DEBUG_SCREEN_LAYERS)
         {
             // Draw the entire buffer. Useful for debugging

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -175,7 +175,7 @@ function ScreenAdapter(screen_container, bus)
     }, this);
     bus.register("screen-set-size-graphical", function(data)
     {
-        this.set_size_graphical(data[0], data[1], data[3], data[4]);
+        this.set_size_graphical(data[0], data[1], data[2], data[3]);
     }, this);
 
 

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -332,12 +332,7 @@ function ScreenAdapter(screen_container, bus)
         graphical_mode_width = width;
         graphical_mode_height = height;
 
-        layers =
-        [{
-            screen_x: 0, screen_y: 0,
-            buffer_x: 0, buffer_y: 0,
-            buffer_width: width, buffer_height: height
-        }];
+        layers = [];
 
         this.bus.send("screen-tell-buffer", [graphic_buffer32], [graphic_buffer32.buffer]);
         update_scale_graphic();

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -524,6 +524,7 @@ function ScreenAdapter(screen_container, bus)
             graphic_context.lineWidth = 1;
             return;
         }
+
         layers.forEach((layer) =>
         {
             graphic_context.putImageData(

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,12 @@ var LOG_PAGE_FAULTS = false;
 var LOG_LEVEL = LOG_ALL & ~LOG_PS2 & ~LOG_PIT & ~LOG_VIRTIO & ~LOG_9P & ~LOG_PIC &
                           ~LOG_DMA & ~LOG_SERIAL & ~LOG_NET & ~LOG_FLOPPY & ~LOG_DISK;
 
+/**
+ * @const
+ * Draws entire buffer and visualizes the layers that would be drawn
+ */
+var DEBUG_SCREEN_LAYERS = DEBUG && false;
+
 
 /** @const */
 var ENABLE_HPET = DEBUG && false;

--- a/src/state.js
+++ b/src/state.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /** @const */
-var STATE_VERSION = 4;
+var STATE_VERSION = 5;
 
 /** @const */
 var STATE_MAGIC = 0x86768676|0;

--- a/src/vga.js
+++ b/src/vga.js
@@ -561,8 +561,10 @@ VGAScreen.prototype.vga_memory_write_graphical_planar = function(addr, value)
     this.diff_addr_min = actual_buffer_addr - 7 < this.diff_addr_min ? actual_buffer_addr - 7 : this.diff_addr_min;
     this.diff_addr_max = actual_buffer_addr > this.diff_addr_max ? actual_buffer_addr : this.diff_addr_max;
 
-    // 256 color shift mode
+    // Planar shift mode
     // see http://www.osdever.net/FreeVGA/vga/vgaseq.htm
+    // Shift these, so that the bits for the color are in
+    // the correct position in the for loop
     var plane0_feed = this.plane0[addr] << 0;
     var plane1_feed = this.plane1[addr] << 1;
     var plane2_feed = this.plane2[addr] << 2;

--- a/src/vga.js
+++ b/src/vga.js
@@ -202,9 +202,6 @@ function VGAScreen(cpu, bus, vga_memory_size)
     /** @type {number} */
     this.svga_height = 0;
 
-    /** @type {number} */
-    this.text_mode_width = 80;
-
     this.svga_enabled = false;
 
     /** @type {number} */
@@ -444,7 +441,7 @@ VGAScreen.prototype.get_state = function()
     // state[14]
     state[15] = this.svga_width;
     state[16] = this.svga_height;
-    state[17] = this.text_mode_width;
+    // state[17]
     state[18] = this.svga_enabled;
     state[19] = this.svga_bpp;
     state[20] = this.svga_bank_offset;
@@ -495,7 +492,7 @@ VGAScreen.prototype.set_state = function(state)
     // state[14]
     this.svga_width = state[15];
     this.svga_height = state[16];
-    this.text_mode_width = state[17];
+    // state[17]
     this.svga_enabled = state[18];
     this.svga_bpp = state[19];
     this.svga_bank_offset = state[20];
@@ -744,141 +741,6 @@ VGAScreen.prototype.vga_memory_write_graphical = function(addr, value)
     var pixel_addr = this.vga_addr_to_pixel(addr);
     this.partial_replot(pixel_addr, pixel_addr + 7);
 };
-
-//VGAScreen.prototype.single_plot = function(addr)
-//{
-//    // ## Step 3. Serialize plane bytes
-//    // Transfers plane data through the graphics controller to
-//    // the attribute controller, depending on the shift modes.
-//
-//    // Calculate the address base of the affected pixels
-//    if(this.underline_location_register & 0x40)
-//    {
-//        // Doubleword addressing. The CRT controller increments the
-//        // address by 4 bytes, so select the address concerned
-//        addr &= ~0x3;
-//    }
-//    else if(!(this.crtc_mode & 0x40))
-//    {
-//        // Word mode addressing. The CRT controller increments the address
-//        // by 2 bytes each time.
-//        addr &= ~0x1;
-//    }
-//
-//    var plane0_byte;
-//    var plane1_byte;
-//    var plane2_byte;
-//    var plane3_byte;
-//
-//    // TODO: If assuming that the programs are well behaved, this
-//    // may not be necessary
-//    if(this.sequencer_memory_mode & 0x8)
-//    {
-//        // Chain 4
-//        plane0_byte = this.plane0[addr];
-//        plane1_byte = this.plane1[addr + 1];
-//        plane2_byte = this.plane2[addr + 2];
-//        plane3_byte = this.plane3[addr + 3];
-//    }
-//    else if(this.planar_mode & 0x10)
-//    {
-//        // Odd/Even??????? CGA Emulation??
-//        plane0_byte = this.plane0[addr];
-//        plane1_byte = this.plane1[addr + 1];
-//        plane2_byte = this.plane2[addr];
-//        plane3_byte = this.plane3[addr + 1];
-//    }
-//    else
-//    {
-//        plane0_byte = this.plane0[addr];
-//        plane1_byte = this.plane1[addr];
-//        plane2_byte = this.plane2[addr];
-//        plane3_byte = this.plane3[addr];
-//    }
-//
-//    // TODO: Combine with the DAC stage below and
-//    // the plane selection stage above
-//    var shift_loads = new Uint8Array(8);
-//    switch(this.planar_mode & 0x60)
-//    {
-//        // Planar Shift Mode
-//        // See http://www.osdever.net/FreeVGA/vga/vgaseq.htm
-//        case 0x00:
-//            // Shift these, so that the bits for the color are in
-//            // the correct position in the for loop
-//            plane0_byte <<= 0;
-//            plane1_byte <<= 1;
-//            plane2_byte <<= 2;
-//            plane3_byte <<= 3;
-//
-//            for(var i = 7; i >= 0; i--)
-//            {
-//                shift_loads[7 - i] =
-//                        plane0_byte >> i & 1 |
-//                        plane1_byte >> i & 2 |
-//                        plane2_byte >> i & 4 |
-//                        plane3_byte >> i & 8;
-//            }
-//            break;
-//
-//        // Packed Shift Mode, aka Interleaved Shift Mode
-//        // Video Modes 4h and 5h
-//        case 0x20:
-//            shift_loads[0] = (plane0_byte >> 6 & 0x3) | (plane2_byte >> 4 & 0xC);
-//            shift_loads[1] = (plane0_byte >> 4 & 0x3) | (plane2_byte >> 2 & 0xC);
-//            shift_loads[2] = (plane0_byte >> 2 & 0x3) | (plane2_byte >> 0 & 0xC);
-//            shift_loads[3] = (plane0_byte >> 0 & 0x3) | (plane2_byte << 2 & 0xC);
-//
-//            shift_loads[4] = (plane1_byte >> 6 & 0x3) | (plane3_byte >> 4 & 0xC);
-//            shift_loads[5] = (plane1_byte >> 4 & 0x3) | (plane3_byte >> 2 & 0xC);
-//            shift_loads[6] = (plane1_byte >> 2 & 0x3) | (plane3_byte >> 0 & 0xC);
-//            shift_loads[7] = (plane1_byte >> 0 & 0x3) | (plane3_byte << 2 & 0xC);
-//            break;
-//
-//        // 256-Color Shift Mode
-//        // Video Modes 13h and unchained 256 color
-//        case 0x40:
-//        case 0x60:
-//            shift_loads[0] = plane0_byte >> 4 & 0xF;
-//            shift_loads[1] = plane0_byte >> 0 & 0xF;
-//            shift_loads[2] = plane1_byte >> 4 & 0xF;
-//            shift_loads[3] = plane1_byte >> 0 & 0xF;
-//            shift_loads[4] = plane2_byte >> 4 & 0xF;
-//            shift_loads[5] = plane2_byte >> 0 & 0xF;
-//            shift_loads[6] = plane3_byte >> 4 & 0xF;
-//            shift_loads[7] = plane3_byte >> 0 & 0xF;
-//            break;
-//    }
-//
-//    var pixel_addr = this.vga_addr_to_pixel(addr);
-//    var pixel_addr_max;
-//
-//    // Pixel Width, aka PEL Width, aka Clocking Mode
-//    if(this.attribute_mode & 0x40)
-//    {
-//        pixel_addr_max = pixel_addr + 3;
-//
-//        // Assemble from two sets of 4 bits.
-//        for(var i = 0, j = 0; i < 4; i++, j += 2)
-//        {
-//            var color256 = (shift_loads[j] << 4) | shift_loads[j + 1];
-//            this.pixel_buffer[pixel_addr + i] = color256;
-//            this.dac_color_use_set(pixel_addr + i, color256);
-//        }
-//    }
-//    else
-//    {
-//        pixel_addr_max = pixel_addr + 7;
-//
-//        for(var i = 0; i < 8; i++)
-//        {
-//            this.pixel_buffer[pixel_addr + i] = shift_loads[i];
-//            this.dac_color_use_set(pixel_addr + i, shift_loads[i]);
-//        }
-//    }
-//
-//    this.partial_redraw(pixel_addr, pixel_addr_max);
-//};
 
 /**
  * Copies data_byte into the four planes, with each plane
@@ -1176,15 +1038,15 @@ VGAScreen.prototype.dac_color_use_reset = function()
     this.dac_color_use_next.fill(VGA_UNUSED_COLOR_ID);
 };
 
-VGAScreen.prototype.get_bytes_per_row = function()
+VGAScreen.prototype.vga_bytes_per_line = function()
 {
-    var bytes_per_row = this.offset_register << 2;
-    if(this.underline_location_register & 0x40) bytes_per_row <<= 1;
-    else if(this.crtc_mode & 0x40) bytes_per_row >>>= 1;
-    return bytes_per_row;
+    var bytes_per_line = this.offset_register << 2;
+    if(this.underline_location_register & 0x40) bytes_per_line <<= 1;
+    else if(this.crtc_mode & 0x40) bytes_per_line >>>= 1;
+    return bytes_per_line;
 };
 
-VGAScreen.prototype.get_addr_shift_count = function()
+VGAScreen.prototype.vga_addr_shift_count = function()
 {
     // Count in multiples of 0x40 for convenience
     // Left shift 2 for word mode - 2 bytes per dot clock
@@ -1204,7 +1066,7 @@ VGAScreen.prototype.get_addr_shift_count = function()
 
 VGAScreen.prototype.vga_addr_to_pixel = function(addr)
 {
-    var shift_count = this.get_addr_shift_count();
+    var shift_count = this.vga_addr_shift_count();
 
     // Undo effects of substituted bits 13 and 14
     // Assumptions:
@@ -1350,7 +1212,7 @@ VGAScreen.prototype.update_vga_graphical_size = function()
 
         this.svga_height = this.scan_line_to_screen_row(vertical_scans);
 
-        // The virtual buffer height is however many rows of data that can fit
+        // The virtual buffer height is however many rows of data that can fit.
         // Previously drawn graphics outside of current memory address space can
         // still be drawn by setting start_address. The address at
         // VGA_HOST_MEMORY_SPACE_START[memory_space_select] is mapped to the first
@@ -1358,7 +1220,7 @@ VGAScreen.prototype.update_vga_graphical_size = function()
         // Depended on by: Windows 98 start screen
         var available_bytes = VGA_HOST_MEMORY_SPACE_SIZE[0];
 
-        this.virtual_height = available_bytes / this.get_bytes_per_row() | 0;
+        this.virtual_height = Math.ceil(available_bytes / this.vga_bytes_per_line());
 
         this.set_size_graphical(this.svga_width, this.svga_height, 8,
             this.virtual_width, this.virtual_height);
@@ -1466,62 +1328,12 @@ VGAScreen.prototype.update_cursor_scanline = function()
     this.bus.send("screen-update-cursor-scanline", [this.cursor_scanline_start, this.cursor_scanline_end]);
 };
 
-//VGAScreen.prototype.set_video_mode = function(mode)
-//{
-//    var is_graphical = false;
-//
-//    var width = 0;
-//    var height = 0;
-//
-//    switch(mode)
-//    {
-//        case 0x66:
-//            this.set_size_text(110, 46);
-//            break;
-//        case 0x03:
-//            this.set_size_text(this.text_mode_width, 25);
-//            break;
-//        case 0x10:
-//            width = 640;
-//            height = 350;
-//            is_graphical = true;
-//            this.graphical_mode_is_linear = false;
-//            break;
-//        case 0x12:
-//            width = 640;
-//            height = 480;
-//            is_graphical = true;
-//            this.graphical_mode_is_linear = false;
-//            break;
-//        case 0x13:
-//            width = 320;
-//            height = 200;
-//            is_graphical = true;
-//            this.graphical_mode_is_linear = true;
-//            break;
-//        default:
-//    }
-//
-//    this.bus.send("screen-set-mode", is_graphical);
-//    this.stats.is_graphical = is_graphical;
-//
-//    if(is_graphical)
-//    {
-//        /*
-//        this.svga_width = width;
-//        this.svga_height = height;
-//        this.set_size_graphical(width, height, 8, width, height);
-//
-//        // TODO: update with this instead
-//        this.update_vga_graphical_size();
-//        */
-//    }
-//
-//    this.graphical_mode = is_graphical;
-//
-//    dbg_log("Current video mode: " + h(mode), LOG_VGA);
-//};
-
+/**
+ * Attribute controller register / index write
+ * @see {@link http://www.osdever.net/FreeVGA/vga/attrreg.htm}
+ * @see {@link http://www.mcamafia.de/pdf/ibm_vgaxga_trm2.pdf} page 89
+ * @see {@link https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-hsw-display_0.pdf} page 48
+ */
 VGAScreen.prototype.port3C0_write = function(value)
 {
     if(this.attribute_controller_index === -1)
@@ -1578,6 +1390,8 @@ VGAScreen.prototype.port3C0_write = function(value)
                 if(this.color_plane_enable !== value)
                 {
                     this.color_plane_enable = value;
+
+                    // Data stored in image buffer are invalidated
                     this.complete_redraw();
                 }
                 break;
@@ -1594,6 +1408,8 @@ VGAScreen.prototype.port3C0_write = function(value)
                 if(this.color_select !== value)
                 {
                     this.color_select = value;
+
+                    // Data stored in image buffer are invalidated
                     this.complete_redraw();
                 }
                 break;
@@ -1609,7 +1425,6 @@ VGAScreen.prototype.port3C0_read = function()
 {
     dbg_log("3C0 read", LOG_VGA);
     var result = this.attribute_controller_index;
-    // this.attribute_controller_index = -1;
     return result;
 };
 
@@ -1621,34 +1436,29 @@ VGAScreen.prototype.port3C0_read16 = function()
 
 VGAScreen.prototype.port3C1_read = function()
 {
-    var index = this.attribute_controller_index;
-
-    // TODO: Should it reset the index? Some programs behave incorrectly.
-    // Manual says 3C1 does not toggle this flip flop.
-    // this.attribute_controller_index = -1;
-
-    if(index < 10)
+    if(this.attribute_controller_index < 10)
     {
-        dbg_log("3C1 / internal palette read " + h(index), LOG_VGA);
-        return this.dac_map[index];
+        dbg_log("3C1 / internal palette read: " + h(this.attribute_controller_index) +
+            " -> " + h(this.dac_map[this.attribute_controller_index]), LOG_VGA);
+        return this.dac_map[this.attribute_controller_index];
     }
 
-    switch(index)
+    switch(this.attribute_controller_index)
     {
         case 0x10:
-            dbg_log("3C1 / attribute mode read " + h(index), LOG_VGA);
+            dbg_log("3C1 / attribute mode read: " + h(this.attribute_mode), LOG_VGA);
             return this.attribute_mode;
         case 0x12:
-            dbg_log("3C1 / color plane enable read " + h(index), LOG_VGA);
+            dbg_log("3C1 / color plane enable read: " + h(this.color_plane_enable), LOG_VGA);
             return this.color_plane_enable;
         case 0x13:
-            dbg_log("3C1 / horizontal panning read " + h(index), LOG_VGA);
+            dbg_log("3C1 / horizontal panning read: " + h(this.horizontal_panning), LOG_VGA);
             return this.horizontal_panning;
         case 0x14:
-            dbg_log("3C1 / color select read " + h(index), LOG_VGA);
+            dbg_log("3C1 / color select read: " + h(this.color_select), LOG_VGA);
             return this.color_select;
         default:
-            dbg_log("3C1 / attribute controller read " + h(index), LOG_VGA);
+            dbg_log("3C1 / attribute controller read " + h(this.attribute_controller_index), LOG_VGA);
     }
     return -1;
 
@@ -1658,9 +1468,6 @@ VGAScreen.prototype.port3C2_write = function(value)
 {
     dbg_log("3C2 / miscellaneous output register = " + h(value), LOG_VGA);
     this.miscellaneous_output_register = value;
-
-    // cheat way to figure out which video mode is indended to be used
-    //this.switch_video_mode(value);
 };
 
 VGAScreen.prototype.port3C4_write = function(value)
@@ -1673,12 +1480,18 @@ VGAScreen.prototype.port3C4_read = function()
     return this.sequencer_index;
 };
 
+/**
+ * Sequencer register writes
+ * @see {@link http://www.osdever.net/FreeVGA/vga/seqreg.htm}
+ * @see {@link http://www.mcamafia.de/pdf/ibm_vgaxga_trm2.pdf} page 47
+ * @see {@link https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-hsw-display_0.pdf} page 19
+ */
 VGAScreen.prototype.port3C5_write = function(value)
 {
     switch(this.sequencer_index)
     {
         case 0x02:
-            //dbg_log("plane write mask: " + h(value), LOG_VGA);
+            dbg_log("plane write mask: " + h(value), LOG_VGA);
             this.plane_write_bm = value;
             break;
         case 0x04:
@@ -1719,6 +1532,12 @@ VGAScreen.prototype.port3C8_write = function(index)
     this.dac_color_index_write = index * 3;
 };
 
+/**
+ * DAC color palette register writes
+ * @see {@link http://www.osdever.net/FreeVGA/vga/colorreg.htm}
+ * @see {@link http://www.mcamafia.de/pdf/ibm_vgaxga_trm2.pdf} page 104
+ * @see {@link https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-hsw-display_0.pdf} page 57
+ */
 VGAScreen.prototype.port3C9_write = function(color_byte)
 {
     var index = this.dac_color_index_write / 3 | 0,
@@ -1765,7 +1584,7 @@ VGAScreen.prototype.port3C9_write = function(color_byte)
 
 VGAScreen.prototype.port3C9_read = function()
 {
-    //dbg_log("3C9 read", LOG_VGA);
+    dbg_log("3C9 read", LOG_VGA);
 
     var index = this.dac_color_index_read / 3 | 0;
     var offset = this.dac_color_index_read % 3;
@@ -1791,6 +1610,12 @@ VGAScreen.prototype.port3CE_read = function()
     return this.graphics_index;
 };
 
+/**
+ * Graphics controller register writes
+ * @see {@link http://www.osdever.net/FreeVGA/vga/graphreg.htm}
+ * @see {@link http://www.mcamafia.de/pdf/ibm_vgaxga_trm2.pdf} page 78
+ * @see {@link https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-hsw-display_0.pdf} page 29
+ */
 VGAScreen.prototype.port3CF_write = function(value)
 {
     switch(this.graphics_index)
@@ -1880,6 +1705,12 @@ VGAScreen.prototype.port3D4_write = function(register)
     this.index_crtc = register;
 };
 
+/**
+ * CRT controller register writes
+ * @see {@link http://www.osdever.net/FreeVGA/vga/crtcreg.htm}
+ * @see {@link http://www.mcamafia.de/pdf/ibm_vgaxga_trm2.pdf} page 55
+ * @see {@link https://01.org/sites/default/files/documentation/intel-gfx-prm-osrc-hsw-display_0.pdf} page 63
+ */
 VGAScreen.prototype.port3D5_write = function(value)
 {
     switch(this.index_crtc)
@@ -1898,8 +1729,6 @@ VGAScreen.prototype.port3D5_write = function(value)
                 this.horizontal_blank_start = value;
                 this.update_vga_graphical_size();
             }
-            // TODO
-            this.text_mode_width = value;
             break;
         case 0x7:
             dbg_log("3D5 / overflow register write: " + h(value), LOG_VGA);
@@ -2133,39 +1962,6 @@ VGAScreen.prototype.port3DA_read = function()
     return value;
 };
 
-//VGAScreen.prototype.switch_video_mode = function(mar)
-//{
-//    // Cheap way to figure this out, using the Miscellaneous Output Register
-//    // See: http://wiki.osdev.org/VGA_Hardware#List_of_register_settings
-//
-//    if(mar === 0x66)
-//    {
-//        this.set_video_mode(0x66);
-//    }
-//    else if(mar === 0x67)
-//    {
-//        this.set_video_mode(0x3);
-//    }
-//    else if(mar === 0xE3)
-//    {
-//        // also mode X
-//        this.set_video_mode(0x12);
-//    }
-//    else if(mar === 0x63)
-//    {
-//        this.set_video_mode(0x13);
-//    }
-//    else if(mar === 0xA3)
-//    {
-//        this.set_video_mode(0x10);
-//    }
-//    else
-//    {
-//        dbg_log("Unkown MAR value: " + h(mar, 2) + ", going back to text mode", LOG_VGA);
-//        this.set_video_mode(0x3);
-//    }
-//};
-
 VGAScreen.prototype.svga_bytes_per_line = function()
 {
     var bits = this.svga_bpp === 15 ? 16 : this.svga_bpp;
@@ -2306,7 +2102,7 @@ VGAScreen.prototype.vga_replot = function()
     var start = this.diff_plot_min & ~0xF;
     var end = (this.diff_plot_max | 0xF) + 1;
 
-    var addr_shift = this.get_addr_shift_count();
+    var addr_shift = this.vga_addr_shift_count();
     var addr_substitution = ~this.crtc_mode & 0x3;
 
     var shift_mode = this.planar_mode & 0x60

--- a/src/vga.js
+++ b/src/vga.js
@@ -2403,7 +2403,7 @@ VGAScreen.prototype.screen_fill_buffer = function()
             screen_x: 0, screen_y: min_y,
             buffer_x: 0, buffer_y: min_y,
             buffer_width: this.svga_width,
-            buffer_height: max_y - min_y,
+            buffer_height: max_y - min_y + 1,
         }]);
     }
     else

--- a/src/vga.js
+++ b/src/vga.js
@@ -1138,9 +1138,8 @@ VGAScreen.prototype.set_size_text = function(cols_count, rows_count)
 
 VGAScreen.prototype.set_size_graphical = function(width, height, bpp, virtual_width, virtual_height)
 {
-    this.stats.bpp = bpp;
-
     var needs_update = !this.stats.is_graphical ||
+        this.stats.bpp !== bpp ||
         this.screen_width !== width ||
         this.screen_height !== height ||
         this.virtual_width !== virtual_width ||
@@ -1153,11 +1152,12 @@ VGAScreen.prototype.set_size_graphical = function(width, height, bpp, virtual_wi
         this.virtual_width = virtual_width;
         this.virtual_height = virtual_height;
 
+        this.stats.bpp = bpp;
         this.stats.is_graphical = true;
         this.stats.res_x = width;
         this.stats.res_y = height;
 
-        this.bus.send("screen-set-size-graphical", [width, height, virtual_width, virtual_height]);
+        this.bus.send("screen-set-size-graphical", [width, height, virtual_width, virtual_height, bpp]);
     }
 };
 

--- a/src/vga.js
+++ b/src/vga.js
@@ -2422,6 +2422,9 @@ VGAScreen.prototype.vga_redraw = function()
                 buffer[addr] = color;
                 addr = dac_next[addr];
             }
+
+            // Tell screen adapter to redraw all via start and end pixel
+            this.complete_redraw();
         }
     }
     else
@@ -2458,6 +2461,9 @@ VGAScreen.prototype.vga_redraw = function()
                 buffer[addr] = color;
                 addr = dac_next[addr];
             }
+
+            // Tell screen adapter to redraw all via start and end pixel
+            this.complete_redraw();
         }
     }
 };

--- a/src/vga.js
+++ b/src/vga.js
@@ -2350,7 +2350,7 @@ VGAScreen.prototype.vga_redraw = function()
             var color = this.vga256_palette[color256];
             color = color & 0xFF00 | color << 16 | color >> 16 | 0xFF000000;
 
-            var addr = dac_root[color256];
+            var addr = dac_root[color16];
             while(addr !== VGA_UNUSED_COLOR_ID)
             {
                 buffer[addr] = color;

--- a/src/vga.js
+++ b/src/vga.js
@@ -1517,7 +1517,7 @@ VGAScreen.prototype.port3C0_read16 = function()
 
 VGAScreen.prototype.port3C1_read = function()
 {
-    if(this.attribute_controller_index < 10)
+    if(this.attribute_controller_index < 0x10)
     {
         dbg_log("3C1 / internal palette read: " + h(this.attribute_controller_index) +
             " -> " + h(this.dac_map[this.attribute_controller_index]), LOG_VGA);

--- a/src/vga.js
+++ b/src/vga.js
@@ -544,7 +544,7 @@ VGAScreen.prototype.set_state = function(state)
         if(this.svga_enabled)
         {
             this.set_size_graphical(this.svga_width, this.svga_height,
-                8, this.svga_width, this.svga_height);
+                this.svga_bpp, this.svga_width, this.svga_height);
             this.update_layers();
         }
         else

--- a/src/vga.js
+++ b/src/vga.js
@@ -342,6 +342,8 @@ VGAScreen.prototype.get_state = function()
     state[40] = this.graphical_mode_is_linear;
     state[41] = this.attribute_controller_index;
     state[42] = this.offset_register;
+    state[43] = this.planar_setreset;
+    state[44] = this.planar_setreset_enable;
 
     return state;
 };
@@ -391,13 +393,31 @@ VGAScreen.prototype.set_state = function(state)
     this.graphical_mode_is_linear = state[40];
     this.attribute_controller_index = state[41];
     this.offset_register = state[42];
+    this.planar_setreset = state[43];
+    this.planar_setreset_enable = state[44];
+
+    this.planar_bitmap_dword = this.apply_feed(this.planar_bitmap);
+    this.planar_setreset_dword = this.apply_expand(this.planar_setreset);
+    this.planar_setreset_enable_dword = this.apply_expand(this.planar_setreset_enable);
+
+    this.latch_dword = 0;
+    this.latch_dword |= this.latch0 << 0;
+    this.latch_dword |= this.latch1 << 8;
+    this.latch_dword |= this.latch2 << 16;
+    this.latch_dword |= this.latch3 << 24;
 
     this.bus.send("screen-set-mode", this.graphical_mode);
 
     if(this.graphical_mode)
     {
-        // TODO: Consider non-svga modes
-        this.set_size_graphical(this.svga_width, this.svga_height, this.svga_bpp);
+        if(this.svga_enabled)
+        {
+            this.set_size_graphical(this.svga_width, this.svga_height, this.svga_bpp);
+        }
+        else
+        {
+            this.switch_video_mode(this.miscellaneous_output_register);
+        }
     }
     else
     {

--- a/src/vga.js
+++ b/src/vga.js
@@ -360,7 +360,7 @@ function VGAScreen(cpu, bus, vga_memory_size)
     {
         if(this.dest_buffer && data[0])
         {
-            data[0].set(this.dest_buffer.subarray(0,data[0].length));
+            data[0].set(this.dest_buffer.subarray(0, data[0].length));
         }
         this.dest_buffer = data[0];
     }, this);
@@ -1266,8 +1266,7 @@ VGAScreen.prototype.update_layers = function()
     var pixel_addr_start = this.vga_addr_to_pixel(start_addr + byte_panning);
 
     var start_buffer_row = pixel_addr_start / this.virtual_width | 0;
-    var start_buffer_col = pixel_addr_start % this.virtual_width;
-    start_buffer_col += pixel_panning;
+    var start_buffer_col = pixel_addr_start % this.virtual_width + pixel_panning;
 
     var split_screen_row = this.scan_line_to_screen_row(1 + this.line_compare);
     split_screen_row = Math.min(split_screen_row, this.svga_height);
@@ -2413,7 +2412,6 @@ VGAScreen.prototype.screen_fill_buffer = function()
         this.vga_redraw();
         this.bus.send("screen-fill-buffer-end", this.layers);
     }
-
 
     this.reset_diffs();
     this.update_vertical_retrace();

--- a/src/vga.js
+++ b/src/vga.js
@@ -1245,6 +1245,7 @@ VGAScreen.prototype.update_layers = function()
         // See http://www.phatcode.net/res/224/files/html/ch29/29-05.html#Heading6
         // and http://www.osdever.net/FreeVGA/vga/seqreg.htm#01
         this.bus.send("screen-update-layers", []);
+        this.bus.send("screen-clear", []);
         return;
     }
 

--- a/src/vga.js
+++ b/src/vga.js
@@ -449,8 +449,7 @@ VGAScreen.prototype.vga_memory_read = function(addr)
     // planar mode
     addr &= 0xFFFF;
 
-    this.latch_dword = 0;
-    this.latch_dword |= this.plane0[addr] << 0;
+    this.latch_dword = this.plane0[addr];
     this.latch_dword |= this.plane1[addr] << 8;
     this.latch_dword |= this.plane2[addr] << 16;
     this.latch_dword |= this.plane3[addr] << 24;
@@ -512,9 +511,9 @@ VGAScreen.prototype.vga_memory_write_graphical_planar = function(addr, value)
         return;
     }
 
-    var plane_dword,
-        write_mode = this.planar_mode & 3,
-        bitmask = this.planar_bitmap_dword;
+    var plane_dword;
+    var write_mode = this.planar_mode & 3;
+    var bitmask = this.planar_bitmap_dword;
 
     // not implemented:
     // - Shift mode
@@ -576,8 +575,8 @@ VGAScreen.prototype.vga_memory_write_graphical_planar = function(addr, value)
                 plane0_feed >> i & 1 |
                 plane1_feed >> i & 2 |
                 plane2_feed >> i & 4 |
-                plane3_feed >> i & 8,
-            color = this.dac_map[color_index];
+                plane3_feed >> i & 8;
+        var color = this.dac_map[color_index];
 
         this.svga_memory[offset + VGA_PLANAR_REAL_BUFFER_START] = color;
 
@@ -593,8 +592,7 @@ VGAScreen.prototype.vga_memory_write_graphical_planar = function(addr, value)
  */
 VGAScreen.prototype.apply_feed = function(data_byte)
 {
-    var dword = 0;
-    dword |= data_byte << 0;
+    var dword = data_byte;
     dword |= data_byte << 8;
     dword |= data_byte << 16;
     dword |= data_byte << 24;
@@ -609,8 +607,7 @@ VGAScreen.prototype.apply_feed = function(data_byte)
  */
 VGAScreen.prototype.apply_expand = function(data_byte)
 {
-    var dword = 0;
-    dword |= (data_byte & 0x1 ? 0xFF : 0x00) << 0;
+    var dword = data_byte & 0x1 ? 0xFF : 0x00;
     dword |= (data_byte & 0x2 ? 0xFF : 0x00) << 8;
     dword |= (data_byte & 0x4 ? 0xFF : 0x00) << 16;
     dword |= (data_byte & 0x8 ? 0xFF : 0x00) << 24;
@@ -626,9 +623,9 @@ VGAScreen.prototype.apply_expand = function(data_byte)
  */
 VGAScreen.prototype.apply_rotate = function(data_byte)
 {
-    var wrapped = data_byte | (data_byte << 8),
-        count = this.planar_rotate_reg & 0x7,
-        shifted = wrapped >>> count;
+    var wrapped = data_byte | (data_byte << 8);
+    var count = this.planar_rotate_reg & 0x7;
+    var shifted = wrapped >>> count;
     return shifted & 0xFF;
 };
 
@@ -679,8 +676,7 @@ VGAScreen.prototype.apply_logical = function(data_dword, latch_dword)
  */
 VGAScreen.prototype.apply_bitmask = function(data_dword, bitmask_dword)
 {
-    var plane_dword = 0;
-    plane_dword |= bitmask_dword & data_dword;
+    var plane_dword = bitmask_dword & data_dword;
     plane_dword |= ~bitmask_dword & this.latch_dword;
     return plane_dword;
 };

--- a/src/vga.js
+++ b/src/vga.js
@@ -1226,9 +1226,12 @@ VGAScreen.prototype.update_layers = function()
     if(this.svga_enabled && this.svga_width)
     {
         this.bus.send("screen-update-layers", [{
-            screen_x: 0, screen_y: 0,
-            buffer_x: 0, buffer_y: 0,
-            buffer_width: this.svga_width, buffer_height: this.svga_height
+            screen_x: 0,
+            screen_y: 0,
+            buffer_x: 0,
+            buffer_width: this.svga_width,
+            buffer_min_y: 0,
+            buffer_max_y: this.svga_height,
         }]);
         return;
     }
@@ -1277,9 +1280,9 @@ VGAScreen.prototype.update_layers = function()
             screen_x: x,
             screen_y: 0,
             buffer_x: 0,
-            buffer_y: start_buffer_row + y,
             buffer_width: this.virtual_width,
-            buffer_height: split_screen_row,
+            buffer_min_y: start_buffer_row + y,
+            buffer_max_y: start_buffer_row + y + split_screen_row,
         });
     }
 
@@ -1296,9 +1299,9 @@ VGAScreen.prototype.update_layers = function()
             screen_x: x,
             screen_y: split_screen_row,
             buffer_x: 0,
-            buffer_y: y,
             buffer_width: this.virtual_width,
-            buffer_height: split_buffer_height,
+            buffer_min_y: y,
+            buffer_max_y: y + split_buffer_height,
         });
     }
 

--- a/src/vga.js
+++ b/src/vga.js
@@ -1149,7 +1149,7 @@ VGAScreen.prototype.set_size_graphical = function(width, height, bpp, virtual_wi
     this.stats.res_x = width;
     this.stats.res_y = height;
 
-    this.bus.send("screen-set-size-graphical", [width, height, bpp, virtual_width, virtual_height]);
+    this.bus.send("screen-set-size-graphical", [width, height, virtual_width, virtual_height]);
 };
 
 VGAScreen.prototype.update_vga_size = function()

--- a/src/vga.js
+++ b/src/vga.js
@@ -419,8 +419,7 @@ VGAScreen.prototype.set_state = function(state)
 
     if(this.graphical_mode)
     {
-        // TODO: Check to see if there is anything else to do for
-        // non-svga mode
+        // TODO: Check to see if there is anything else to do for non-svga mode
         var bpp = this.svga_enabled ? this.svga_bpp : 8;
         this.set_size_graphical(this.svga_width, this.svga_height, bpp);
     }
@@ -532,17 +531,14 @@ VGAScreen.prototype.vga_memory_write_graphical_planar = function(addr, value)
             plane_dword = this.apply_logical(plane_dword, this.latch_dword);
             plane_dword = this.apply_bitmask(plane_dword, bitmask);
             break;
-
         case 1:
             plane_dword = this.latch_dword;
             break;
-
         case 2:
             plane_dword = this.apply_expand(value);
             plane_dword = this.apply_logical(plane_dword, this.latch_dword);
             plane_dword = this.apply_bitmask(plane_dword, bitmask);
             break;
-
         case 3:
             value = this.apply_rotate(value);
             bitmask &= this.apply_expand(value);
@@ -601,7 +597,7 @@ VGAScreen.prototype.apply_feed = function(data_byte)
     dword |= data_byte << 16;
     dword |= data_byte << 24;
     return dword;
-}
+};
 
 /**
  * Expands bits 0 to 3 to ocupy bits 0 to 31. Each
@@ -617,7 +613,7 @@ VGAScreen.prototype.apply_expand = function(data_byte)
     dword |= (data_byte & 0x4 ? 0xFF : 0x00) << 16;
     dword |= (data_byte & 0x8 ? 0xFF : 0x00) << 24;
     return dword;
-}
+};
 
 /**
  * Planar Write - Barrel Shifter
@@ -644,7 +640,7 @@ VGAScreen.prototype.apply_rotate = function(data_byte)
  */
 VGAScreen.prototype.apply_setreset = function(data_dword, enable_dword)
 {
-    data_dword |=  enable_dword & this.planar_setreset_dword;
+    data_dword |= enable_dword & this.planar_setreset_dword;
     data_dword &= ~enable_dword | this.planar_setreset_dword;
     return data_dword;
 };
@@ -682,7 +678,7 @@ VGAScreen.prototype.apply_logical = function(data_dword, latch_dword)
 VGAScreen.prototype.apply_bitmask = function(data_dword, bitmask_dword)
 {
     var plane_dword = 0;
-    plane_dword |=  bitmask_dword & data_dword;
+    plane_dword |= bitmask_dword & data_dword;
     plane_dword |= ~bitmask_dword & this.latch_dword;
     return plane_dword;
 };
@@ -692,8 +688,8 @@ VGAScreen.prototype.apply_bitmask = function(data_dword, bitmask_dword)
  */
 VGAScreen.prototype.plane_update = function(addr, plane_dword)
 {
-    if(this.plane_write_bm & 0x1) this.plane0[addr] = (plane_dword >>  0) & 0xFF;
-    if(this.plane_write_bm & 0x2) this.plane1[addr] = (plane_dword >>  8) & 0xFF;
+    if(this.plane_write_bm & 0x1) this.plane0[addr] = (plane_dword >> 0) & 0xFF;
+    if(this.plane_write_bm & 0x2) this.plane1[addr] = (plane_dword >> 8) & 0xFF;
     if(this.plane_write_bm & 0x4) this.plane2[addr] = (plane_dword >> 16) & 0xFF;
     if(this.plane_write_bm & 0x8) this.plane3[addr] = (plane_dword >> 24) & 0xFF;
 };

--- a/src/vga.js
+++ b/src/vga.js
@@ -1641,7 +1641,7 @@ VGAScreen.prototype.port3C8_write = function(index)
 
 VGAScreen.prototype.port3C8_read = function()
 {
-    return this.dac_color_index_write;
+    return this.dac_color_index_write / 3 | 0;
 };
 
 /**

--- a/src/vga.js
+++ b/src/vga.js
@@ -419,14 +419,10 @@ VGAScreen.prototype.set_state = function(state)
 
     if(this.graphical_mode)
     {
-        if(this.svga_enabled)
-        {
-            this.set_size_graphical(this.svga_width, this.svga_height, this.svga_bpp);
-        }
-        else
-        {
-            this.switch_video_mode(this.miscellaneous_output_register);
-        }
+        // TODO: Check to see if there is anything else to do for
+        // non-svga mode
+        var bpp = this.svga_enabled ? this.svga_bpp : 8;
+        this.set_size_graphical(this.svga_width, this.svga_height, bpp);
     }
     else
     {

--- a/src/vga.js
+++ b/src/vga.js
@@ -661,12 +661,6 @@ VGAScreen.prototype.vga_memory_write_graphical_linear = function(addr, value)
 
 VGAScreen.prototype.vga_memory_write_graphical = function(addr, value)
 {
-    // ## Step 1. Apply write logic
-    // Bitwise operations performed on the input values and the read-latches
-    // to calculate the actual bytes sent to the four planes.
-    // The exact type of operations depend on the write mode field set in
-    // the Graphics Mode register.
-
     var plane_dword;
     var write_mode = this.planar_mode & 3;
     var bitmask = this.apply_feed(this.planar_bitmap);
@@ -701,15 +695,8 @@ VGAScreen.prototype.vga_memory_write_graphical = function(addr, value)
             break;
     }
 
-    // ## Step 2. Update Planes
-    // Chained modes selects the planes to write to depending on the
-    // system address.
-
     var plane_select = 0xF;
 
-    // Note: If the programs are well behaved, this part is uneccessary as
-    // the behaviour will be 'masked' out by the serialize step.
-    // However, for OS developers, this step helps catch some bugs.
     switch(this.sequencer_memory_mode & 0xC)
     {
         // Odd/Even (aka chain 2)
@@ -842,7 +829,6 @@ VGAScreen.prototype.apply_bitmask = function(data_dword, bitmask_dword)
 
 VGAScreen.prototype.text_mode_redraw = function()
 {
-    // TODO: startaddress or startaddress << 1?
     var addr = this.start_address << 1,
         chr,
         color;
@@ -864,7 +850,6 @@ VGAScreen.prototype.text_mode_redraw = function()
 
 VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
 {
-    // TODO: startaddress or startaddress >> 1?
     var memory_start = (addr >> 1) - this.start_address,
         row = memory_start / this.max_cols | 0,
         col = memory_start % this.max_cols,
@@ -1062,7 +1047,7 @@ VGAScreen.prototype.vga_addr_shift_count = function()
     shift_count -= this.attribute_mode & 0x40;
 
     return shift_count >>> 6;
-}
+};
 
 VGAScreen.prototype.vga_addr_to_pixel = function(addr)
 {

--- a/src/vga.js
+++ b/src/vga.js
@@ -1502,7 +1502,7 @@ VGAScreen.prototype.screen_fill_buffer = function()
             var start_pixel = start - offset;
             var end_pixel = end - offset + 1;
 
-            for(var i = start; i < end; i++)
+            for(var i = start; i <= end; i++)
             {
                 var color = this.vga256_palette[this.svga_memory[i]];
                 buffer[i - offset] = color & 0xFF00 | color << 16 | color >> 16 | 0xFF000000;

--- a/src/vga.js
+++ b/src/vga.js
@@ -1656,7 +1656,7 @@ VGAScreen.prototype.port3C9_write = function(color_byte)
         offset = this.dac_color_index_write % 3,
         color = this.vga256_palette[index];
 
-    color_byte = color_byte * 255 / 63 & 0xFF;
+    color_byte = (color_byte & 0x3F) * 255 / 63 | 0;
 
     if(offset === 0)
     {

--- a/src/vga.js
+++ b/src/vga.js
@@ -530,7 +530,7 @@ VGAScreen.prototype.vga_memory_write_graphical_planar = function(addr, value)
             break;
         case 3:
             value = this.apply_rotate(value);
-            bitmask &= this.apply_expand(value);
+            bitmask &= this.apply_feed(value);
             plane_dword = setreset_dword;
             plane_dword = this.apply_bitmask(plane_dword, bitmask);
             break;

--- a/src/vga.js
+++ b/src/vga.js
@@ -557,7 +557,7 @@ VGAScreen.prototype.vga_memory_read = function(addr)
     // VGA chip only decodes addresses within the selected memory space.
     if(addr < 0 || addr >= VGA_HOST_MEMORY_SPACE_SIZE[memory_space_select])
     {
-        dbg_log('vga read outside memory space: addr:' + h(addr), LOG_VGA);
+        dbg_log("vga read outside memory space: addr:" + h(addr), LOG_VGA);
         return 0;
     }
 
@@ -631,7 +631,7 @@ VGAScreen.prototype.vga_memory_write = function(addr, value)
 
     if(addr < 0 || addr >= VGA_HOST_MEMORY_SPACE_SIZE[memory_space_select])
     {
-        dbg_log('vga write outside memory space: addr:' + h(addr) + ', value:' + h(value), LOG_VGA);
+        dbg_log("vga write outside memory space: addr:" + h(addr) + ", value:" + h(value), LOG_VGA);
         return;
     }
 

--- a/src/vga.js
+++ b/src/vga.js
@@ -1191,7 +1191,7 @@ VGAScreen.prototype.set_size_graphical = function(width, height, bpp, virtual_wi
     this.bus.send("screen-set-size-graphical", [width, height, bpp, virtual_width, virtual_height]);
 };
 
-VGAScreen.prototype.update_vga_graphical_size = function()
+VGAScreen.prototype.update_vga_size = function()
 {
     if(this.svga_enabled)
     {
@@ -1409,7 +1409,7 @@ VGAScreen.prototype.port3C0_write = function(value)
                         this.complete_replot();
                     }
 
-                    this.update_vga_graphical_size();
+                    this.update_vga_size();
 
                     // Data stored in image buffer are invalidated
                     this.complete_redraw();
@@ -1697,7 +1697,7 @@ VGAScreen.prototype.port3CF_write = function(value)
             if(this.miscellaneous_graphics_register !== value)
             {
                 this.miscellaneous_graphics_register = value;
-                this.update_vga_graphical_size();
+                this.update_vga_size();
             }
             break;
         case 7:
@@ -1762,14 +1762,14 @@ VGAScreen.prototype.port3D5_write = function(value)
             if(this.horizontal_display_enable_end !== value)
             {
                 this.horizontal_display_enable_end = value;
-                this.update_vga_graphical_size();
+                this.update_vga_size();
             }
             break;
         case 0x2:
             if(this.horizontal_blank_start !== value)
             {
                 this.horizontal_blank_start = value;
-                this.update_vga_graphical_size();
+                this.update_vga_size();
             }
             break;
         case 0x7:
@@ -1779,7 +1779,7 @@ VGAScreen.prototype.port3D5_write = function(value)
             this.vertical_display_enable_end |= (value << 3 & 0x200) | (value << 7 & 0x100);
             if(previous_vertical_display_enable_end != this.vertical_display_enable_end)
             {
-                this.update_vga_graphical_size();
+                this.update_vga_size();
             }
             this.line_compare = (this.line_compare & 0x2FF) | (value << 4 & 0x100);
 
@@ -1787,7 +1787,7 @@ VGAScreen.prototype.port3D5_write = function(value)
             this.vertical_blank_start = (this.vertical_blank_start & 0x2FF) | (value << 5 & 0x100);
             if(previous_vertical_blank_start !== this.vertical_blank_start)
             {
-                this.update_vga_graphical_size();
+                this.update_vga_size();
             }
             this.update_vga_panning();
             break;
@@ -1805,7 +1805,7 @@ VGAScreen.prototype.port3D5_write = function(value)
             this.vertical_blank_start = (this.vertical_blank_start & 0x1FF) | (value << 4 & 0x200);
             if(previous_vertical_blank_start !== this.vertical_blank_start)
             {
-                this.update_vga_graphical_size();
+                this.update_vga_size();
             }
 
             this.update_vga_panning();
@@ -1863,7 +1863,7 @@ VGAScreen.prototype.port3D5_write = function(value)
             if((this.vertical_display_enable_end & 0xFF) !== value)
             {
                 this.vertical_display_enable_end = (this.vertical_display_enable_end & 0x300) | value;
-                this.update_vga_graphical_size();
+                this.update_vga_size();
             }
             break;
         case 0x13:
@@ -1871,7 +1871,7 @@ VGAScreen.prototype.port3D5_write = function(value)
             if(this.offset_register !== value)
             {
                 this.offset_register = value;
-                this.update_vga_graphical_size();
+                this.update_vga_size();
 
                 if(~this.crtc_mode & 0x3)
                 {
@@ -1888,7 +1888,7 @@ VGAScreen.prototype.port3D5_write = function(value)
                 var previous_underline = this.underline_location_register;
 
                 this.underline_location_register = value;
-                this.update_vga_graphical_size();
+                this.update_vga_size();
 
                 if((previous_underline ^ value) & 0x40)
                 {
@@ -1902,7 +1902,7 @@ VGAScreen.prototype.port3D5_write = function(value)
             if((this.vertical_blank_start & 0xFF) !== value)
             {
                 this.vertical_blank_start = (this.vertical_blank_start & 0x300) | value;
-                this.update_vga_graphical_size();
+                this.update_vga_size();
             }
             break;
         case 0x17:
@@ -1912,7 +1912,7 @@ VGAScreen.prototype.port3D5_write = function(value)
                 var previous_mode = this.crtc_mode;
 
                 this.crtc_mode = value;
-                this.update_vga_graphical_size();
+                this.update_vga_size();
 
                 if((previous_mode ^ value) & 0x43)
                 {

--- a/src/vga.js
+++ b/src/vga.js
@@ -178,6 +178,7 @@ function VGAScreen(cpu, bus, vga_memory_size)
 
     /** @type {boolean} */
     this.graphical_mode = false;
+    setTimeout(() => { bus.send("screen-set-mode", this.graphical_mode); }, 0);
 
     /*
      * VGA palette containing 256 colors for video mode 13, svga 8bpp, etc.


### PR DESCRIPTION
### This package contains the following goodness

- VGA write modes 0, 1, 2, 3 with set/reset, planar rotation.
- VGA write using single dword to represent all 4 plane bytes.
- VGA read mode 1.
- Provides a workaround solution to issues #110 and #90 (sacrificing the performance and resolution of the vbe driver for normal vga)

**Update:** this PR now also includes:
- VGA chain odd/even and interleaved shift - implements modes 4h and 5h.
- VGA unchained, chain 4 256 color shift - implements modes 13h, mode X.
- VGA panning, page flipping, split screen.
- VGA palette redraws.

### Demo

(This is the same video as the one for sb16 PR)

https://drive.google.com/file/d/1FSt14j7ayKnaT7AS8lF_4S1i4ZX9GlEk/view
(the demo also contains code for 320x400 display mode that is not included with this PR)

### Notes

- I'm curious to see if you like how the modes are implemented here. The calculations (bitmasks, ALU, etc.) got moved out from inside `vga_memory_write_graphical_planar` into their own, separate functions. This way, ~~the code looks more beautiful and satisfies my OCD~~ the circuitry intentions for each mode is much clearer. I'm not sure about the performance aspects though (I haven't profiled them yet).

### Todo

- [x] Find a way to test out each mode. So far, I've only tested by booting up Windows 98 with VBE drivers removed, which worked well even before read mode 1 was implemented.
- [x] Test with Windows 98: windows, screen savers, paint, solitaire
- [x] Test some of Michael Abrash's Graphics Programming Black Book sample code
- [x] Test some DOS games on the write modes
- [x] Merge routines for mode 12h and 13h into single function.
- [x] Implement unchained 256 color shift
- [x] Implement odd/even chain and interleaved shift
- [x] Implement page flipping, panning, and split screens
- [x] Try out using linked lists to keep track of what pixels use what color, so when the palette changes the pixels can be updated
- [x] Fix the svga and text mode regressions on other OSes
- [x] Fix / optimize / consider keeping or removing the linked list.
- [x] Add new states to `get_state` and `set_state` functions.