### PR TITLE
Temporary solution for hardcoded className

### DIFF
--- a/src/browser/keyboard.js
+++ b/src/browser/keyboard.js
@@ -299,7 +299,7 @@ function KeyboardAdapter(bus)
         if(e.target)
         {
             // className shouldn't be hardcoded here
-            return e.target.className === "phone_keyboard" ||
+            return e.target.className.includes("phone_keyboard") ||
                 (e.target.nodeName !== "INPUT" && e.target.nodeName !== "TEXTAREA");
         }
         else

--- a/src/browser/keyboard.js
+++ b/src/browser/keyboard.js
@@ -299,7 +299,7 @@ function KeyboardAdapter(bus)
         if(e.target)
         {
             // className shouldn't be hardcoded here
-            return e.target.className.includes("phone_keyboard") ||
+            return e.target.classList.contains("phone_keyboard") ||
                 (e.target.nodeName !== "INPUT" && e.target.nodeName !== "TEXTAREA");
         }
         else


### PR DESCRIPTION
This is a temporary solution for hardcoded `className` in keyboard handler.

---

Previously, `className` have to only contain `phone_keyboard` and nothing else. So if the element contained also other classes, it won't be handled.

It now checks if `className` includes `phone_keyboard` so element can now also use other classes.

---

A complete solution would be to completely drop `className` check and instead check if the element is a child element of screen container. This would enable handling all elements in the screen container.

This can be done with `screen_element.contains(e.target)`. The reason why I didn't use this in this PR is that `screen_element` isn't available in the keyboard adapter. To fix this, adapters need to be modified to accept and use `V86Starter` options which contain screen element.