### PR TITLE
Detect and trigger Alt-Key keyup, fixes #165

### DIFF
--- a/src/browser/keyboard.js
+++ b/src/browser/keyboard.js
@@ -328,6 +328,7 @@ function KeyboardAdapter(bus)
         if(!e.altKey && keys_pressed[0x38])
         {
             // trigger ALT keyup manually - some browsers don't
+            // see issue #165
             handle_code(0x38, false);
         }
         return handler(e, false);
@@ -338,6 +339,7 @@ function KeyboardAdapter(bus)
         if(!e.altKey && keys_pressed[0x38])
         {
             // trigger ALT keyup manually - some browsers don't
+            // see issue #165
             handle_code(0x38, false);
         }
         return handler(e, true);

--- a/src/browser/keyboard.js
+++ b/src/browser/keyboard.js
@@ -325,11 +325,21 @@ function KeyboardAdapter(bus)
 
     function keyup_handler(e)
     {
+        if(!e.altKey && keys_pressed[0x38])
+        {
+            // trigger ALT keyup manually - some browsers don't
+            handle_code(0x38, false);
+        }
         return handler(e, false);
     }
 
     function keydown_handler(e)
     {
+        if(!e.altKey && keys_pressed[0x38])
+        {
+            // trigger ALT keyup manually - some browsers don't
+            handle_code(0x38, false);
+        }
         return handler(e, true);
     }
 


### PR DESCRIPTION
Firefox 57 and Edge 41 on Windows (tested on Windows 10) do not emit keyup event for the alt key when the alt key is pressed with other keys, although Firefox on Ubuntu *does* appears to emit the event. Interesting how older versions of Firefox *do* seem to emit the event too. See #165.

This patch is tested on Firefox (Ubuntu Xenial in a VM and Windows 10) and Chrome. Haven't tested on Apple and with other browsers.

Possible bug with the web browsers? If it is, it might be better to close this PR and wait until they fix it rather add noisy code that adapts to their bugs... if we don't mind keeping v86 in a buggy state while we wait that is.

**Update:** Edge Alt keyup sometimes fires, sometimes doesn't. Strange. https://jsbin.com/vocehicipe/6/edit?html,js,output

Related: https://connect.microsoft.com/IE/feedback/details/2513563/no-keyup-event-for-alt-when-used-as-the-only-modifier-key