### PR TITLE
 Handle simultaneous keyboard and mouse streams

### DIFF
--- a/src/ps2.js
+++ b/src/ps2.js
@@ -53,6 +53,9 @@ function PS2(cpu, bus)
     /** @type {boolean} */
     this.next_read_resolution = false;
 
+    /** @type {boolean} */
+    this.next_byte_is_aux = false;
+
     /**
      * @type {ByteQueue}
      */
@@ -71,6 +74,9 @@ function PS2(cpu, bus)
 
     /** @type {number} */
     this.last_mouse_packet = -1;
+
+    /** @type {number} */
+    this.last_notify = 0;
 
     /**
      * @type {ByteQueue}
@@ -128,15 +134,17 @@ PS2.prototype.get_state = function()
     state[11] = this.next_handle_scan_code_set;
     state[12] = this.next_read_rate;
     state[13] = this.next_read_resolution;
-    //state[14] = this.kbd_buffer;
+    state[14] = this.next_byte_is_aux;
     state[15] = this.last_port60_byte;
     state[16] = this.sample_rate;
     state[17] = this.resolution;
     state[18] = this.scaling2;
-    //state[19] = this.mouse_buffer;
+    state[19] = this.last_notify;
     state[20] = this.command_register;
     state[21] = this.read_output_register;
     state[22] = this.read_command_register;
+    //state[23] = this.kbd_buffer;
+    //state[24] = this.mouse_buffer;
 
     return state;
 };
@@ -157,41 +165,78 @@ PS2.prototype.set_state = function(state)
     this.next_handle_scan_code_set = state[11];
     this.next_read_rate = state[12];
     this.next_read_resolution = state[13];
-    //this.kbd_buffer = state[14];
+    this.next_byte_is_aux = state[14];
     this.last_port60_byte = state[15];
     this.sample_rate = state[16];
     this.resolution = state[17];
     this.scaling2 = state[18];
-    //this.mouse_buffer = state[19];
+    this.last_notify = state[19];
     this.command_register = state[20];
     this.read_output_register = state[21];
     this.read_command_register = state[22];
+    //this.kbd_buffer = state[23];
+    //this.mouse_buffer = state[24];
 
     this.bus.send("mouse-enable", this.use_mouse);
 };
 
-PS2.prototype.mouse_irq = function()
+PS2.prototype.mouse_notify = function()
 {
+    this.last_notify = Date.now();
+
+    // ensure port 0x60 read returns mouse data
+    this.next_byte_is_aux = true;
+
     if(this.command_register & 2)
     {
+        dbg_log("mouse irq raise", LOG_PS2);
+
+        // ensure rising edge
+        this.cpu.device_lower_irq(12);
         this.cpu.device_raise_irq(12);
     }
 };
 
-PS2.prototype.kbd_irq = function()
+PS2.prototype.kbd_notify = function()
 {
+    this.last_notify = Date.now();
+
+    // ensure port 0x60 read returns kbd data
+    this.next_byte_is_aux = false;
+
     if(this.command_register & 1)
     {
+        dbg_log("kbd irq raise", LOG_PS2);
+
+        // ensure rising edge
+        this.cpu.device_lower_irq(1);
         this.cpu.device_raise_irq(1);
     }
 };
 
+PS2.prototype.notify_has_expired = function()
+{
+    return Date.now() - this.last_notify > 1000;
+}
+
 PS2.prototype.kbd_send_code = function(code)
 {
+    dbg_log("kbd send code", LOG_PS2);
     if(this.enable_keyboard_stream)
     {
+        var notify_expired = this.notify_has_expired();
+
+        var was_empty = !(this.kbd_buffer.length || this.mouse_buffer.length);
+
+        dbg_log("kbd push", LOG_PS2);
         this.kbd_buffer.push(code);
-        this.kbd_irq();
+
+        if(notify_expired || was_empty)
+        {
+            // restart chain if previous IRQ was not handled
+            // or start new chain
+            this.kbd_notify();
+        }
     }
 };
 
@@ -266,13 +311,21 @@ PS2.prototype.send_mouse_packet = function(dx, dy)
     //    delta_y = this.apply_scaling2(delta_y);
     //}
 
+    var notify_expired = this.notify_has_expired();
+    var was_empty = !(this.kbd_buffer.length || this.mouse_buffer.length);
+
     this.mouse_buffer.push(info_byte);
     this.mouse_buffer.push(delta_x);
     this.mouse_buffer.push(delta_y);
 
     dbg_log("adding mouse packets: " + [info_byte, dx, dy], LOG_PS2);
 
-    this.mouse_irq();
+    if(notify_expired || was_empty)
+    {
+        // restart chain if previous IRQ was not handled
+        // or start new chain
+        this.mouse_notify();
+    }
 };
 
 PS2.prototype.apply_scaling2 = function(n)
@@ -298,11 +351,6 @@ PS2.prototype.apply_scaling2 = function(n)
     }
 };
 
-PS2.prototype.next_byte_is_aux = function()
-{
-    return this.mouse_buffer.length && !this.kbd_buffer.length;
-};
-
 PS2.prototype.port60_read = function()
 {
     //dbg_log("port 60 read: " + (buffer[0] || "(none)"));
@@ -314,28 +362,36 @@ PS2.prototype.port60_read = function()
         return this.last_port60_byte;
     }
 
-    var do_mouse_buffer = this.next_byte_is_aux();
-
-    if(do_mouse_buffer)
+    if(this.next_byte_is_aux)
     {
+        dbg_log("mouse irq lower", LOG_PS2);
         this.cpu.device_lower_irq(12);
         this.last_port60_byte = this.mouse_buffer.shift();
         dbg_log("Port 60 read (mouse): " + h(this.last_port60_byte), LOG_PS2);
 
-        if(this.mouse_buffer.length >= 1)
+        if(this.mouse_buffer.length)
         {
-            this.mouse_irq();
+            this.mouse_notify();
+        }
+        else if(this.kbd_buffer.length)
+        {
+            this.kbd_notify();
         }
     }
     else
     {
+        dbg_log("kbd irq lower", LOG_PS2);
         this.cpu.device_lower_irq(1);
         this.last_port60_byte = this.kbd_buffer.shift();
         dbg_log("Port 60 read (kbd)  : " + h(this.last_port60_byte), LOG_PS2);
 
-        if(this.kbd_buffer.length >= 1)
+        if(this.kbd_buffer.length)
         {
-            this.kbd_irq();
+            this.kbd_notify();
+        }
+        else if(this.mouse_buffer.length)
+        {
+            this.mouse_notify();
         }
     }
 
@@ -352,7 +408,7 @@ PS2.prototype.port64_read = function()
     {
         status_byte |= 1;
     }
-    if(this.next_byte_is_aux())
+    if(this.next_byte_is_aux)
     {
         status_byte |= 0x20;
     }
@@ -373,7 +429,7 @@ PS2.prototype.port60_write = function(write_byte)
 
         // not sure, causes "spurious ack" in Linux
         //this.kbd_buffer.push(0xFA);
-        //this.kbd_irq();
+        //this.kbd_notify();
 
         dbg_log("Keyboard command register = " + h(this.command_register), LOG_PS2);
     }
@@ -383,7 +439,7 @@ PS2.prototype.port60_write = function(write_byte)
 
         this.mouse_buffer.clear();
         this.mouse_buffer.push(write_byte);
-        this.mouse_irq();
+        this.mouse_notify();
     }
     else if(this.next_read_sample)
     {
@@ -398,7 +454,7 @@ PS2.prototype.port60_write = function(write_byte)
             dbg_log("invalid sample rate, reset to 100", LOG_PS2);
             this.sample_rate = 100;
         }
-        this.mouse_irq();
+        this.mouse_notify();
     }
     else if(this.next_read_resolution)
     {
@@ -416,21 +472,21 @@ PS2.prototype.port60_write = function(write_byte)
             this.resolution = 1 << write_byte;
             dbg_log("resolution: " + this.resolution, LOG_PS2);
         }
-        this.mouse_irq();
+        this.mouse_notify();
     }
     else if(this.next_read_led)
     {
         // nope
         this.next_read_led = false;
         this.kbd_buffer.push(0xFA);
-        this.kbd_irq();
+        this.kbd_notify();
     }
     else if(this.next_handle_scan_code_set)
     {
         this.next_handle_scan_code_set = false;
 
         this.kbd_buffer.push(0xFA);
-        this.kbd_irq();
+        this.kbd_notify();
 
         if(write_byte)
         {
@@ -446,7 +502,7 @@ PS2.prototype.port60_write = function(write_byte)
         // nope
         this.next_read_rate = false;
         this.kbd_buffer.push(0xFA);
-        this.kbd_irq();
+        this.kbd_notify();
     }
     else if(this.next_is_mouse_command)
     {
@@ -539,7 +595,7 @@ PS2.prototype.port60_write = function(write_byte)
             dbg_log("Unimplemented mouse command: " + h(write_byte), LOG_PS2);
         }
 
-        this.mouse_irq();
+        this.mouse_notify();
     }
     else
     {
@@ -592,7 +648,7 @@ PS2.prototype.port60_write = function(write_byte)
             dbg_log("Unimplemented keyboard command: " + h(write_byte), LOG_PS2);
         }
 
-        this.kbd_irq();
+        this.kbd_notify();
     }
 };
 

--- a/src/ps2.js
+++ b/src/ps2.js
@@ -362,6 +362,16 @@ PS2.prototype.apply_scaling2 = function(n)
     }
 };
 
+PS2.prototype.send_command_response = function(response_byte)
+{
+    this.kbd_buffer.clear();
+    this.mouse_buffer.clear();
+    this.kbd_buffer.push(response_byte);
+
+    // Ensure next 0x60 read receives response_byte
+    this.kbd_notify();
+};
+
 PS2.prototype.port60_read = function()
 {
     //dbg_log("port 60 read: " + (buffer[0] || "(none)"));
@@ -670,9 +680,7 @@ PS2.prototype.port64_write = function(write_byte)
     switch(write_byte)
     {
     case 0x20:
-        this.kbd_buffer.clear();
-        this.mouse_buffer.clear();
-        this.kbd_buffer.push(this.command_register);
+        this.send_command_response(this.command_register);
         break;
     case 0x60:
         this.read_command_register = true;
@@ -695,20 +703,14 @@ PS2.prototype.port64_write = function(write_byte)
         break;
     case 0xA9:
         // test second ps/2 port
-        this.kbd_buffer.clear();
-        this.mouse_buffer.clear();
-        this.kbd_buffer.push(0);
+        this.send_command_response(0);
         break;
     case 0xAA:
-        this.kbd_buffer.clear();
-        this.mouse_buffer.clear();
-        this.kbd_buffer.push(0x55);
+        this.send_command_response(0x55);
         break;
     case 0xAB:
         // Test first PS/2 port
-        this.kbd_buffer.clear();
-        this.mouse_buffer.clear();
-        this.kbd_buffer.push(0);
+        this.send_command_response(0);
         break;
     case 0xAD:
         // Disable Keyboard

--- a/src/state.js
+++ b/src/state.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /** @const */
-var STATE_VERSION = 5;
+var STATE_VERSION = 6;
 
 /** @const */
 var STATE_MAGIC = 0x86768676|0;

--- a/src/state.js
+++ b/src/state.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /** @const */
-var STATE_VERSION = 4;
+var STATE_VERSION = 5;
 
 /** @const */
 var STATE_MAGIC = 0x86768676|0;


### PR DESCRIPTION
This fixes #182, by handling the following situations:

- Not all mouse/keyboard IRQ handlers check the status port to see whether the next port 0x60 read is going to return the mouse byte or keyboard byte. For example: [KolibriOS](http://websvn.kolibrios.org/filedetails.php?repname=Kolibri+OS&path=%2Fdrivers%2Fmouse%2Fcommouse.asm)

- Not all interrupts may result in reading port 0x60 to clear the interrupt itself. For example, the mouse IRQ handler for Windows 1 and 98 appears to skip reading port 0x60 if it finds out that the next byte
to be returned is a keyboard byte and not a mouse byte. The mouse IRQ thus never gets a chance to get cleared, and subsequent `device_raise_irq` do not actually trigger the handler.

- Between the time:
  ... after a mouse interrupt gets raised, or the OS reads the status port, and
  ... before the OS reads port 0x60,
more keyboard data may be received, and this race condition will make the OS read a keyboard byte when it is expecting a mouse byte, and vice versa. Thus, this patch ensures that incoming keyboard data will not mess up the `next_byte_is_aux` state, and vice versa with incoming mouse data. Instead, `next_byte_is_aux` is only toggled when the current buffer being read has been fully cleared.

Do you like this approach? I don't mind scrapping the changes I've made if you think there's a better method.