### PR TITLE
Use Python 3 for webserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ clean:
 	$(MAKE) -C $(NASM_TEST_DIR) clean
 
 run:
-	python2 -m SimpleHTTPServer 2> /dev/null
+	python3 -m http.server 2> /dev/null
 	#sleep 1
 	#$(BROWSER) http://localhost:8000/index.html &
 


### PR DESCRIPTION
Use Python 3 for webserver because Python 2 is very old and it will be unsupported in 2020.