### PR TITLE
Add other adapters to destroy method

### DIFF
--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -459,7 +459,11 @@ V86Starter.prototype.stop = function()
  */
 V86Starter.prototype.destroy = function()
 {
+    this.network_adapter.destroy();
     this.keyboard_adapter.destroy();
+    this.mouse_adapter.destroy();
+    this.screen_adapter.destroy();
+    this.serial_adapter.destroy();
 };
 
 /**


### PR DESCRIPTION
I've added other adapters to the `destroy` method. I haven't added `SpeakerAdapter` because it doesn't have the `destroy` method. I also didn't add `ModemAdapter` because it is not used.

This is related to #283. However, this issue shouldn't be closed because of https://github.com/copy/v86/issues/283#issuecomment-496960821.