### PR TITLE
Use ES intrinsics for mul / imul, bsr / bsf

### DIFF
--- a/src/arith.js
+++ b/src/arith.js
@@ -275,53 +275,20 @@ CPU.prototype.imul_reg16 = function(operand1, operand2)
     return result;
 }
 
-CPU.prototype.do_mul32 = function(a, b)
-{
-    var a00 = a & 0xFFFF;
-    var a16 = a >>> 16;
-    var b00 = b & 0xFFFF;
-    var b16 = b >>> 16;
-    var low_result = a00 * b00;
-    var mid = (low_result >>> 16) + (a16 * b00 | 0) | 0;
-    var high_result = mid >>> 16;
-    mid = (mid & 0xFFFF) + (a00 * b16 | 0) | 0;
-    this.mul32_result[0] = (mid << 16) | low_result & 0xFFFF;
-    this.mul32_result[1] = ((mid >>> 16) + (a16 * b16 | 0) | 0) + high_result | 0;
-    return this.mul32_result;
-};
-
-CPU.prototype.do_imul32 = function(a, b)
-{
-    var is_neg = false;
-    if(a < 0) {
-        is_neg = true;
-        a = -a | 0;
-    }
-    if(b < 0) {
-        is_neg = !is_neg;
-        b = -b | 0;
-    }
-    var result = this.do_mul32(a, b);
-    if(is_neg) {
-        result[0] = -result[0] | 0;
-        result[1] = ~result[1] + !result[0] | 0;
-    }
-    return result;
-}
-
 CPU.prototype.mul32 = function(source_operand)
 {
     var dest_operand = this.reg32s[reg_eax];
 
-    var result = this.do_mul32(dest_operand, source_operand);
+    var lo = v86util.imul(dest_operand, source_operand);
+    var hi = v86util.imul_high(dest_operand >>> 0, source_operand >>> 0);
 
-    this.reg32s[reg_eax] = result[0];
-    this.reg32s[reg_edx] = result[1];
+    this.reg32s[reg_eax] = lo;
+    this.reg32s[reg_edx] = hi;
 
-    this.last_result = result[0];
+    this.last_result = lo;
     this.last_op_size = OPSIZE_32;
 
-    if(result[1] === 0)
+    if(hi === 0)
     {
         this.flags &= ~1 & ~flag_overflow;
     }
@@ -341,15 +308,16 @@ CPU.prototype.imul32 = function(source_operand)
 
     var dest_operand = this.reg32s[reg_eax];
 
-    var result = this.do_imul32(dest_operand, source_operand);
+    var lo = v86util.imul(dest_operand, source_operand);
+    var hi = v86util.imul_high(dest_operand, source_operand);
 
-    this.reg32s[reg_eax] = result[0];
-    this.reg32s[reg_edx] = result[1];
+    this.reg32s[reg_eax] = lo;
+    this.reg32s[reg_edx] = hi;
 
-    this.last_result = result[0];
+    this.last_result = lo;
     this.last_op_size = OPSIZE_32;
 
-    if(result[1] === (result[0] >> 31))
+    if(hi === (lo >> 31))
     {
         this.flags &= ~1 & ~flag_overflow;
     }
@@ -373,12 +341,13 @@ CPU.prototype.imul_reg32 = function(operand1, operand2)
     dbg_assert(operand1 < 0x80000000 && operand1 >= -0x80000000);
     dbg_assert(operand2 < 0x80000000 && operand2 >= -0x80000000);
 
-    var result = this.do_imul32(operand1, operand2);
+    var lo = v86util.imul(operand1, operand2);
+    var hi = Math.floor((operand1 | 0) * (operand2 | 0) / 0x100000000);
 
-    this.last_result = result[0];
+    this.last_result = lo;
     this.last_op_size = OPSIZE_32;
 
-    if(result[1] === (result[0] >> 31))
+    if(hi === (lo >> 31))
     {
         this.flags &= ~1 & ~flag_overflow;
     }
@@ -388,7 +357,7 @@ CPU.prototype.imul_reg32 = function(operand1, operand2)
     }
     this.flags_changed = flags_all & ~1 & ~flag_overflow;
 
-    return result[0];
+    return lo;
 
     //console.log(operand + " * " + source_operand);
     //console.log("= " + this.reg32[reg]);

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -181,7 +181,6 @@ function CPU(bus)
     /** @type {number} */
     this.last_result = 0;
 
-    this.mul32_result = new Int32Array(2);
     this.div32_result = new Float64Array(2);
 
     this.tsc_offset = 0;

--- a/src/instructions.js
+++ b/src/instructions.js
@@ -4841,24 +4841,24 @@ t[0xF4] = cpu => {
 
         let i = (cpu.modrm_byte >> 3 & 7) << 2;
 
-        let result = cpu.do_mul32(destination[0] , source[0]);
-        cpu.reg_xmm32s[i] = result[0];
-        cpu.reg_xmm32s[i + 1] = result[1];
+        let d = destination[0];
+        let s = source[0];
+        cpu.reg_xmm32s[i] = v86util.imul(d, s);
+        cpu.reg_xmm32s[i + 1] = v86util.imul_high(d >>> 0, s >>> 0);
 
-        result = cpu.do_mul32(destination[2] , source[2]);
-        cpu.reg_xmm32s[i + 2] = result[0];
-        cpu.reg_xmm32s[i + 3] = result[1];
+        d = destination[2];
+        s = source[2];
+        cpu.reg_xmm32s[i + 2] = v86util.imul(d, s);
+        cpu.reg_xmm32s[i + 3] = v86util.imul_high(d >>> 0, s >>> 0);
     }
     else
     {
         // pmuludq mm1, mm2/m64
         dbg_assert((cpu.prefixes & (PREFIX_MASK_REP | PREFIX_MASK_OPSIZE)) == 0);
-        let source64s = cpu.read_mmx_mem64s();
-        let destination_low = cpu.reg_mmxs[2 * (cpu.modrm_byte >> 3 & 7)];
+        let s = cpu.read_mmx_mem64s()[0];
+        let d = cpu.reg_mmxs[2 * (cpu.modrm_byte >> 3 & 7)];
 
-        let result = cpu.do_mul32(destination_low,source64s[0])
-
-        cpu.write_mmx64s(result[0], result[1]);
+        cpu.write_mmx64s(v86util.imul(d, s), v86util.imul_high(d >>> 0, s >>> 0));
     }
 };
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -131,6 +131,38 @@ SyncBuffer.prototype.get_buffer = function(fn)
 
 (function()
 {
+    var clz32 = Math.clz32;
+    if(typeof clz32 === "function" && clz32(0) === 32 &&
+       clz32(0x12345) === 15 && clz32(-1) === 0)
+    {
+        /**
+         * calculate the integer logarithm base 2 of a byte
+         * @param {number} x
+         * @return {number}
+         */
+        v86util.int_log2_byte = function(x)
+        {
+            dbg_assert(x > 0);
+            dbg_assert(x < 0x100);
+
+            return 31 - clz32(x);
+        }
+
+        /**
+         * calculate the integer logarithm base 2
+         * @param {number} x
+         * @return {number}
+         */
+        v86util.int_log2 = function(x)
+        {
+            dbg_assert(x > 0);
+
+            return 31 - clz32(x);
+        }
+
+        return;
+    }
+
     var int_log2_table = new Int8Array(256);
 
     for(var i = 0, b = -2; i < 256; i++)
@@ -192,6 +224,21 @@ SyncBuffer.prototype.get_buffer = function(fn)
         }
     };
 })();
+
+
+v86util.imul =
+    typeof Math.imul === "function" &&
+    Math.imul(0x01234567, 0x89abcdef) === -0x36b1b9d7 ? Math.imul : function(a, b) {
+        b |= 0;
+        return (a & 0x003fffff) * b + ((a & 0xffc00000) * b | 0) | 0;
+    };
+
+
+v86util.imul_high = function(a, b) {
+    dbg_assert(-0x80000000 <= a && a <= 0xffffffff);
+    dbg_assert(-0x80000000 <= b && b <= 0xffffffff);
+    return Math.floor(a * b / 0x100000000);
+};
 
 
 /**


### PR DESCRIPTION
For integer multiplication, direct product of two 32-bit integers in
double precision FP arithmetic yields its higher 53 bits which are
sufficient for higher half of the product, while the lower half may be
computed with `Math.imul()`. A polyfill is provided for < IE 10.

For `floor(log2(n))` where `n` is a 32-bit integer, `31 - Math.clz32(n)`
is an accurate substitute for `v86util.int_log2` and preserves
`int_log2(0) = -1` (should it ever occur).