### PR TITLE
ACPI test for travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ images/
 *.img
 *.fixture
 *.fuse_hidden*
+*.DS_Store

--- a/.travis-run-integration-acpi.sh
+++ b/.travis-run-integration-acpi.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+mkdir -p images
+(cd images && curl --compressed -OOOOOOOOOO https://copy.sh/v86/images/{linux.iso,linux3.iso,kolibri.img,windows101.img,os8.dsk,freedos722.img,openbsd.img,oberon.dsk,oberon-boot.dsk})
+make build/libv86.js useacpi=true
+tests/full/run.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script:
 env:
     - TEST_SUITE=unit
     - TEST_SUITE=integration
+    - TEST_SUITE=integration-acpi
     - TEST_SUITE=unit-qemu
     - TEST_SUITE=nasm
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ NASM_TEST_DIR=./tests/nasm
 all: build/v86_all.js
 browser: build/v86_all.js
 
+ACPI=false
+ifeq ($(useacpi),true)
+ACPI=true
+endif
+
 # Used for nodejs builds and in order to profile code.
 # `debug` gives identifiers a readable name, make sure it doesn't have any side effects.
 CLOSURE_READABLE=--formatting PRETTY_PRINT --debug
@@ -92,6 +97,7 @@ build/v86_all.js: $(CLOSURE) src/*.js src/browser/*.js lib/*.js
 	java -jar $(CLOSURE) \
 		--js_output_file build/v86_all.js\
 		--define=DEBUG=false\
+		--define=ENABLE_ACPI=$(ACPI)\
 		$(CLOSURE_SOURCE_MAP)\
 		$(CLOSURE_FLAGS)\
 		--compilation_level ADVANCED\
@@ -112,6 +118,7 @@ build/libv86.js: $(CLOSURE) src/*.js lib/*.js src/browser/*.js
 	java -jar $(CLOSURE) \
 		--js_output_file build/libv86.js\
 		--define=DEBUG=false\
+		--define=ENABLE_ACPI=$(ACPI)\
 		$(CLOSURE_FLAGS)\
 		--compilation_level SIMPLE\
 		$(TRANSPILE_ES6_FLAGS)\

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,10 @@ var LOG_LEVEL = LOG_ALL & ~LOG_PS2 & ~LOG_PIT & ~LOG_VIRTIO & ~LOG_9P & ~LOG_PIC
 /** @const */
 var ENABLE_HPET = DEBUG && false;
 
-/** @const */
+/**
+ * @define {boolean}
+ * Overridden by closure compiler
+ */
 var ENABLE_ACPI = false;
 
 


### PR DESCRIPTION
This pull request adds..

- An ACPI test on travis
- The build option to enable ACPI `useacpi=true` ex: `make build/libv86.js useacpi=true`

- .DS_Store added to the .gitignore because it was annoying me

Thanks for the help with git, you guys are great

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/copy/v86/186)
<!-- Reviewable:end -->
