### PR TITLE
Fix state-restore mixer volume bug and Safari hang bug

### DIFF
--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -962,8 +962,17 @@ SpeakerBufferSourceDAC.prototype.queue = function(data)
         // Allocating new AudioBuffer every block
         // - Memory profiles show insignificant improvements if recycling old buffers.
         buffer = this.audio_context.createBuffer(2, sample_count, this.sampling_rate);
-        buffer.copyToChannel(data[0], 0);
-        buffer.copyToChannel(data[1], 1);
+        if(buffer.copyToChannel)
+        {
+            buffer.copyToChannel(data[0], 0);
+            buffer.copyToChannel(data[1], 1);
+        }
+        else
+        {
+            // Safari doesn't support copyToChannel yet. See #286
+            buffer.getChannelData(0).set(data[0]);
+            buffer.getChannelData(1).set(data[1]);
+        }
     }
 
     var source = this.audio_context.createBufferSource();

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -82,6 +82,7 @@ var DSP_COMMAND_SIZES = new Uint8Array(256);
 var DSP_COMMAND_HANDLERS = [];
 var MIXER_READ_HANDLERS = [];
 var MIXER_WRITE_HANDLERS = [];
+var MIXER_REGISTER_IS_LEGACY = new Uint8Array(256);
 var FM_HANDLERS = [];
 
 
@@ -1191,6 +1192,12 @@ SB16.prototype.mixer_full_update = function()
     // Start at 1. Don't re-reset.
     for(var i = 1; i < this.mixer_registers.length; i++)
     {
+        if(MIXER_REGISTER_IS_LEGACY[i])
+        {
+            // Legacy registers are actually mapped to other register locations. Update
+            // using the new registers rather than the legacy registers.
+            continue;
+        }
         this.mixer_write(i, this.mixer_registers[i]);
     }
 };
@@ -1224,6 +1231,8 @@ function register_mixer_write(address, handler)
 // Legacy registers map each nibble to the last 4 bits of the new registers
 function register_mixer_legacy(address_old, address_new_left, address_new_right)
 {
+    MIXER_REGISTER_IS_LEGACY[address_old] = 1;
+
     /** @this {SB16} */
     MIXER_READ_HANDLERS[address_old] = function()
     {


### PR DESCRIPTION
Fixes #286 for Safari.
Tested on my friend's iPad and at least it doesn't hang when trying to play audio.

This PR also fixes a bug where restoring emulator state loads the wrong volume values, causing the Windows 98 demo to be silent until the volume is manually readjusted in the guest OS.