### PR TITLE
Add COM2 to COM4 and extend API

### DIFF
--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -828,6 +828,20 @@ V86Starter.prototype.serial0_send = function(data)
 };
 
 /**
+ * Send bytes to a serial port (to be received by the emulated PC).
+ *
+ * @param {Uint8Array} data
+ * @export
+ */
+V86Starter.prototype.serial_send_bytes = function(serial, data)
+{
+    for(var i = 0; i < data.length; i++)
+    {
+        this.bus.send("serial" + serial + "-input", data[i]);
+    }
+};
+
+/**
  * Write to a file in the 9p filesystem. Nothing happens if no filesystem has
  * been initialized. First argument to the callback is an error object if
  * something went wrong and null otherwise.

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -351,6 +351,10 @@ CPU.prototype.get_state = function()
 
     state[66] = this.reg_mmxs;
 
+    state[67] = this.devices.uart1;
+    state[68] = this.devices.uart2;
+    state[69] = this.devices.uart3;
+
     return state;
 };
 
@@ -426,6 +430,10 @@ CPU.prototype.set_state = function(state)
     this.tss_size_32 = state[65];
 
     this.reg_mmxs = state[66];
+
+    this.devices.uart1 = state[67];
+    this.devices.uart2 = state[68];
+    this.devices.uart3 = state[69];
 
     this.mem16 = new Uint16Array(this.mem8.buffer, this.mem8.byteOffset, this.mem8.length >> 1);
     this.mem32s = new Int32Array(this.mem8.buffer, this.mem8.byteOffset, this.mem8.length >> 2);
@@ -733,6 +741,9 @@ CPU.prototype.init = function(settings, device_bus)
         this.devices.ps2 = new PS2(this, device_bus);
 
         this.devices.uart = new UART(this, 0x3F8, device_bus);
+        this.devices.uart1 = new UART(this, 0x2F8, device_bus);
+        this.devices.uart2 = new UART(this, 0x3E8, device_bus);
+        this.devices.uart3 = new UART(this, 0x2E8, device_bus);
 
         this.devices.fdc = new FloppyController(this, settings.fda, settings.fdb);
 

--- a/src/uart.js
+++ b/src/uart.js
@@ -69,21 +69,29 @@ function UART(cpu, port, bus)
 
     this.current_line = [];
 
-    if(port === 0x3E8 || port === 0x3F8)
-    {
+    switch(port) {
+      case 0x3F8:
+        this.com = 0;
         this.irq = 4;
-    }
-    else if(port === 0x3E8 || port === 0x3E8)
-    {
+        break;
+      case 0x2F8:
+        this.com = 1;
         this.irq = 3;
-    }
-    else
-    {
+        break;
+      case 0x3E8:
+        this.com = 2;
+        this.irq = 4;
+        break;
+      case 0x2E8:
+        this.com = 3;
+        this.irq = 3;
+        break;
+      default:
         dbg_log("Invalid port: " + h(port), LOG_SERIAL);
         return;
     }
 
-    this.bus.register("serial0-input", function(data)
+    this.bus.register("serial" + this.com + "-input", function(data)
     {
         this.data_received(data);
     }, this);
@@ -310,6 +318,8 @@ UART.prototype.write_data = function(out_byte)
 
     this.ThrowInterrupt(UART_IIR_THRI);
 
+    this.bus.send("serial" + this.com + "-output-byte", out_byte);
+
     if(out_byte === 0xFF)
     {
         return;
@@ -317,15 +327,14 @@ UART.prototype.write_data = function(out_byte)
 
     var char = String.fromCharCode(out_byte);
 
-    this.bus.send("serial0-output-char", char);
+    this.bus.send("serial" + this.com + "-output-char", char);
 
     this.current_line.push(out_byte);
 
     if(char === "\n")
     {
         dbg_log("SERIAL: " + String.fromCharCode.apply("", this.current_line).trimRight());
-        this.bus.send("serial0-output-line", String.fromCharCode.apply("", this.current_line));
+        this.bus.send("serial" + this.com + "-output-line", String.fromCharCode.apply("", this.current_line));
         this.current_line = [];
     }
 };
-


### PR DESCRIPTION
Add COM2 to COM4 and extend API to allow receiving output bytes and sending input bytes to them.

This change allows me to run a DOS terminal emulator software for the German Bildschirmtext system in the browser, talking to an emulated server over a WebSocket connection. See https://github.com/stblassitude/v86-btx

I'm happy to update this patch with changes you deem necessary, for example, I've not added any tests or documentation.