### PR TITLE
Implement SB16 Mixer Chip + Several Speaker Improvements

### DIFF
--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -14,39 +14,6 @@
     /** @const */
     var ON_HTTPS = location.protocol === "https:";
 
-    function dump_file(ab, name)
-    {
-        if(!(ab instanceof Array))
-        {
-            ab = [ab];
-        }
-
-        var blob = new Blob(ab);
-        download(blob, name);
-    }
-
-    function download(file_or_blob, name)
-    {
-        var a = document.createElement("a");
-        a["download"] = name;
-        a.href = window.URL.createObjectURL(file_or_blob);
-        a.dataset["downloadurl"] = ["application/octet-stream", a["download"], a.href].join(":");
-
-        if(document.createEvent)
-        {
-            var ev = document.createEvent("MouseEvent");
-            ev.initMouseEvent("click", true, true, window,
-                              0, 0, 0, 0, 0, false, false, false, false, 0, null);
-            a.dispatchEvent(ev);
-        }
-        else
-        {
-            a.click();
-        }
-
-        window.URL.revokeObjectURL(a.href);
-    }
-
     /**
      * @return {Object.<string, string>}
      */

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -272,11 +272,11 @@ function SpeakerMixerSource(audio_context, source_node, destination_node)
 /** @param {string=} channel */
 SpeakerMixerSource.prototype.connect = function(channel)
 {
-    if(channel !== "left")
+    if(!channel || channel === "left")
     {
         this.node_gain_left.connect(this.node_merger, 0, 0);
     }
-    if(channel !== "right")
+    if(!channel || channel === "right")
     {
         this.node_gain_right.connect(this.node_merger, 0, 1);
     }
@@ -285,11 +285,11 @@ SpeakerMixerSource.prototype.connect = function(channel)
 /** @param {string=} channel */
 SpeakerMixerSource.prototype.disconnect = function(channel)
 {
-    if(channel !== "left")
+    if(!channel || channel === "left")
     {
         this.node_gain_left.disconnect();
     }
-    if(channel !== "right")
+    if(!channel || channel === "right")
     {
         this.node_gain_right.disconnect();
     }

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -151,9 +151,9 @@ function SpeakerMixer(bus, audio_context)
             source = this.sources.get(source_name);
         }
 
-        if(typeof source === "undefined")
+        if(source === undefined)
         {
-            console.warn("Mixer set volume - cannot set volume for undefined source: " + source_name);
+            dbg_assert(false, "Mixer set volume - cannot set volume for undefined source: " + source_name);
             return;
         }
 
@@ -201,10 +201,7 @@ SpeakerMixer.prototype.add_source = function(source_node, source_name)
         this.input_right
     );
 
-    if(this.sources.has(source_name))
-    {
-        console.warn("Mixer add source - overwritting source: " + source_name);
-    }
+    dbg_assert(!this.sources.has(source_name), "Mixer add source - overwritting source: " + source_name);
 
     this.sources.set(source_name, source);
     return source;
@@ -218,9 +215,9 @@ SpeakerMixer.prototype.connect_source = function(source_name, channel)
 {
     var source = this.sources.get(source_name);
 
-    if(typeof source === "undefined")
+    if(source === undefined)
     {
-        console.warn("Mixer connect - cannot connect undefined source: " + source_name);
+        dbg_assert(false, "Mixer connect - cannot connect undefined source: " + source_name);
         return;
     }
 
@@ -235,9 +232,9 @@ SpeakerMixer.prototype.disconnect_source = function(source_name, channel)
 {
     var source = this.sources.get(source_name);
 
-    if(typeof source === "undefined")
+    if(source === undefined)
     {
-        console.warn("Mixer disconnect - cannot disconnect undefined source: " + source_name);
+        dbg_assert(false, "Mixer disconnect - cannot disconnect undefined source: " + source_name);
         return;
     }
 
@@ -267,7 +264,7 @@ SpeakerMixer.prototype.set_volume = function(value, channel)
             this.volume_both = value;
             break;
         default:
-            console.warn("Mixer set master volume - unknown channel: " + channel);
+            dbg_assert(false, "Mixer set master volume - unknown channel: " + channel);
             return;
     }
 
@@ -400,7 +397,7 @@ SpeakerMixerSource.prototype.set_volume = function(value, channel)
             this.volume_both = value;
             break;
         default:
-            console.warn("Mixer set volume - unknown channel: " + channel);
+            dbg_assert(false, "Mixer set volume - unknown channel: " + channel);
             return;
     }
 
@@ -799,10 +796,7 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
                     this.pump();
                     break;
                 case "debug-log":
-                    if(DEBUG)
-                    {
-                        console.log("SpeakerWorkletDAC - Worklet: " + event.data.value);
-                    }
+                    dbg_log("SpeakerWorkletDAC - Worklet: " + event.data.value);
                     break;
             }
         };
@@ -998,10 +992,7 @@ SpeakerBufferSourceDAC.prototype.queue = function(data)
 
     if(this.buffered_time < current_time)
     {
-        if(DEBUG)
-        {
-            console.log("Speaker DAC - Creating/Recreating reserve - shouldn't occur frequently during playback");
-        }
+        dbg_log("Speaker DAC - Creating/Recreating reserve - shouldn't occur frequently during playback");
 
         // Schedule pump() to queue evenly, starting from current time
         this.buffered_time = current_time;

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -397,11 +397,12 @@ function SpeakerDAC(bus, audio_context, mixer)
     {
         this.enabled = false;
     }, this);
-    bus.register("dac-tell-sampling-rate", function(data)
+    bus.register("dac-tell-sampling-rate", function(rate)
     {
-        this.sampling_rate = data[0];
-        this.rate_ratio = Math.ceil(DAC_MINIMUM_SAMPLING_RATE / data[0]);
-        this.node_lowpass.frequency.setValueAtTime(data[0] / 2, this.audio_context.currentTime);
+        rate = /** @type{number} */(rate);
+        this.sampling_rate = rate;
+        this.rate_ratio = Math.ceil(DAC_MINIMUM_SAMPLING_RATE / rate);
+        this.node_lowpass.frequency.setValueAtTime(rate / 2, this.audio_context.currentTime);
     }, this);
 
     if(DEBUG)

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -151,16 +151,14 @@ function SpeakerMixer(bus, audio_context)
         source.set_volume(gain);
     }, this);
 
-    bus.register("mixer-gain-left", function(decibels)
+    bus.register("mixer-gain-left", function(/** number */ decibels)
     {
-        decibels = /** @type{number} */(decibels);
         this.gain_left = Math.pow(10, decibels / 20);
         this.update();
     }, this);
 
-    bus.register("mixer-gain-right", function(decibels)
+    bus.register("mixer-gain-right", function(/** number */ decibels)
     {
-        decibels = /** @type{number} */(decibels);
         this.gain_right = Math.pow(10, decibels / 20);
         this.update();
     }, this);

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -24,83 +24,207 @@ function SpeakerAdapter(bus)
 
     this.audio_context = new (window.AudioContext || window.webkitAudioContext)();
 
-    this.beep_gain = this.audio_context.createGain();
-    this.beep_gain.gain.setValueAtTime(0, this.audio_context.currentTime);
-    this.beep_gain.connect(this.audio_context.destination);
+    // TODO: Find / calibrate / verify the filter frequencies
 
     this.beep_oscillator = this.audio_context.createOscillator();
     this.beep_oscillator.type = "square";
     this.beep_oscillator.frequency.setValueAtTime(440, this.audio_context.currentTime);
-    this.beep_oscillator.connect(this.beep_gain);
-    this.beep_oscillator.start();
-
-    this.beep_playing = false;
-    this.beep_enable = false;
-    this.beep_frequency = 440;
-    this.pit_enabled = false;
-    this.cpu_running = true;
+    this.beep_gain = this.audio_context.createGain();
+    this.beep_gain.gain.setValueAtTime(0, this.audio_context.currentTime);
 
     this.dac_processor = this.audio_context.createScriptProcessor(2048, 0, 2);
     this.dac_processor.onaudioprocess = this.dac_process.bind(this);
-    this.dac_processor.connect(this.audio_context.destination);
+    this.dac_gain_left = this.audio_context.createGain();
+    this.dac_gain_left.gain.setValueAtTime(1, this.audio_context.currentTime);
+    this.dac_gain_right = this.audio_context.createGain();
+    this.dac_gain_right.gain.setValueAtTime(1, this.audio_context.currentTime);
+    this.dac_splitter = this.audio_context.createChannelSplitter(2);
     this.dac_buffer0 = new Float32Array(this.dac_processor.bufferSize);
     this.dac_buffer1 = new Float32Array(this.dac_processor.bufferSize);
-    this.dac_enabled = true;
 
+    this.master_splitter = this.audio_context.createChannelSplitter(2);
+
+    this.master_volume_left = this.audio_context.createGain();
+    this.master_volume_right = this.audio_context.createGain();
+
+    this.master_treble_left = this.audio_context.createBiquadFilter();
+    this.master_treble_right = this.audio_context.createBiquadFilter();
+    this.master_treble_left.type = "highshelf";
+    this.master_treble_right.type = "highshelf";
+    this.master_treble_left.frequency.setValueAtTime(2000, this.audio_context.currentTime);
+    this.master_treble_right.frequency.setValueAtTime(2000, this.audio_context.currentTime);
+
+    this.master_bass_left = this.audio_context.createBiquadFilter();
+    this.master_bass_right = this.audio_context.createBiquadFilter();
+    this.master_bass_left.type = "lowshelf";
+    this.master_bass_right.type = "lowshelf";
+    this.master_bass_left.frequency.setValueAtTime(200, this.audio_context.currentTime);
+    this.master_bass_right.frequency.setValueAtTime(200, this.audio_context.currentTime);
+
+    this.master_gain_left = this.audio_context.createGain();
+    this.master_gain_right = this.audio_context.createGain();
+
+    this.master_merger = this.audio_context.createChannelMerger(2);
+
+    // Mixer Graph
+    // Don't initially connect beep oscillator
+    this.beep_gain
+        .connect(this.master_splitter);
+    this.dac_processor
+        .connect(this.dac_splitter);
+    this.dac_splitter
+        .connect(this.dac_gain_left, 0)
+        .connect(this.master_volume_left);
+    this.dac_splitter
+        .connect(this.dac_gain_right, 1)
+        .connect(this.master_volume_right);
+    this.master_splitter
+        .connect(this.master_volume_left, 0)
+    /* Treble and bass disabled: leads not lag and noise
+        .connect(this.master_treble_left)
+        .connect(this.master_bass_left)
+        .connect(this.master_gain_left)
+    */
+        .connect(this.master_merger, 0, 0);
+    this.master_splitter
+        .connect(this.master_volume_right, 1)
+    /* Treble and bass disabled: leads not lag and noise
+        .connect(this.master_treble_right)
+        .connect(this.master_bass_right)
+        .connect(this.master_gain_right)
+    */
+        .connect(this.master_merger, 0, 1);
+    this.master_merger
+        .connect(this.audio_context.destination);
+
+    // Mixer Switches
+    bus.register("mixer-pcspeaker-connect", function()
+    {
+        this.beep_gain.connect(this.master_splitter);
+    }, this);
+    bus.register("mixer-pcspeaker-disconnect", function()
+    {
+        this.beep_gain.disconnect();
+    }, this);
+    bus.register("mixer-dac-connect", function()
+    {
+        this.dac_gain_left.connect(this.master_volume_right);
+        this.dac_gain_right.connect(this.master_volume_right);
+    }, this);
+    bus.register("mixer-dac-disconnect", function()
+    {
+        this.dac_gain_left.disconnect();
+        this.dac_gain_right.disconnect();
+    }, this);
+
+    // Mixer Levels
+    function create_volume_handler(audio_node, scaling, in_decibels)
+    {
+        if(in_decibels)
+        {
+            return function(decibels)
+            {
+                audio_node.gain.setValueAtTime(decibels, this.audio_context.currentTime);
+            };
+        }
+        else
+        {
+            return function(decibels)
+            {
+                var gain = Math.pow(10, decibels / 20) * scaling;
+                audio_node.gain.setValueAtTime(gain, this.audio_context.currentTime);
+            };
+        }
+    };
+
+    bus.register("mixer-pcspeaker-volume",
+        create_volume_handler(this.beep_gain, 1, false), this);
+
+    bus.register("mixer-dac-volume-left",
+        create_volume_handler(this.dac_gain_left, 3, false), this);
+
+    bus.register("mixer-dac-volume-right",
+        create_volume_handler(this.dac_gain_right, 1, false), this);
+
+    bus.register("mixer-master-volume-left",
+        create_volume_handler(this.master_volume_left, 1, false), this);
+
+    bus.register("mixer-master-volume-right",
+        create_volume_handler(this.master_volume_right, 1, false), this);
+
+    bus.register("mixer-master-gain-left",
+        create_volume_handler(this.master_gain_left, 1, false), this);
+
+    bus.register("mixer-master-gain-right",
+        create_volume_handler(this.master_gain_right, 1, false), this);
+
+    bus.register("mixer-master-treble-left",
+        create_volume_handler(this.master_treble_left, 1, true), this);
+
+    bus.register("mixer-master-treble-right",
+        create_volume_handler(this.master_treble_right, 1, true), this);
+
+    bus.register("mixer-master-bass-left",
+        create_volume_handler(this.master_bass_left, 1, true), this);
+
+    bus.register("mixer-master-bass-right",
+        create_volume_handler(this.master_bass_right, 1, true), this);
+
+    // Emulator Events
     bus.register("emulator-stopped", function()
     {
-        this.cpu_running = false;
-        this.beep_update();
+        this.audio_context.suspend();
     }, this);
-
     bus.register("emulator-started", function()
     {
-        this.cpu_running = true;
-        this.beep_update();
+        this.audio_context.resume();
     }, this);
 
-    bus.register("pcspeaker-enable", function(yesplease)
+    // PC Speaker
+    bus.register("pcspeaker-enable", function()
     {
-        this.beep_enable = yesplease;
-        this.beep_update();
+        this.beep_oscillator.connect(this.beep_gain);
     }, this);
-
+    bus.register("pcspeaker-disable", function()
+    {
+        this.beep_oscillator.disconnect();
+    }, this);
     bus.register("pcspeaker-update", function(data)
     {
         var counter_mode = data[0];
         var counter_reload = data[1];
-        this.pit_enabled = counter_mode == 3;
-        this.beep_frequency = OSCILLATOR_FREQ * 1000 / counter_reload;
-        this.beep_frequency = Math.min(this.beep_frequency, this.beep_oscillator.frequency.maxValue);
-        this.beep_frequency = Math.max(this.beep_frequency, 0);
-        this.beep_update();
+
+        var frequency = 0;
+        var beep_enabled = counter_mode === 3;
+
+        if(beep_enabled)
+        {
+            frequency = OSCILLATOR_FREQ * 1000 / counter_reload;
+            frequency = Math.min(frequency, this.beep_oscillator.frequency.maxValue);
+            frequency = Math.max(frequency, 0);
+        }
+
+        this.beep_oscillator.frequency.setValueAtTime(frequency, this.audio_context.currentTime);
     }, this);
 
-    bus.register("speaker-update-data", function(data)
+    // DAC
+    bus.register("dac-update-data", function(data)
     {
         this.dac_buffer0 = data[0];
         this.dac_buffer1 = data[1];
     }, this);
-
-    bus.register("speaker-request-samplerate", function()
+    bus.register("dac-request-samplerate", function()
     {
-        bus.send("speaker-tell-samplerate", this.audio_context.sampleRate);
+        bus.send("dac-tell-samplerate", this.audio_context.sampleRate);
     }, this);
-
-    bus.send("speaker-tell-samplerate", this.audio_context.sampleRate);
-
-    bus.register("speaker-update-enable", function(enabled)
+    bus.send("dac-tell-samplerate", this.audio_context.sampleRate);
+    bus.register("dac-enable", function(enabled)
     {
-        if(this.dac_enabled && !enabled)
-        {
-            this.dac_processor.disconnect(this.audio_context.destination);
-            this.dac_enabled = false;
-        }
-        else if(!this.dac_enabled && enabled)
-        {
-            this.dac_processor.connect(this.audio_context.destination);
-            this.dac_enabled = true;
-        }
+        this.dac_processor.connect(this.dac_splitter);
+    }, this);
+    bus.register("dac-disable", function()
+    {
+        this.dac_processor.disconnect();
     }, this);
 
     if(DEBUG)
@@ -117,41 +241,19 @@ function SpeakerAdapter(bus)
             },250);
         }
     }
+
+    // Start Nodes
+    this.beep_oscillator.start();
 }
-
-SpeakerAdapter.prototype.beep_update = function()
-{
-    var current_time = this.audio_context.currentTime;
-
-    if(this.pit_enabled && this.beep_enable && this.cpu_running)
-    {
-        this.beep_oscillator.frequency.setValueAtTime(this.beep_frequency, current_time);
-        if(!this.beep_playing)
-        {
-            this.beep_gain.gain.setValueAtTime(0.05, current_time);
-            this.beep_playing = true;
-        }
-    }
-    else if(this.beep_playing)
-    {
-        this.beep_gain.gain.setValueAtTime(0, current_time);
-        this.beep_playing = false;
-    }
-};
 
 SpeakerAdapter.prototype.dac_process = function(event)
 {
-    if(!this.dac_enabled)
-    {
-        return;
-    }
-
     var out = event.outputBuffer;
 
     out.copyToChannel(this.dac_buffer0, 0);
     out.copyToChannel(this.dac_buffer1, 1);
 
-    this.bus.send("speaker-request-data", out.length);
+    this.bus.send("dac-request-data", out.length);
 
     if(DEBUG)
     {

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -1006,7 +1006,9 @@ function SpeakerDACDebugger(audio_context, source_node)
     this.node_source = source_node;
 
     this.node_processor = null;
+
     this.node_gain = this.audio_context.createGain();
+    this.node_gain.gain.setValueAtTime(0, this.audio_context.currentTime);
 
     this.node_gain
         .connect(this.audio_context.destination);
@@ -1033,9 +1035,6 @@ SpeakerDACDebugger.prototype.start = function(duration_ms)
         this.output[0].push(event.inputBuffer.getChannelData(0).slice());
         this.output[1].push(event.inputBuffer.getChannelData(1).slice());
     };
-
-    this.node_gain = this.audio_context.createGain();
-    this.node_gain.gain.setValueAtTime(0, this.audio_context.currentTime);
 
     this.node_source
         .connect(this.node_processor)

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -39,6 +39,8 @@ function SpeakerAdapter(bus)
     /** @const */
     this.dac = new SpeakerDAC(bus, this.audio_context, this.mixer);
 
+    this.pcspeaker.start();
+
     bus.register("emulator-stopped", function()
     {
         this.audio_context.suspend();
@@ -49,6 +51,11 @@ function SpeakerAdapter(bus)
         this.audio_context.resume();
     }, this);
 
+    bus.register("speaker-confirm-initialized", function()
+    {
+        bus.send("speaker-has-initialized");
+    }, this);
+    bus.send("speaker-has-initialized");
 }
 
 /**
@@ -423,10 +430,12 @@ function PCSpeaker(bus, audio_context, mixer)
 
         this.node_oscillator.frequency.setValueAtTime(frequency, audio_context.currentTime);
     }, this);
-
-    // Start after configuration
-    setTimeout(() => this.node_oscillator.start(), 0);
 }
+
+PCSpeaker.prototype.start = function()
+{
+    this.node_oscillator.start();
+};
 
 /**
  * @constructor

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -236,7 +236,7 @@ SpeakerMixer.prototype.disconnect_source = function(source_id, channel)
  */
 SpeakerMixer.prototype.set_volume = function(value, channel)
 {
-    if(!channel)
+    if(channel === undefined)
     {
         channel = MIXER_CHANNEL_BOTH;
     }
@@ -353,7 +353,7 @@ SpeakerMixerSource.prototype.disconnect = function(channel)
  */
 SpeakerMixerSource.prototype.set_volume = function(value, channel)
 {
-    if(!channel)
+    if(channel === undefined)
     {
         channel = MIXER_CHANNEL_BOTH;
     }

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -432,10 +432,15 @@ SpeakerDAC.prototype.queue = function(data)
         buffer = this.audio_context.createBuffer(2, new_sample_count, new_sampling_rate);
         var buffer_data0 = buffer.getChannelData(0);
         var buffer_data1 = buffer.getChannelData(1);
+
+        var buffer_index = 0;
         for(var i = 0; i < sample_count; i++)
         {
-            buffer_data0[i << 1] = buffer_data0[(i << 1) + 1] = data[0][i];
-            buffer_data1[i << 1] = buffer_data1[(i << 1) + 1] = data[1][i];
+            for(var j = 0; j < this.rate_ratio; j++, buffer_index++)
+            {
+                buffer_data0[buffer_index] = data[0][i];
+                buffer_data1[buffer_index] = data[1][i];
+            }
         }
     }
     else

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -733,7 +733,7 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
                     value: message,
                 });
             }
-        }
+        };
 
         registerProcessor("dac-processor", DACProcessor);
     }

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -2,7 +2,9 @@
 
 /** @const */
 var DAC_QUEUE_RESERVE = 0.2;
-var DAC_MINIMUM_SAMPLING_RATE = 8000;
+
+/** @const */
+var AUDIOBUFFER_MINIMUM_SAMPLING_RATE = 8000;
 
 /**
  * @constructor
@@ -469,7 +471,10 @@ function PCSpeaker(bus, audio_context, mixer)
  */
 function SpeakerWorkletDAC(bus, audio_context, mixer)
 {
+    /** @const */
     this.bus = bus;
+
+    /** @const */
     this.audio_context = audio_context;
 
     // State
@@ -563,11 +568,6 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
                 };
             }
 
-            static get parameterDescriptors()
-            {
-                return [{ name: "gain", defaultValue: 1 }];
-            }
-
             process(inputs, outputs, parameters)
             {
                 for(var i = 0; i < outputs[0][0].length; i++)
@@ -585,9 +585,6 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
                         sum0 += this.get_sample(convolute_index, 0) * this.kernel(this.source_time - j);
                         sum1 += this.get_sample(convolute_index, 1) * this.kernel(this.source_time - j);
                     }
-
-                    sum0 *= parameters.gain[i];
-                    sum1 *= parameters.gain[i];
 
                     if(isNaN(sum0) || isNaN(sum1))
                     {
@@ -838,6 +835,8 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
 
     bus.register("dac-tell-sampling-rate", function(rate)
     {
+        dbg_assert(rate > 0, "Sampling rate should be nonzero");
+
         this.sampling_rate = rate;
 
         if(!this.node_processor)
@@ -937,9 +936,11 @@ function SpeakerBufferSourceDAC(bus, audio_context, mixer)
 
     bus.register("dac-tell-sampling-rate", function(rate)
     {
+        dbg_assert(rate > 0, "Sampling rate should be nonzero");
+
         rate = /** @type{number} */(rate);
         this.sampling_rate = rate;
-        this.rate_ratio = Math.ceil(DAC_MINIMUM_SAMPLING_RATE / rate);
+        this.rate_ratio = Math.ceil(AUDIOBUFFER_MINIMUM_SAMPLING_RATE / rate);
         this.node_lowpass.frequency.setValueAtTime(rate / 2, this.audio_context.currentTime);
     }, this);
 

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -484,15 +484,18 @@ function SpeakerDAC(bus, audio_context, mixer)
     {
         this.queue(data);
     }, this);
+
     bus.register("dac-enable", function(enabled)
     {
         this.enabled = true;
         this.pump();
     }, this);
+
     bus.register("dac-disable", function()
     {
         this.enabled = false;
     }, this);
+
     bus.register("dac-tell-sampling-rate", function(rate)
     {
         rate = /** @type{number} */(rate);

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -1071,7 +1071,7 @@ SpeakerDACDebugger.prototype.download_txt = function(history_id, channel)
         .map((v) => v.join(" "))
         .join(" ");
 
-    this.download(txt, "dacdata.txt", "text/plain");
+    dump_file(txt, "dacdata.txt");
 };
 
 // Useful for general plotting
@@ -1086,16 +1086,5 @@ SpeakerDACDebugger.prototype.download_csv = function(history_id)
             csv_rows.push(`${buffers[0][buffer_id][i]},${buffers[1][buffer_id][i]}`);
         }
     }
-    this.download(csv_rows.join("\n"), "dacdata.csv", "text/csv");
-};
-
-SpeakerDACDebugger.prototype.download = function(str, filename, mime)
-{
-    var blob = new Blob([str], { type: mime });
-    var a = document.createElement("a");
-    a["download"] = filename;
-    a.href = window.URL.createObjectURL(blob);
-    a.dataset["downloadurl"] = [mime, a["download"], a.href].join(":");
-    a.click();
-    window.URL.revokeObjectURL(a.href);
+    dump_file(csv_rows.join("\n"), "dacdata.csv");
 };

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -80,7 +80,7 @@ function SpeakerAdapter(bus)
         .connect(this.master_volume_right);
     this.master_splitter
         .connect(this.master_volume_left, 0)
-    /* Treble and bass disabled: leads not lag and noise
+    /* Treble and bass disabled: leads to lag and noise
         .connect(this.master_treble_left)
         .connect(this.master_bass_left)
         .connect(this.master_gain_left)
@@ -88,7 +88,7 @@ function SpeakerAdapter(bus)
         .connect(this.master_merger, 0, 0);
     this.master_splitter
         .connect(this.master_volume_right, 1)
-    /* Treble and bass disabled: leads not lag and noise
+    /* Treble and bass disabled: leads to lag and noise
         .connect(this.master_treble_right)
         .connect(this.master_bass_right)
         .connect(this.master_gain_right)

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -22,15 +22,7 @@ function SpeakerAdapter(bus)
         return;
     }
 
-    var SpeakerDAC;
-    if(window.AudioWorklet)
-    {
-        SpeakerDAC = SpeakerWorkletDAC;
-    }
-    else
-    {
-        SpeakerDAC = SpeakerBufferSourceDAC;
-    }
+    var SpeakerDAC = window.AudioWorklet ? SpeakerWorkletDAC : SpeakerBufferSourceDAC;
 
     /** @const */
     this.bus = bus;
@@ -141,15 +133,7 @@ function SpeakerMixer(bus, audio_context)
 
         var gain = Math.pow(10, decibels / 20);
 
-        var source;
-        if(source_name === "master")
-        {
-            source = this;
-        }
-        else
-        {
-            source = this.sources.get(source_name);
-        }
+        var source = source_name === "master" ? this : this.sources.get(source_name);
 
         if(source === undefined)
         {
@@ -180,7 +164,7 @@ function SpeakerMixer(bus, audio_context)
         {
             audio_node.gain.setValueAtTime(decibels, this.audio_context.currentTime);
         };
-    };
+    }
     bus.register("mixer-treble-left", create_gain_handler(this.node_treble_left), this);
     bus.register("mixer-treble-right", create_gain_handler(this.node_treble_right), this);
     bus.register("mixer-bass-left", create_gain_handler(this.node_bass_left), this);
@@ -273,15 +257,8 @@ SpeakerMixer.prototype.set_volume = function(value, channel)
 
 SpeakerMixer.prototype.update = function()
 {
-    var net_gain_left =
-        this.volume_both *
-        this.volume_left *
-        this.gain_left;
-
-    var net_gain_right =
-        this.volume_both *
-        this.volume_right *
-        this.gain_right;
+    var net_gain_left = this.volume_both * this.volume_left * this.gain_left;
+    var net_gain_right = this.volume_both * this.volume_right * this.gain_right;
 
     this.node_gain_left.gain.setValueAtTime(net_gain_left, this.audio_context.currentTime);
     this.node_gain_right.gain.setValueAtTime(net_gain_right, this.audio_context.currentTime);
@@ -328,17 +305,8 @@ function SpeakerMixerSource(audio_context, source_node, destination_left, destin
 
 SpeakerMixerSource.prototype.update = function()
 {
-    var net_gain_left =
-        this.connected_left *
-        this.gain_hidden *
-        this.volume_both *
-        this.volume_left;
-
-    var net_gain_right =
-        this.connected_right *
-        this.gain_hidden *
-        this.volume_both *
-        this.volume_right;
+    var net_gain_left = this.connected_left * this.gain_hidden * this.volume_both * this.volume_left;
+    var net_gain_right = this.connected_right * this.gain_hidden * this.volume_both * this.volume_right;
 
     this.node_gain_left.gain.setValueAtTime(net_gain_left, this.audio_context.currentTime);
     this.node_gain_right.gain.setValueAtTime(net_gain_right, this.audio_context.currentTime);
@@ -675,7 +643,7 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
                     var new_big_buffer =
                     [
                         new Float32Array(new_big_buffer_size),
-                        new Float32Array(new_big_buffer_size)
+                        new Float32Array(new_big_buffer_size),
                     ];
 
                     // Copy the first, already-shifted, small buffer into the new buffer.
@@ -705,7 +673,7 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
                 {
                     this.port.postMessage(
                     {
-                        type: "pump"
+                        type: "pump",
                     });
                 }
             }
@@ -747,7 +715,7 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
                 this.port.postMessage(
                 {
                     type: "debug-log",
-                    value: message
+                    value: message,
                 });
             }
         }
@@ -779,13 +747,13 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
         {
             "numberOfInputs": 0,
             "numberOfOutputs": 1,
-            "outputChannelCount": [2]
+            "outputChannelCount": [2],
         });
 
         this.node_processor.port.postMessage(
         {
             type: "sampling-rate",
-            value: this.sampling_rate
+            value: this.sampling_rate,
         });
 
         this.node_processor.port.onmessage = (event) =>
@@ -842,7 +810,7 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
         this.node_processor.port.postMessage(
         {
             type: "sampling-rate",
-            value: rate
+            value: rate,
         });
     }, this);
 
@@ -867,7 +835,7 @@ SpeakerWorkletDAC.prototype.queue = function(data)
     this.node_processor.port.postMessage(
     {
         type: "queue",
-        value: data
+        value: data,
     }, [data[0].buffer, data[1].buffer]);
 };
 
@@ -1051,7 +1019,7 @@ function SpeakerDACDebugger(audio_context, source_node)
 }
 
 /** @suppress {deprecated} */
-SpeakerDACDebugger.prototype.start = function(durationMs)
+SpeakerDACDebugger.prototype.start = function(duration_ms)
 {
     this.is_active = true;
     this.queued = [[], []];
@@ -1076,7 +1044,7 @@ SpeakerDACDebugger.prototype.start = function(durationMs)
     setTimeout(() =>
     {
         this.stop();
-    }, durationMs);
+    }, duration_ms);
 };
 
 SpeakerDACDebugger.prototype.stop = function()

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -6,7 +6,7 @@ var DAC_MINIMUM_SAMPLING_RATE = 8000;
 
 /**
  * @constructor
- * @param {BusConnector} bus
+ * @param {!BusConnector} bus
  */
 function SpeakerAdapter(bus)
 {
@@ -20,178 +20,309 @@ function SpeakerAdapter(bus)
         return;
     }
 
-    /** @const @type {BusConnector} */
+    /** @const */
     this.bus = bus;
 
+    /** @const */
     this.audio_context = new (window.AudioContext || window.webkitAudioContext)();
 
-    // TODO: Find / calibrate / verify the filter frequencies
+    /** @const */
+    this.mixer = new SpeakerMixer(bus, this.audio_context);
 
-    this.beep_oscillator = this.audio_context.createOscillator();
-    this.beep_oscillator.type = "square";
-    this.beep_oscillator.frequency.setValueAtTime(440, this.audio_context.currentTime);
-    this.beep_gain = this.audio_context.createGain();
-    this.beep_gain.gain.setValueAtTime(0, this.audio_context.currentTime);
+    /** @const */
+    this.pcspeaker = new PCSpeaker(bus, this.audio_context, this.mixer);
 
-    this.dac_gain_left = this.audio_context.createGain();
-    this.dac_gain_left.gain.setValueAtTime(1, this.audio_context.currentTime);
-    this.dac_gain_right = this.audio_context.createGain();
-    this.dac_gain_right.gain.setValueAtTime(1, this.audio_context.currentTime);
-    this.dac_splitter = this.audio_context.createChannelSplitter(2);
-    this.dac_lowpass = this.audio_context.createBiquadFilter();
-    this.dac_lowpass.type = "lowpass";
-    this.dac_enabled = false;
-    this.dac_sampling_rate = 22050;
-    this.dac_buffered_time = 0;
-    this.dac_rate_ratio = 1;
+    /** @const */
+    this.dac = new SpeakerDAC(bus, this.audio_context, this.mixer);
 
-    this.master_splitter = this.audio_context.createChannelSplitter(2);
-
-    this.master_volume_left = this.audio_context.createGain();
-    this.master_volume_right = this.audio_context.createGain();
-
-    this.master_treble_left = this.audio_context.createBiquadFilter();
-    this.master_treble_right = this.audio_context.createBiquadFilter();
-    this.master_treble_left.type = "highshelf";
-    this.master_treble_right.type = "highshelf";
-    this.master_treble_left.frequency.setValueAtTime(2000, this.audio_context.currentTime);
-    this.master_treble_right.frequency.setValueAtTime(2000, this.audio_context.currentTime);
-
-    this.master_bass_left = this.audio_context.createBiquadFilter();
-    this.master_bass_right = this.audio_context.createBiquadFilter();
-    this.master_bass_left.type = "lowshelf";
-    this.master_bass_right.type = "lowshelf";
-    this.master_bass_left.frequency.setValueAtTime(200, this.audio_context.currentTime);
-    this.master_bass_right.frequency.setValueAtTime(200, this.audio_context.currentTime);
-
-    this.master_gain_left = this.audio_context.createGain();
-    this.master_gain_right = this.audio_context.createGain();
-
-    this.master_merger = this.audio_context.createChannelMerger(2);
-
-    // Mixer Graph
-    // Don't initially connect beep oscillator
-    this.beep_gain
-        .connect(this.master_splitter);
-    this.dac_lowpass
-        .connect(this.dac_splitter);
-    this.dac_splitter
-        .connect(this.dac_gain_left, 0)
-        .connect(this.master_volume_left);
-    this.dac_splitter
-        .connect(this.dac_gain_right, 1)
-        .connect(this.master_volume_right);
-    this.master_splitter
-        .connect(this.master_volume_left, 0)
-    /* Treble and bass disabled: leads to lag and noise
-        .connect(this.master_treble_left)
-        .connect(this.master_bass_left)
-        .connect(this.master_gain_left)
-    */
-        .connect(this.master_merger, 0, 0);
-    this.master_splitter
-        .connect(this.master_volume_right, 1)
-    /* Treble and bass disabled: leads to lag and noise
-        .connect(this.master_treble_right)
-        .connect(this.master_bass_right)
-        .connect(this.master_gain_right)
-    */
-        .connect(this.master_merger, 0, 1);
-    this.master_merger
-        .connect(this.audio_context.destination);
-
-    // Mixer Switches
-    bus.register("mixer-pcspeaker-connect", function()
-    {
-        this.beep_gain.connect(this.master_splitter);
-    }, this);
-    bus.register("mixer-pcspeaker-disconnect", function()
-    {
-        this.beep_gain.disconnect();
-    }, this);
-    bus.register("mixer-dac-connect", function()
-    {
-        this.dac_gain_left.connect(this.master_volume_right);
-        this.dac_gain_right.connect(this.master_volume_right);
-    }, this);
-    bus.register("mixer-dac-disconnect", function()
-    {
-        this.dac_gain_left.disconnect();
-        this.dac_gain_right.disconnect();
-    }, this);
-
-    // Mixer Levels
-    function create_volume_handler(audio_node, scaling, in_decibels)
-    {
-        if(in_decibels)
-        {
-            return function(decibels)
-            {
-                audio_node.gain.setValueAtTime(decibels, this.audio_context.currentTime);
-            };
-        }
-        else
-        {
-            return function(decibels)
-            {
-                var gain = Math.pow(10, decibels / 20) * scaling;
-                audio_node.gain.setValueAtTime(gain, this.audio_context.currentTime);
-            };
-        }
-    };
-
-    bus.register("mixer-pcspeaker-volume",
-        create_volume_handler(this.beep_gain, 1, false), this);
-
-    bus.register("mixer-dac-volume-left",
-        create_volume_handler(this.dac_gain_left, 3, false), this);
-
-    bus.register("mixer-dac-volume-right",
-        create_volume_handler(this.dac_gain_right, 1, false), this);
-
-    bus.register("mixer-master-volume-left",
-        create_volume_handler(this.master_volume_left, 1, false), this);
-
-    bus.register("mixer-master-volume-right",
-        create_volume_handler(this.master_volume_right, 1, false), this);
-
-    bus.register("mixer-master-gain-left",
-        create_volume_handler(this.master_gain_left, 1, false), this);
-
-    bus.register("mixer-master-gain-right",
-        create_volume_handler(this.master_gain_right, 1, false), this);
-
-    bus.register("mixer-master-treble-left",
-        create_volume_handler(this.master_treble_left, 1, true), this);
-
-    bus.register("mixer-master-treble-right",
-        create_volume_handler(this.master_treble_right, 1, true), this);
-
-    bus.register("mixer-master-bass-left",
-        create_volume_handler(this.master_bass_left, 1, true), this);
-
-    bus.register("mixer-master-bass-right",
-        create_volume_handler(this.master_bass_right, 1, true), this);
-
-    // Emulator Events
     bus.register("emulator-stopped", function()
     {
         this.audio_context.suspend();
     }, this);
+
     bus.register("emulator-started", function()
     {
         this.audio_context.resume();
     }, this);
 
-    // PC Speaker
+}
+
+/**
+ * @constructor
+ * @param {!BusConnector} bus
+ * @param {!AudioContext} audio_context
+ */
+function SpeakerMixer(bus, audio_context)
+{
+    /** @const */
+    this.audio_context = audio_context;
+
+    this.sources = new Map();
+
+    // Nodes
+    // TODO: Find / calibrate / verify the filter frequencies
+
+    this.node_volume = this.audio_context.createGain();
+
+    this.node_splitter = this.audio_context.createChannelSplitter(2);
+
+    this.node_volume_left = this.audio_context.createGain();
+    this.node_volume_right = this.audio_context.createGain();
+
+    this.node_treble_left = this.audio_context.createBiquadFilter();
+    this.node_treble_right = this.audio_context.createBiquadFilter();
+    this.node_treble_left.type = "highshelf";
+    this.node_treble_right.type = "highshelf";
+    this.node_treble_left.frequency.setValueAtTime(2000, this.audio_context.currentTime);
+    this.node_treble_right.frequency.setValueAtTime(2000, this.audio_context.currentTime);
+
+    this.node_bass_left = this.audio_context.createBiquadFilter();
+    this.node_bass_right = this.audio_context.createBiquadFilter();
+    this.node_bass_left.type = "lowshelf";
+    this.node_bass_right.type = "lowshelf";
+    this.node_bass_left.frequency.setValueAtTime(200, this.audio_context.currentTime);
+    this.node_bass_right.frequency.setValueAtTime(200, this.audio_context.currentTime);
+
+    this.node_gain_left = this.audio_context.createGain();
+    this.node_gain_right = this.audio_context.createGain();
+
+    this.node_merger = this.audio_context.createChannelMerger(2);
+
+    // Graph
+
+    this.input = this.node_volume;
+
+    this.node_volume
+        .connect(this.node_splitter);
+    this.node_splitter
+        .connect(this.node_volume_left, 0)
+        .connect(this.node_treble_left)
+        .connect(this.node_bass_left)
+        .connect(this.node_gain_left)
+        .connect(this.node_merger, 0, 0);
+    this.node_splitter
+        .connect(this.node_volume_right, 1)
+        .connect(this.node_treble_right)
+        .connect(this.node_bass_right)
+        .connect(this.node_gain_right)
+        .connect(this.node_merger, 0, 1);
+    this.node_merger
+        .connect(this.audio_context.destination);
+
+    // Interface
+
+    this.master_as_a_source =
+    {
+        node_gain_left: this.node_volume_left,
+        node_gain_right: this.node_volume_right,
+        node_gain: this.node_volume,
+    };
+
+    bus.register("mixer-connect", function(data)
+    {
+        var source_name = data[0];
+        var channel = data[1];
+        this.connect_source(source_name, channel);
+    }, this);
+
+    bus.register("mixer-disconnect", function(data)
+    {
+        var source_name = data[0];
+        var channel = data[1];
+        this.disconnect_source(source_name, channel);
+    }, this);
+
+    bus.register("mixer-volume", function(data)
+    {
+        var source_name = data[0];
+        var channel = data[1];
+        var decibels = data[2];
+
+        var gain = Math.pow(10, decibels / 20);
+
+        var source;
+        if(source_name === "master")
+        {
+            source = this.master_as_a_source;
+        }
+        else
+        {
+            source = this.sources.get(source_name);
+        }
+
+        if(typeof source === "undefined")
+        {
+            console.warn("Mixer set volume - cannot set volume for undefined source: " + source_name);
+            return;
+        }
+
+        var node;
+        switch(channel)
+        {
+            case "left":
+                node = source.node_gain_left;
+                break;
+            case "right":
+                node = source.node_gain_right;
+                break;
+            case "both":
+                node = source.node_gain;
+                break;
+            default:
+                console.warn("Mixer set volume - unknown channel: " + channel);
+                return;
+        }
+
+        node.gain.setValueAtTime(gain, this.audio_context.currentTime);
+    }, this);
+
+    function create_gain_handler(audio_node, in_decibels)
+    {
+        return function(decibels)
+        {
+            var gain = in_decibels ? decibels : Math.pow(10, decibels / 20);
+            audio_node.gain.setValueAtTime(gain, this.audio_context.currentTime);
+        };
+    };
+    bus.register("mixer-gain-left", create_gain_handler(this.node_gain_left, false), this);
+    bus.register("mixer-gain-right", create_gain_handler(this.node_gain_right, false), this);
+    bus.register("mixer-treble-left", create_gain_handler(this.node_treble_left, false), this);
+    bus.register("mixer-treble-right", create_gain_handler(this.node_treble_right, false), this);
+    bus.register("mixer-bass-left", create_gain_handler(this.node_bass_left, false), this);
+    bus.register("mixer-bass-right", create_gain_handler(this.node_bass_right, false), this);
+}
+
+SpeakerMixer.prototype.add_source = function(source_node, source_name)
+{
+    var source = new SpeakerMixerSource(this.audio_context, source_node, this.input);
+
+    if(this.sources.has(source_name))
+    {
+        console.warn("Mixer add source - overwritting source: " + source_name);
+    }
+
+    this.sources.set(source_name, source);
+};
+
+/**
+ * @param {string} source_name
+ * @param {string=} channel
+ */
+SpeakerMixer.prototype.connect_source = function(source_name, channel)
+{
+    var source = this.sources.get(source_name);
+
+    if(typeof source === "undefined")
+    {
+        console.warn("Mixer connect - cannot connect undefined source: " + source_name);
+        return;
+    }
+
+    source.connect(channel);
+};
+
+/**
+ * @param {string} source_name
+ * @param {string=} channel
+ */
+SpeakerMixer.prototype.disconnect_source = function(source_name, channel)
+{
+    var source = this.sources.get(source_name);
+
+    if(typeof source === "undefined")
+    {
+        console.warn("Mixer disconnect - cannot disconnect undefined source: " + source_name);
+        return;
+    }
+
+    source.disconnect(channel);
+};
+
+/**
+ * @constructor
+ * @param {!AudioContext} audio_context
+ * @param {!AudioNode} source_node
+ * @param {!AudioNode} destination_node
+ */
+function SpeakerMixerSource(audio_context, source_node, destination_node)
+{
+    // Nodes
+
+    this.node_gain = audio_context.createGain();
+    this.node_splitter = audio_context.createChannelSplitter(2);
+    this.node_gain_left = audio_context.createGain();
+    this.node_gain_right = audio_context.createGain();
+    this.node_merger = audio_context.createChannelMerger(2);
+
+    // Graph
+
+    source_node
+        .connect(this.node_gain)
+        .connect(this.node_splitter);
+    this.node_splitter
+        .connect(this.node_gain_left, 0)
+        .connect(this.node_merger, 0, 0);
+    this.node_splitter
+        .connect(this.node_gain_right, 1)
+        .connect(this.node_merger, 0, 1);
+    this.node_merger
+        .connect(destination_node);
+}
+
+/** @param {string=} channel */
+SpeakerMixerSource.prototype.connect = function(channel)
+{
+    if(channel !== "left")
+    {
+        this.node_gain_left.connect(this.node_merger, 0, 0);
+    }
+    if(channel !== "right")
+    {
+        this.node_gain_right.connect(this.node_merger, 0, 1);
+    }
+};
+
+/** @param {string=} channel */
+SpeakerMixerSource.prototype.disconnect = function(channel)
+{
+    if(channel !== "left")
+    {
+        this.node_gain_left.disconnect();
+    }
+    if(channel !== "right")
+    {
+        this.node_gain_right.disconnect();
+    }
+};
+
+/**
+ * @constructor
+ * @param {!BusConnector} bus
+ * @param {!AudioContext} audio_context
+ */
+function PCSpeaker(bus, audio_context, mixer)
+{
+    // Nodes
+
+    this.node_oscillator = audio_context.createOscillator();
+    this.node_oscillator.type = "square";
+    this.node_oscillator.frequency.setValueAtTime(440, audio_context.currentTime);
+
+    // Interface
+
+    mixer.add_source(this.node_oscillator, "pcspeaker");
+    mixer.disconnect_source("pcspeaker");
+
     bus.register("pcspeaker-enable", function()
     {
-        this.beep_oscillator.connect(this.beep_gain);
+        mixer.connect_source("pcspeaker");
     }, this);
+
     bus.register("pcspeaker-disable", function()
     {
-        this.beep_oscillator.disconnect();
+        mixer.disconnect_source("pcspeaker");
     }, this);
+
     bus.register("pcspeaker-update", function(data)
     {
         var counter_mode = data[0];
@@ -203,141 +334,101 @@ function SpeakerAdapter(bus)
         if(beep_enabled)
         {
             frequency = OSCILLATOR_FREQ * 1000 / counter_reload;
-            frequency = Math.min(frequency, this.beep_oscillator.frequency.maxValue);
+            frequency = Math.min(frequency, this.node_oscillator.frequency.maxValue);
             frequency = Math.max(frequency, 0);
         }
 
-        this.beep_oscillator.frequency.setValueAtTime(frequency, this.audio_context.currentTime);
+        this.node_oscillator.frequency.setValueAtTime(frequency, audio_context.currentTime);
     }, this);
 
-    // DAC
+    // Start after configuration
+    setTimeout(() => this.node_oscillator.start(), 0);
+}
+
+/**
+ * @constructor
+ * @param {!BusConnector} bus
+ * @param {!AudioContext} audio_context
+ */
+function SpeakerDAC(bus, audio_context, mixer)
+{
+    /** @const */
+    this.bus = bus;
+
+    /** @const */
+    this.audio_context = audio_context;
+
+    // States
+
+    this.enabled = false;
+    this.sampling_rate = 22050;
+    this.buffered_time = 0;
+    this.rate_ratio = 1;
+
+    // Nodes
+
+    this.node_lowpass = this.audio_context.createBiquadFilter();
+    this.node_lowpass.type = "lowpass";
+
+    this.node_gain = this.audio_context.createGain();
+    this.node_gain.gain.setValueAtTime(3, this.audio_context.currentTime);
+
+    // Graph
+
+    this.node_lowpass
+        .connect(this.node_gain);
+
+    // Interface
+
+    mixer.add_source(this.node_gain, "dac");
+
     bus.register("dac-send-data", function(data)
     {
-        this.dac_queue(data);
+        this.queue(data);
     }, this);
     bus.register("dac-enable", function(enabled)
     {
-        this.dac_enabled = true;
-        this.dac_pump();
+        this.enabled = true;
+        this.pump();
     }, this);
     bus.register("dac-disable", function()
     {
-        this.dac_enabled = false;
+        this.enabled = false;
     }, this);
     bus.register("dac-tell-sampling-rate", function(data)
     {
-        this.dac_sampling_rate = data[0];
-        this.dac_rate_ratio = Math.ceil(DAC_MINIMUM_SAMPLING_RATE / data[0]);
-        this.dac_lowpass.frequency.setValueAtTime(data[0] / 2, this.audio_context.currentTime);
+        this.sampling_rate = data[0];
+        this.rate_ratio = Math.ceil(DAC_MINIMUM_SAMPLING_RATE / data[0]);
+        this.node_lowpass.frequency.setValueAtTime(data[0] / 2, this.audio_context.currentTime);
     }, this);
-
-    // Start Nodes
-    this.beep_oscillator.start();
 
     if(DEBUG)
     {
-        this.debug_dac = false;
-        this.debug_dac_queued_history = [];
-        this.debug_dac_output_history = [];
+        this.debug = false;
+        this.debug_queued_history = [];
+        this.debug_output_history = [];
     }
 }
 
-if(DEBUG)
-{
-    /** @suppress {deprecated} */
-    SpeakerAdapter.prototype.debug_dac_start = function()
-    {
-        this.debug_dac = true;
-        this.debug_dac_queued = [[], []];
-        this.debug_dac_output = [[], []];
-        this.debug_dac_queued_history.push(this.debug_dac_queued);
-        this.debug_dac_output_history.push(this.debug_dac_output);
-
-        this.debug_dac_processor = this.audio_context.createScriptProcessor(1024, 2, 2);
-        this.debug_dac_processor.onaudioprocess = (event) =>
-        {
-            this.debug_dac_output[0].push(event.inputBuffer.getChannelData(0).slice());
-            this.debug_dac_output[1].push(event.inputBuffer.getChannelData(1).slice());
-        };
-
-        this.debug_dac_gain = this.audio_context.createGain();
-        this.debug_dac_gain.gain.value = 0;
-
-        this.dac_lowpass
-            .connect(this.debug_dac_processor)
-            .connect(this.debug_dac_gain)
-            .connect(this.audio_context.destination);
-
-        setTimeout(() =>
-        {
-            this.debug_dac_stop();
-        }, 1000);
-    };
-
-    SpeakerAdapter.prototype.debug_dac_stop = function()
-    {
-        this.debug_dac = false;
-        this.dac_lowpass.disconnect(this.debug_dac_processor);
-        this.debug_dac_processor.disconnect();
-        this.debug_dac_processor = null;
-    };
-
-    // Useful for Audacity imports
-    SpeakerAdapter.prototype.debug_dac_download_txt = function(history_id, channel)
-    {
-        var txt = this.debug_dac_output_history[history_id][channel]
-            .map((v) => v.join(" "))
-            .join(" ");
-
-        this.debug_download(txt, "dacdata.txt", "text/plain");
-    };
-
-    // Useful for general plotting
-    SpeakerAdapter.prototype.debug_dac_download_csv = function(history_id)
-    {
-        var buffers = this.debug_dac_output_history[history_id];
-        var csv_rows = [];
-        for(var buffer_id = 0; buffer_id < buffers[0].length; buffer_id++)
-        {
-            for(var i = 0; i < buffers[0][buffer_id].length; i++)
-            {
-                csv_rows.push(`${buffers[0][buffer_id][i]},${buffers[1][buffer_id][i]}`);
-            }
-        }
-        this.debug_download(csv_rows.join("\n"), "dacdata.csv", "text/csv");
-    };
-
-    SpeakerAdapter.prototype.debug_download = function(str, filename, mime)
-    {
-        var blob = new Blob([str], { type: mime });
-        var a = document.createElement("a");
-        a["download"] = filename;
-        a.href = window.URL.createObjectURL(blob);
-        a.dataset["downloadurl"] = [mime, a["download"], a.href].join(":");
-        a.click();
-        window.URL.revokeObjectURL(a.href);
-    };
-}
-
-SpeakerAdapter.prototype.dac_queue = function(data)
+SpeakerDAC.prototype.queue = function(data)
 {
     if(DEBUG)
     {
-        if(this.debug_dac)
+        if(this.debug)
         {
-            this.debug_dac_queued[0].push(data[0].slice());
-            this.debug_dac_queued[1].push(data[1].slice());
+            this.debug_queued[0].push(data[0].slice());
+            this.debug_queued[1].push(data[1].slice());
         }
     }
 
     var sample_count = data[0].length;
-    var block_duration = sample_count / this.dac_sampling_rate;
+    var block_duration = sample_count / this.sampling_rate;
 
     var buffer;
-    if(this.dac_rate_ratio > 1)
+    if(this.rate_ratio > 1)
     {
-        var new_sample_count = sample_count * this.dac_rate_ratio;
-        var new_sampling_rate = this.dac_sampling_rate * this.dac_rate_ratio;
+        var new_sample_count = sample_count * this.rate_ratio;
+        var new_sampling_rate = this.sampling_rate * this.rate_ratio;
         buffer = this.audio_context.createBuffer(2, new_sample_count, new_sampling_rate);
         var buffer_data0 = buffer.getChannelData(0);
         var buffer_data1 = buffer.getChannelData(1);
@@ -349,19 +440,19 @@ SpeakerAdapter.prototype.dac_queue = function(data)
     }
     else
     {
-        buffer = this.audio_context.createBuffer(2, sample_count, this.dac_sampling_rate);
+        buffer = this.audio_context.createBuffer(2, sample_count, this.sampling_rate);
         buffer.copyToChannel(data[0], 0);
         buffer.copyToChannel(data[1], 1);
     }
 
     var source = this.audio_context.createBufferSource();
     source.buffer = buffer;
-    source.connect(this.dac_lowpass);
-    source.addEventListener("ended", this.dac_pump.bind(this));
+    source.connect(this.node_lowpass);
+    source.addEventListener("ended", this.pump.bind(this));
 
     var current_time = this.audio_context.currentTime;
 
-    if(this.dac_buffered_time < current_time)
+    if(this.buffered_time < current_time)
     {
         if(DEBUG)
         {
@@ -369,33 +460,110 @@ SpeakerAdapter.prototype.dac_queue = function(data)
         }
 
         // Schedule pump() to queue evenly, starting from current time
-        this.dac_buffered_time = current_time;
+        this.buffered_time = current_time;
         var target_silence_duration = DAC_QUEUE_RESERVE - block_duration;
         var current_silence_duration = 0;
         while(current_silence_duration <= target_silence_duration)
         {
             current_silence_duration += block_duration;
-            this.dac_buffered_time += block_duration;
-            setTimeout(() => this.dac_pump(), current_silence_duration * 1000);
+            this.buffered_time += block_duration;
+            setTimeout(() => this.pump(), current_silence_duration * 1000);
         }
     }
 
-    source.start(this.dac_buffered_time);
-    this.dac_buffered_time += block_duration;
+    source.start(this.buffered_time);
+    this.buffered_time += block_duration;
 
     // Chase the schedule - ensure reserve is full
-    setTimeout(() => this.dac_pump(), 0);
+    setTimeout(() => this.pump(), 0);
 };
 
-SpeakerAdapter.prototype.dac_pump = function()
+SpeakerDAC.prototype.pump = function()
 {
-    if(!this.dac_enabled)
+    if(!this.enabled)
     {
         return;
     }
-    if(this.dac_buffered_time - this.audio_context.currentTime > DAC_QUEUE_RESERVE)
+    if(this.buffered_time - this.audio_context.currentTime > DAC_QUEUE_RESERVE)
     {
         return;
     }
     this.bus.send("dac-request-data");
 };
+
+if(DEBUG)
+{
+    /** @suppress {deprecated} */
+    SpeakerDAC.prototype.debug_start = function(durationMs)
+    {
+        this.debug = true;
+        this.debug_queued = [[], []];
+        this.debug_output = [[], []];
+        this.debug_queued_history.push(this.debug_queued);
+        this.debug_output_history.push(this.debug_output);
+
+        this.debug_processor = this.audio_context.createScriptProcessor(1024, 2, 2);
+        this.debug_processor.onaudioprocess = (event) =>
+        {
+            this.debug_output[0].push(event.inputBuffer.getChannelData(0).slice());
+            this.debug_output[1].push(event.inputBuffer.getChannelData(1).slice());
+        };
+
+        this.debug_gain = this.audio_context.createGain();
+        this.debug_gain.gain.setValueAtTime(0, this.audio_context.currentTime);
+
+        this.node_lowpass
+            .connect(this.debug_processor)
+            .connect(this.debug_gain)
+            .connect(this.audio_context.destination);
+
+        setTimeout(() =>
+        {
+            this.debug_stop();
+        }, durationMs);
+    };
+
+    SpeakerDAC.prototype.debug_stop = function()
+    {
+        this.debug = false;
+        this.node_lowpass.disconnect(this.debug_processor);
+        this.debug_processor.disconnect();
+        this.debug_processor = null;
+    };
+
+    // Useful for Audacity imports
+    SpeakerDAC.prototype.debug_download_txt = function(history_id, channel)
+    {
+        var txt = this.debug_output_history[history_id][channel]
+            .map((v) => v.join(" "))
+            .join(" ");
+
+        this.debug_download(txt, "dacdata.txt", "text/plain");
+    };
+
+    // Useful for general plotting
+    SpeakerDAC.prototype.debug_download_csv = function(history_id)
+    {
+        var buffers = this.debug_output_history[history_id];
+        var csv_rows = [];
+        for(var buffer_id = 0; buffer_id < buffers[0].length; buffer_id++)
+        {
+            for(var i = 0; i < buffers[0][buffer_id].length; i++)
+            {
+                csv_rows.push(`${buffers[0][buffer_id][i]},${buffers[1][buffer_id][i]}`);
+            }
+        }
+        this.debug_download(csv_rows.join("\n"), "dacdata.csv", "text/csv");
+    };
+
+    SpeakerDAC.prototype.debug_download = function(str, filename, mime)
+    {
+        var blob = new Blob([str], { type: mime });
+        var a = document.createElement("a");
+        a["download"] = filename;
+        a.href = window.URL.createObjectURL(blob);
+        a.dataset["downloadurl"] = [mime, a["download"], a.href].join(":");
+        a.click();
+        window.URL.revokeObjectURL(a.href);
+    };
+}

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -469,6 +469,7 @@ function SpeakerDAC(bus, audio_context, mixer)
     this.sampling_rate = 22050;
     this.buffered_time = 0;
     this.rate_ratio = 1;
+    this.free_buffers_of_length = new Map();
 
     // Nodes
 
@@ -492,13 +493,20 @@ function SpeakerDAC(bus, audio_context, mixer)
     bus.register("dac-disable", function()
     {
         this.enabled = false;
+
+        // Prevent growth if block size changes
+        this.free_buffers_of_length.clear();
     }, this);
     bus.register("dac-tell-sampling-rate", function(rate)
     {
         rate = /** @type{number} */(rate);
         this.sampling_rate = rate;
         this.rate_ratio = Math.ceil(DAC_MINIMUM_SAMPLING_RATE / rate);
+        this.buffer_sampling_rate = rate * this.rate_ratio;
         this.node_lowpass.frequency.setValueAtTime(rate / 2, this.audio_context.currentTime);
+
+        // Previous buffers were only valid for a given sample rate
+        this.free_buffers_of_length.clear();
     }, this);
 
     if(DEBUG)
@@ -508,6 +516,26 @@ function SpeakerDAC(bus, audio_context, mixer)
         this.debug_output_history = [];
     }
 }
+
+SpeakerDAC.prototype.get_audio_buffer = function(sample_count)
+{
+    var buffers = this.free_buffers_of_length.get(sample_count);
+
+    if(!buffers)
+    {
+        buffers = [];
+        this.free_buffers_of_length.set(sample_count, buffers);
+    }
+
+    if(!buffers.length)
+    {
+        return this.audio_context.createBuffer(2, sample_count, this.buffer_sampling_rate);
+    }
+    else
+    {
+        return buffers.pop();
+    }
+};
 
 SpeakerDAC.prototype.queue = function(data)
 {
@@ -522,13 +550,11 @@ SpeakerDAC.prototype.queue = function(data)
 
     var sample_count = data[0].length;
     var block_duration = sample_count / this.sampling_rate;
+    var buffer_sample_count = sample_count * this.rate_ratio;
 
-    var buffer;
+    var buffer = this.get_audio_buffer(buffer_sample_count);
     if(this.rate_ratio > 1)
     {
-        var new_sample_count = sample_count * this.rate_ratio;
-        var new_sampling_rate = this.sampling_rate * this.rate_ratio;
-        buffer = this.audio_context.createBuffer(2, new_sample_count, new_sampling_rate);
         var buffer_data0 = buffer.getChannelData(0);
         var buffer_data1 = buffer.getChannelData(1);
 
@@ -544,7 +570,6 @@ SpeakerDAC.prototype.queue = function(data)
     }
     else
     {
-        buffer = this.audio_context.createBuffer(2, sample_count, this.sampling_rate);
         buffer.copyToChannel(data[0], 0);
         buffer.copyToChannel(data[1], 1);
     }
@@ -552,7 +577,18 @@ SpeakerDAC.prototype.queue = function(data)
     var source = this.audio_context.createBufferSource();
     source.buffer = buffer;
     source.connect(this.node_lowpass);
-    source.addEventListener("ended", this.pump.bind(this));
+    source.addEventListener("ended", () =>
+    {
+        var buffers = this.free_buffers_of_length.get(buffer_sample_count);
+
+        if(buffers)
+        {
+            buffers.push(buffer);
+        }
+        buffer = null;
+
+        this.pump();
+    });
 
     var current_time = this.audio_context.currentTime;
 

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -805,14 +805,12 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
 
         this.node_processor
             .connect(this.node_output);
-
-        // Interface
-
-        this.mixer_connection = mixer.add_source(this.node_output, "dac");
-        this.mixer_connection.set_gain_hidden(3);
     });
 
     // Interface
+
+    this.mixer_connection = mixer.add_source(this.node_output, "dac");
+    this.mixer_connection.set_gain_hidden(3);
 
     bus.register("dac-send-data", function(data)
     {

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -272,11 +272,12 @@ function SpeakerMixerSource(audio_context, source_node, destination_node)
 /** @param {string=} channel */
 SpeakerMixerSource.prototype.connect = function(channel)
 {
-    if(!channel || channel === "left")
+    var both = !channel || channel === "both";
+    if(both || channel === "left")
     {
         this.node_gain_left.connect(this.node_merger, 0, 0);
     }
-    if(!channel || channel === "right")
+    if(both || channel === "right")
     {
         this.node_gain_right.connect(this.node_merger, 0, 1);
     }
@@ -285,11 +286,12 @@ SpeakerMixerSource.prototype.connect = function(channel)
 /** @param {string=} channel */
 SpeakerMixerSource.prototype.disconnect = function(channel)
 {
-    if(!channel || channel === "left")
+    var both = !channel || channel === "both";
+    if(both || channel === "left")
     {
         this.node_gain_left.disconnect();
     }
-    if(!channel || channel === "right")
+    if(both || channel === "right")
     {
         this.node_gain_right.disconnect();
     }

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -743,6 +743,8 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
         .addModule(worklet_url)
         .then(() =>
     {
+        URL.revokeObjectURL(worklet_url);
+
         this.node_processor = new AudioWorkletNode(this.audio_context, "dac-processor",
         {
             "numberOfInputs": 0,

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -835,8 +835,9 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
 
     bus.register("dac-tell-sampling-rate", function(rate)
     {
-        dbg_assert(rate > 0, "Sampling rate should be nonzero");
+        rate = /** @type{number} */(rate);
 
+        dbg_assert(rate > 0, "Sampling rate should be nonzero");
         this.sampling_rate = rate;
 
         if(!this.node_processor)
@@ -936,9 +937,9 @@ function SpeakerBufferSourceDAC(bus, audio_context, mixer)
 
     bus.register("dac-tell-sampling-rate", function(rate)
     {
-        dbg_assert(rate > 0, "Sampling rate should be nonzero");
-
         rate = /** @type{number} */(rate);
+
+        dbg_assert(rate > 0, "Sampling rate should be nonzero");
         this.sampling_rate = rate;
         this.rate_ratio = Math.ceil(AUDIOBUFFER_MINIMUM_SAMPLING_RATE / rate);
         this.node_lowpass.frequency.setValueAtTime(rate / 2, this.audio_context.currentTime);

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -797,10 +797,8 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
         this.enabled = false;
     }, this);
 
-    bus.register("dac-tell-sampling-rate", function(rate)
+    bus.register("dac-tell-sampling-rate", function(/** number */ rate)
     {
-        rate = /** @type{number} */(rate);
-
         dbg_assert(rate > 0, "Sampling rate should be nonzero");
         this.sampling_rate = rate;
 
@@ -899,10 +897,8 @@ function SpeakerBufferSourceDAC(bus, audio_context, mixer)
         this.enabled = false;
     }, this);
 
-    bus.register("dac-tell-sampling-rate", function(rate)
+    bus.register("dac-tell-sampling-rate", function(/** number */ rate)
     {
-        rate = /** @type{number} */(rate);
-
         dbg_assert(rate > 0, "Sampling rate should be nonzero");
         this.sampling_rate = rate;
         this.rate_ratio = Math.ceil(AUDIOBUFFER_MINIMUM_SAMPLING_RATE / rate);

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -468,11 +468,11 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
             return Math.sin(x) / x;
         }
 
-        function create_empty_buffer()
-        {
-            var buffer = new Float32Array(MINIMUM_BUFFER_SIZE);
-            return [buffer, buffer];
-        }
+        var EMPTY_BUFFER =
+        [
+            new Float32Array(MINIMUM_BUFFER_SIZE),
+            new Float32Array(MINIMUM_BUFFER_SIZE),
+        ];
 
         class DACProcessor extends AudioWorkletProcessor
         {
@@ -496,9 +496,9 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
 
                 // Buffers being actively consumed
                 /** @type{Array<Float32Array>} */
-                this.source_buffer_previous = create_empty_buffer();
+                this.source_buffer_previous = EMPTY_BUFFER;
                 /** @type{Array<Float32Array>} */
-                this.source_buffer_current = create_empty_buffer();
+                this.source_buffer_current = EMPTY_BUFFER;
 
                 // Cached length of source_buffer_previous
                 this.source_length_previous = this.source_buffer_previous.length;
@@ -696,7 +696,7 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
             {
                 if(!this.queue_length)
                 {
-                    return create_empty_buffer();
+                    return EMPTY_BUFFER;
                 }
 
                 var item = this.queue_data[this.queue_start];

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -489,7 +489,6 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
         function DACProcessor()
         {
             var self = Reflect.construct(AudioWorkletProcessor, [], DACProcessor);
-            self = /** @type{DACProcessor} */(self);
 
             // Params
 

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -510,9 +510,6 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
             /** @type{Array<Float32Array>} */
             self.source_buffer_current = EMPTY_BUFFER;
 
-            // Cached length of source_buffer_previous
-            self.source_length_previous = self.source_buffer_previous.length;
-
             // Ratio of alienland sample rate to homeland sample rate.
             self.source_samples_per_destination = 1.0;
 
@@ -521,7 +518,7 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
             self.source_block_start = 0;
 
             // Real number representing the position of the current destination
-            // sample relative to source_buffer_current, since source_block_index.
+            // sample relative to source_buffer_current, since source_block_start.
             self.source_time = 0.0;
 
             // Same as source_time but rounded down to an index.
@@ -604,7 +601,10 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
         {
             if(index < 0)
             {
-                index += this.source_length_previous;
+                // -ve index represents previous buffer
+                //          <-------|
+                // [Previous buffer][Current buffer]
+                index += this.source_buffer_previous[0].length;
                 return this.source_buffer_previous[channel][index];
             }
             else
@@ -622,7 +622,6 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
             {
                 this.prepare_next_buffer();
                 this.source_block_start -= current_length;
-                this.source_length_previous = current_length;
             }
         };
 

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -253,7 +253,7 @@ SpeakerAdapter.prototype.dac_queue = function(data)
         {
             current_silence_duration += block_duration;
             this.dac_buffered_time += block_duration;
-            setTimeout(() => this.dac_pump(), current_silence_duration);
+            setTimeout(() => this.dac_pump(), current_silence_duration * 1000);
         }
     }
 

--- a/src/const.js
+++ b/src/const.js
@@ -349,3 +349,17 @@ var PREFIX_66 = PREFIX_MASK_OPSIZE; // alias
 
 /** @const */
 var MXCSR_MASK = (0xFFFF & ~(1 << 6));
+
+
+/** @const */
+var MIXER_CHANNEL_LEFT = 0;
+/** @const */
+var MIXER_CHANNEL_RIGHT = 1;
+/** @const */
+var MIXER_CHANNEL_BOTH = 2;
+/** @const */
+var MIXER_SRC_MASTER = 0;
+/** @const */
+var MIXER_SRC_PCSPEAKER = 1;
+/** @const */
+var MIXER_SRC_DAC = 2;

--- a/src/externs.js
+++ b/src/externs.js
@@ -14,3 +14,56 @@ var exports = {};
 var define = {};
 var module = {};
 
+// New Web Audio API
+
+/**
+ * @constructor
+ * @extends {AudioNode}
+ * @param {Object=} options
+ */
+var AudioWorkletNode = function(context, name, options)
+{
+    this.port =
+    {
+        /**
+         * @param {Object} data
+         * @param {Object=} transfer
+         */
+        postMessage: function(data, transfer) {}
+    };
+};
+
+/**
+ * @constructor
+ */
+var AudioWorkletProcessor = function()
+{
+    this.port =
+    {
+        /**
+         * @param {Object} data
+         * @param {Object=} transfer
+         */
+        postMessage: function(data, transfer) {}
+    };
+}
+
+var AudioWorklet = function() {};
+
+AudioContext.prototype.audioWorklet =
+{
+    /** @return {Promise} */
+    addModule: function(file) {}
+};
+
+/**
+ * @param {string} name
+ * @param {function()} processor
+ */
+var registerProcessor = function(name, processor) {}
+
+/** @const */
+var currentTime = 0;
+
+/** @const */
+var sampleRate = 0;

--- a/src/lib.js
+++ b/src/lib.js
@@ -398,3 +398,36 @@ CircularQueue.prototype.set = function(new_data)
     this.data = new_data;
     this.index = 0;
 };
+
+function dump_file(ab, name)
+{
+    if(!(ab instanceof Array))
+    {
+        ab = [ab];
+    }
+
+    var blob = new Blob(ab);
+    download(blob, name);
+}
+
+function download(file_or_blob, name)
+{
+    var a = document.createElement("a");
+    a["download"] = name;
+    a.href = window.URL.createObjectURL(file_or_blob);
+    a.dataset["downloadurl"] = ["application/octet-stream", a["download"], a.href].join(":");
+
+    if(document.createEvent)
+    {
+        var ev = document.createEvent("MouseEvent");
+        ev.initMouseEvent("click", true, true, window,
+                          0, 0, 0, 0, 0, false, false, false, false, 0, null);
+        a.dispatchEvent(ev);
+    }
+    else
+    {
+        a.click();
+    }
+
+    window.URL.revokeObjectURL(a.href);
+}

--- a/src/pit.js
+++ b/src/pit.js
@@ -46,7 +46,14 @@ function PIT(cpu, bus)
     });
     cpu.io.register_write(0x61, this, function(data)
     {
-        this.bus.send("pcspeaker-enable", data & 1);
+        if(data & 1)
+        {
+            this.bus.send("pcspeaker-enable");
+        }
+        else
+        {
+            this.bus.send("pcspeaker-disable");
+        }
     });
 
     cpu.io.register_read(0x40, this, function() { return this.counter_read(0); });

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -879,8 +879,8 @@ register_dsp_command([0x38], 0);
 register_dsp_command([0x40], 1, function()
 {
     this.sampling_rate_change(
-        1000000
-        / (256 - this.write_buffer.shift())
+        256000000
+        / (65536 - this.write_buffer.shift())
         / this.get_channel_count()
     );
 });

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -231,9 +231,13 @@ function SB16(cpu, bus)
     {
         this.dac_handle_request();
     }, this);
+    bus.register("speaker-has-initialized", function()
+    {
+        this.mixer_reset();
+    }, this);
+    bus.send("speaker-confirm-initialized");
 
     this.dsp_reset();
-    this.mixer_reset();
 }
 
 //
@@ -1179,8 +1183,7 @@ SB16.prototype.mixer_reset = function()
     this.mixer_registers[0x46] = 8 << 4;
     this.mixer_registers[0x47] = 8 << 4;
 
-    // Ensure speaker is loaded during startup before sending bus messages.
-    setTimeout(() => this.mixer_full_update(), 0);
+    this.mixer_full_update();
 };
 
 SB16.prototype.mixer_full_update = function()

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1658,7 +1658,7 @@ register_fm_write(between(0xE0, 0xF5), function(bits, register, address)
 SB16.prototype.fm_update_waveforms = function()
 {
     // To be implemented.
-}
+};
 
 //
 // General behaviours

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -153,7 +153,7 @@ function SB16(cpu, bus)
     this.dma_waiting_transfer = false;
     this.dma_paused = false;
     this.sampling_rate = 22050;
-    bus.send("dac-tell-sampling-rate", this.sampling_rate);
+    bus.send("dac-tell-sampling-rate", [this.sampling_rate]);
     this.bytes_per_sample = 1;
 
     // DMA identification data.
@@ -1662,7 +1662,7 @@ SB16.prototype.fm_update_waveforms = function()
 SB16.prototype.sampling_rate_change = function(rate)
 {
     this.sampling_rate = rate;
-    this.bus.send("dac-tell-sampling-rate", rate);
+    this.bus.send("dac-tell-sampling-rate", [rate]);
 };
 
 SB16.prototype.get_channel_count = function()

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1320,27 +1320,27 @@ register_mixer_write(0x3B, function(data)
     this.bus.send("mixer-volume", ["pcspeaker", "both", (data >>> 6) * 6 - 18]);
 });
 
-// Output Mixer Switches.
-register_mixer_read(0x3C);
-register_mixer_write(0x3C, function(data)
-{
-    this.mixer_registers[0x3C] = data;
-
-    if(data & 0x01) this.bus.send("mixer-connect", ["mic", "both"]);
-    else this.bus.send("mixer-disconnect", ["mic", "both"]);
-
-    if(data & 0x02) this.bus.send("mixer-connect", ["cd", "right"]);
-    else this.bus.send("mixer-disconnect", ["cd", "right"]);
-
-    if(data & 0x04) this.bus.send("mixer-connect", ["cd", "left"]);
-    else this.bus.send("mixer-disconnect", ["cd", "left"]);
-
-    if(data & 0x08) this.bus.send("mixer-connect", ["line", "right"]);
-    else this.bus.send("mixer-disconnect", ["line", "right"]);
-
-    if(data & 0x10) this.bus.send("mixer-connect", ["line", "left"]);
-    else this.bus.send("mixer-disconnect", ["line", "left"]);
-});
+// Output Mixer Switches. TODO.
+//register_mixer_read(0x3C);
+//register_mixer_write(0x3C, function(data)
+//{
+//    this.mixer_registers[0x3C] = data;
+//
+//    if(data & 0x01) this.bus.send("mixer-connect", ["mic", "both"]);
+//    else this.bus.send("mixer-disconnect", ["mic", "both"]);
+//
+//    if(data & 0x02) this.bus.send("mixer-connect", ["cd", "right"]);
+//    else this.bus.send("mixer-disconnect", ["cd", "right"]);
+//
+//    if(data & 0x04) this.bus.send("mixer-connect", ["cd", "left"]);
+//    else this.bus.send("mixer-disconnect", ["cd", "left"]);
+//
+//    if(data & 0x08) this.bus.send("mixer-connect", ["line", "right"]);
+//    else this.bus.send("mixer-disconnect", ["line", "right"]);
+//
+//    if(data & 0x10) this.bus.send("mixer-connect", ["line", "left"]);
+//    else this.bus.send("mixer-disconnect", ["line", "left"]);
+//});
 
 // Input Mixer Left Switches. TODO.
 //register_mixer_read(0x3D);

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1388,7 +1388,8 @@ register_mixer_read(0x44);
 register_mixer_write(0x44, function(data)
 {
     this.mixer_registers[0x44] = data;
-    this.bus.send("mixer-treble-left", (data >>> 3) - (data >>> 7) - 14);
+    data >>>= 3;
+    this.bus.send("mixer-treble-left", data - (data < 16 ? 14 : 16));
 });
 
 // Treble Right.
@@ -1396,7 +1397,8 @@ register_mixer_read(0x45);
 register_mixer_write(0x45, function(data)
 {
     this.mixer_registers[0x45] = data;
-    this.bus.send("mixer-treble-right", (data >>> 3) - (data >>> 7) - 14);
+    data >>>= 3;
+    this.bus.send("mixer-treble-right", data - (data < 16 ? 14 : 16));
 });
 
 // Bass Left.
@@ -1404,7 +1406,8 @@ register_mixer_read(0x46);
 register_mixer_write(0x46, function(data)
 {
     this.mixer_registers[0x46] = data;
-    this.bus.send("mixer-bass-right", (data >>> 3) - (data >>> 7) - 14);
+    data >>>= 3;
+    this.bus.send("mixer-bass-right", data - (data < 16 ? 14 : 16));
 });
 
 // Bass Right.
@@ -1412,7 +1415,8 @@ register_mixer_read(0x47);
 register_mixer_write(0x47, function(data)
 {
     this.mixer_registers[0x47] = data;
-    this.bus.send("mixer-bass-right", (data >>> 3) - (data >>> 7) - 14);
+    data >>>= 3;
+    this.bus.send("mixer-bass-right", data - (data < 16 ? 14 : 16));
 });
 
 // IRQ Select.

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1243,6 +1243,11 @@ function register_mixer_legacy(address_old, address_new_left, address_new_right)
     };
 }
 
+/**
+ * @param {number} address
+ * @param {number} mixer_source
+ * @param {number} channel
+ */
 function register_mixer_volume(address, mixer_source, channel)
 {
     MIXER_READ_HANDLERS[address] = SB16.prototype.mixer_default_read;
@@ -1290,34 +1295,34 @@ register_mixer_legacy(0x28, 0x36, 0x37);
 register_mixer_legacy(0x2E, 0x38, 0x39);
 
 // Master Volume Left.
-register_mixer_volume(0x30, "master", "left");
+register_mixer_volume(0x30, MIXER_SRC_MASTER, MIXER_CHANNEL_LEFT);
 // Master Volume Right.
-register_mixer_volume(0x31, "master", "right");
+register_mixer_volume(0x31, MIXER_SRC_MASTER, MIXER_CHANNEL_RIGHT);
 // Voice Volume Left.
-register_mixer_volume(0x32, "dac", "left");
+register_mixer_volume(0x32, MIXER_SRC_DAC, MIXER_CHANNEL_LEFT);
 // Voice Volume Right.
-register_mixer_volume(0x33, "dac", "right");
+register_mixer_volume(0x33, MIXER_SRC_DAC, MIXER_CHANNEL_RIGHT);
 // MIDI Volume Left. TODO.
-//register_mixer_volume(0x34, "synth", "left");
+//register_mixer_volume(0x34, MIXER_SRC_SYNTH, MIXER_CHANNEL_LEFT);
 // MIDI Volume Right. TODO.
-//register_mixer_volume(0x35, "synth", "right);
+//register_mixer_volume(0x35, MIXER_SRC_SYNTH, MIXER_CHANNEL_RIGHT);
 // CD Volume Left. TODO.
-//register_mixer_volume(0x36, "cd", "left);
+//register_mixer_volume(0x36, MIXER_SRC_CD, MIXER_CHANNEL_LEFT);
 // CD Volume Right. TODO.
-//register_mixer_volume(0x37, "cd", "right);
+//register_mixer_volume(0x37, MIXER_SRC_CD, MIXER_CHANNEL_RIGHT);
 // Line Volume Left. TODO.
-//register_mixer_volume(0x38, "line", "left");
+//register_mixer_volume(0x38, MIXER_SRC_LINE, MIXER_CHANNEL_LEFT);
 // Line Volume Right. TODO.
-//register_mixer_volume(0x39, "line", "right");
+//register_mixer_volume(0x39, MIXER_SRC_LINE, MIXER_CHANNEL_RIGHT);
 // Mic Volume. TODO.
-//register_mixer_volume(0x3A, "mic", "both");
+//register_mixer_volume(0x3A, MIXER_SRC_MIC, MIXER_CHANNEL_BOTH);
 
 // PC Speaker Volume.
 register_mixer_read(0x3B);
 register_mixer_write(0x3B, function(data)
 {
     this.mixer_registers[0x3B] = data;
-    this.bus.send("mixer-volume", ["pcspeaker", "both", (data >>> 6) * 6 - 18]);
+    this.bus.send("mixer-volume", [MIXER_SRC_PCSPEAKER, MIXER_CHANNEL_BOTH, (data >>> 6) * 6 - 18]);
 });
 
 // Output Mixer Switches. TODO.
@@ -1326,20 +1331,20 @@ register_mixer_write(0x3B, function(data)
 //{
 //    this.mixer_registers[0x3C] = data;
 //
-//    if(data & 0x01) this.bus.send("mixer-connect", ["mic", "both"]);
-//    else this.bus.send("mixer-disconnect", ["mic", "both"]);
+//    if(data & 0x01) this.bus.send("mixer-connect", [MIXER_SRC_MIC, MIXER_CHANNEL_BOTH]);
+//    else this.bus.send("mixer-disconnect", [MIXER_SRC_MIC, MIXER_CHANNEL_BOTH]);
 //
-//    if(data & 0x02) this.bus.send("mixer-connect", ["cd", "right"]);
-//    else this.bus.send("mixer-disconnect", ["cd", "right"]);
+//    if(data & 0x02) this.bus.send("mixer-connect", [MIXER_SRC_CD, MIXER_CHANNEL_RIGHT]);
+//    else this.bus.send("mixer-disconnect", [MIXER_SRC_CD, MIXER_CHANNEL_RIGHT]);
 //
-//    if(data & 0x04) this.bus.send("mixer-connect", ["cd", "left"]);
-//    else this.bus.send("mixer-disconnect", ["cd", "left"]);
+//    if(data & 0x04) this.bus.send("mixer-connect", [MIXER_SRC_CD, MIXER_CHANNEL_LEFT]);
+//    else this.bus.send("mixer-disconnect", [MIXER_SRC_CD, MIXER_CHANNEL_LEFT]);
 //
-//    if(data & 0x08) this.bus.send("mixer-connect", ["line", "right"]);
-//    else this.bus.send("mixer-disconnect", ["line", "right"]);
+//    if(data & 0x08) this.bus.send("mixer-connect", [MIXER_SRC_LINE, MIXER_CHANNEL_RIGHT]);
+//    else this.bus.send("mixer-disconnect", [MIXER_SRC_LINE, MIXER_CHANNEL_RIGHT]);
 //
-//    if(data & 0x10) this.bus.send("mixer-connect", ["line", "left"]);
-//    else this.bus.send("mixer-disconnect", ["line", "left"]);
+//    if(data & 0x10) this.bus.send("mixer-connect", [MIXER_SRC_LINE, MIXER_CHANNEL_LEFT]);
+//    else this.bus.send("mixer-disconnect", [MIXER_SRC_LINE, MIXER_CHANNEL_LEFT]);
 //});
 
 // Input Mixer Left Switches. TODO.

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -863,9 +863,10 @@ register_dsp_command([0x38], 0);
 // Set digitized sound transfer Time Constant.
 register_dsp_command([0x40], 1, function()
 {
+    // Note: bTimeConstant = 256 * time constant
     this.sampling_rate_change(
-        256000000
-        / (65536 - this.write_buffer.shift())
+        1000000
+        / (256 - this.write_buffer.shift())
         / this.get_channel_count()
     );
 });

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1258,7 +1258,7 @@ function register_mixer_volume(address, mixer_source, channel)
             (data >>> 2) - 62
         ]);
     };
-};
+}
 
 // Reset.
 register_mixer_read(0x00, function()

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1706,7 +1706,10 @@ SB16.prototype.dma_transfer_start = function()
 
     this.dma_bytes_count = this.dma_sample_count * this.bytes_per_sample;
     this.dma_bytes_block = SB_DMA_BLOCK_SAMPLES * this.bytes_per_sample;
-    this.dma_bytes_block = Math.min(this.dma_bytes_count >> 2, this.dma_bytes_block);
+
+    // Ensure block size is small enough but not too small, and is divisible by 4
+    var max_bytes_block = Math.max(this.dma_bytes_count >> 2 & ~0x3, 32);
+    this.dma_bytes_block = Math.min(max_bytes_block, this.dma_bytes_block);
 
     // (2) Wait until channel is unmasked (if not already)
     this.dma_waiting_transfer = true;

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -153,7 +153,7 @@ function SB16(cpu, bus)
     this.dma_waiting_transfer = false;
     this.dma_paused = false;
     this.sampling_rate = 22050;
-    bus.send("dac-tell-sampling-rate", [this.sampling_rate]);
+    bus.send("dac-tell-sampling-rate", this.sampling_rate);
     this.bytes_per_sample = 1;
 
     // DMA identification data.
@@ -1667,7 +1667,7 @@ SB16.prototype.fm_update_waveforms = function()
 SB16.prototype.sampling_rate_change = function(rate)
 {
     this.sampling_rate = rate;
-    this.bus.send("dac-tell-sampling-rate", [rate]);
+    this.bus.send("dac-tell-sampling-rate", rate);
 };
 
 SB16.prototype.get_channel_count = function()


### PR DESCRIPTION
Good grief. I made another ginormous PR.

### The Good Parts™

- Implements the mixer chip.
- Fixes several SB16 bugs.
- Refactors Speaker Adapter into smaller components:
   - PCSpeaker - *responsible for the beeping sounds and [really awesome retro game music](https://drive.google.com/open?id=1ErJTdOOKkfNHhk4_Sq2gLosfcn1P4C5I)*.
   - DAC - *responsible for queuing and continuously playing audio data - such as Windows 98 sounds and Doom sound effects*.
   - Mixer - *responsible for mixing, panning, and boosting the audio from PCSpeaker and DAC*.

   - The mixer amplifies audio aliases from my naive sample rate converter (which sounds horrible), so I decided to fix the sample rate conversion using the following...

- Removes the deprecated `ScriptProcessorNode`-based DAC, and
- Reimplements the DAC component using `AudioBuffers` inspired by [this article](http://blog.mecheye.net/2017/09/i-dont-know-who-the-web-audio-api-is-designed-for/) by [Jasper St. Pierre](https://github.com/magcius). Fixes the following audio glitches:
   - Sometimes sounds with a short duration doesn't get played.
   - Sometimes an audio playback does not finish completely, and reappears in the beginning of the next audio playback.

- Using `AudioBuffers` allows us to use the browser's sample rate converter, so audio playback is now in-tune! Listen to [the Windows 98 startup sound comparisons](https://drive.google.com/open?id=13K08FdPGrE4xncbWCRZVc6orKmajhKNe). You'll notice that it's *much* better.

- Simplifies the two audio queuing loops into one queuing loop. This helps reducing latency as well.
```
Previously:
SB16 creates a reserve of audio data received from the DMA, and
Speaker creates a reserve audio data received from SB16
 _____         ______         _________
|     | .->-. |      | .->-. |         |
| DMA | |   | | SB16 | |   | | Speaker |
|_____| '-<-' |______| '-<-' |_________|

Now:
Only Speaker creates a reserve, and audio gets passed down the
pipeline almost instantly.
 _____         ______         _________
|     | .->---|      |--->-. |         |
| DMA | |     | SB16 |     | | Speaker |
|_____| '-<---|______|---<-' |_________|

```

- Implements a second DAC that uses Audio Worklets instead of Audio Buffers.
   - Audio Worklets is a new and exciting piece of API.
   - So far, only Chrome since Chrome 64 has implemented `AudioWorklets`, [under some flags:](https://developers.google.com/web/updates/2017/12/audio-worklet) 
`chrome --enable-blink-features=Worklet,AudioWorklet`
   - My worklet-based DAC implements a simple Lanczos Resampler to convert between sample rates.
   - Worklet allows latency to be reduced further.

### The Bad Parts

- In Firefox, the *buffer*-based DAC works well, but in Chrome, it suffers from a fair amount of pops and clicks.
   - The good news is that the *worklet*-based DAC eliminates all pops and clicks, and Chrome is the first to implement Audio Worklets. The catch is that Audio Worklets are not ready for public yet. I'll keep an eye on their progress.
   - Demo for [Chrome buffer-based](https://drive.google.com/open?id=1HqnvRrbY12GHuyFO03fSKVPbY9wtxmqm) (caution: irritating clicks),
   - Demo for [Firefox buffer-based](https://drive.google.com/open?id=1Me9pi3PzHz4Rohrgd7c1gRFYQTcgr4x0), and
   - Demo for [Chrome worklet-based](https://drive.google.com/open?id=12v3oH4fhMzDncZkXRMYSSewNio7azaAh)

- The buffer-based DAC allocates a new `AudioBuffer` and a new `AudioBufferSourceNode` for every block, and a new block is processed approximately every 2~20ms. These new objects eventually gets garbage collected. Allocation and GC in this hot loop doesn't *feel* right.

   - I went to see if keeping a pool of `AudioBuffers` was worth it, as it will reduce the amount of GC. Since the buffer size can vary, I've put them in a `Map` of arrays of `AudioBuffers` that get populated with new `AudioBuffers` on demand.
   - After some quick performance and memory profiling, keeping a pool of `AudioBuffers` doesn't seem to show any significant improvements, so I went back to creating new `AudioBuffers` each block.
   - Now I think about it, I might have profiled it incorrectly, and I might have chose a bad test situation for it.

- I'm not too sure where I should put the Audio Worklet code. The Audio Worklet is a bit like Web Workers in that you register them by supplying a URL of the worklet code to an API function, and the code gets executed in another thread (in this case, the Audio Rendering Thread).
   - At the moment, the worklet code lives inside an ES6 template string that gets converted into a `Blob` and from a `Blob` into an `ObjectURL`. This means that the worklet code doesn't get seen by the compiler. The worklet code can't be compiled because the Closure Compiler doesn't support outputting ES6 classes yet, which is needed to use the Audio Worklet APIs.

As always, I'm happy for any feedback, and I'm happy to rewrite any part of this PR. I also don't mind if you take a while to review this.

I think the state restore in this PR should be compatible with the state files before this PR. The only change is that some old states are no longer used and are ignored. However, new state files might confuse older v86. Should I increment the state version?