### PR TITLE
Fix tabulators from escaping CLI (#217)

### DIFF
--- a/examples/lua.html
+++ b/examples/lua.html
@@ -86,6 +86,7 @@ window.onload = function()
 // Implement bash string escaping.
 function bashEscape(arg)
 {
+    arg = arg.replace(/\t+/g, "");
     return "'" + arg.replace(/'+/g, function (val) {
         return "'" + val.replace(/'/g, "\\'") + "'";
     }) + "'";


### PR DESCRIPTION
Previously, tabulators (\t) would escape the CLI input into `lua -e` and cause unknown output. See #217 

To remedy, the input must be escaped from tabs before escaping special characters into quotes. 

Tested inputs with correct output:
```
	k = 1
	x = 0

while k < 1000 do
    x = x + 1 / (k * k)
    k = k + 2
end

print(math.sqrt(x*8))

	function factorial(n)
   	if n == 0 then
        return 1
    else
    		return n * factorial(n - 1)
    	end
end

print("factorial(10):", factorial(10))
```
`	` (\t)
`		` (\t\t)
```
	print("1")
		
print("2")
```