### PR TITLE
Add basic ANSI escape character control support

### DIFF
--- a/src/browser/serial.js
+++ b/src/browser/serial.js
@@ -53,7 +53,8 @@ function SerialAdapter(element, bus)
                 this.text = this.text.slice(0, -1);
                 this.update();
             }
-            else if(chr === "\x1b") {
+            else if(chr === "\x1b")
+            {
                this.control_mode = true;
                this.control_buffer = "";
             }

--- a/src/browser/serial.js
+++ b/src/browser/serial.js
@@ -46,7 +46,8 @@ function SerialAdapter(element, bus)
 
     this.show_char = function(chr)
     {
-        if(this.control_mode === false) {
+        if(this.control_mode === false)
+        {
             if(chr === "\x08")
             {
                 this.text = this.text.slice(0, -1);
@@ -76,9 +77,9 @@ function SerialAdapter(element, bus)
         {
             this.control_buffer += chr;
             var cmds = {
-                bksp: /$\[.J^/,
-                clr: /$\[.H\x1B\[.J^/,
-                invalid: /$*[^HJ]^/
+                bksp: /^\[.J$/,
+                clr: /^\[.H\x1B\[.J$/,
+                invalid: /^.*[^HJ]$/
             };
             if(cmds.bksp.test(this.control_buffer))
             {
@@ -93,6 +94,7 @@ function SerialAdapter(element, bus)
             }
             else if(cmds.invalid.test(this.control_buffer))
             {
+                this.text = this.text + "^" + this.control_buffer;
                 this.control_mode = false;
             }
         }

--- a/src/browser/serial.js
+++ b/src/browser/serial.js
@@ -77,9 +77,9 @@ function SerialAdapter(element, bus)
         {
             this.control_buffer += chr;
             var cmds = {
-                bksp: /^\[.J$/,
-                clr: /^\[.H\x1B\[.J$/,
-                invalid: /^.*[^HJ]$/
+                bksp: /^\[[0-2]?J$/,
+                clr: /^\[[0-9;]{0,5}H\x1b\[[0-2]?J$/,
+                invalid: /[hl=>0-2M-OmrA-Efg3-8KnRc8qy]/
             };
             if(cmds.bksp.test(this.control_buffer))
             {
@@ -92,7 +92,7 @@ function SerialAdapter(element, bus)
                 this.control_mode = false;
                 this.update();
             }
-            else if(cmds.invalid.test(this.control_buffer))
+            else if(cmds.invalid.test(this.control_buffer.substr(this.control_buffer.length - 1)))
             {
                 this.text = this.text + "^" + this.control_buffer;
                 this.control_mode = false;


### PR DESCRIPTION
Add support for readability in serial terminal

Commands:
^[J - normally clears screen to the right, simply ignored here
^[H^[J - home cursor, clear screen to the right - clears textarea