### PR TITLE
Don't assert on unknown MSR, raise #GP0 instead.

### DIFF
--- a/src/instructions.js
+++ b/src/instructions.js
@@ -2324,7 +2324,8 @@ t[0x30] = cpu => {
             break;
 
         default:
-            dbg_assert(false, "Unknown msr: " + h(index >>> 0, 8));
+            dbg_log("Unknown msr: " + h(index >>> 0, 8));
+            cpu.trigger_gp(0);
     }
 };
 
@@ -2421,7 +2422,8 @@ t[0x32] = cpu => {
             break;
 
         default:
-            dbg_assert(false, "Unknown msr: " + h(index >>> 0, 8));
+            dbg_log("Unknown msr: " + h(index >>> 0, 8));
+            cpu.trigger_gp(0);
     }
 
     cpu.reg32s[reg_eax] = low;


### PR DESCRIPTION
Some builds of the kernel probe for MSRs and cactch the GP0 during boot.
This allows some kernels that to boot that previously would not.