### PR TITLE
use specific version of closure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,10 +152,10 @@ update_version:
 
 
 $(CLOSURE):
-	wget -P $(CLOSURE_DIR) https://dl.google.com/closure-compiler/compiler-latest.zip
-	unzip -d closure-compiler $(CLOSURE_DIR)/compiler-latest.zip \*.jar
+	wget -P $(CLOSURE_DIR) https://dl.google.com/closure-compiler/compiler-20190709.zip
+	unzip -d closure-compiler $(CLOSURE_DIR)/compiler-20190709.zip \*.jar
 	mv $(CLOSURE_DIR)/*.jar $(CLOSURE)
-	rm $(CLOSURE_DIR)/compiler-latest.zip
+	rm $(CLOSURE_DIR)/compiler-20190709.zip
 
 tests: build/libv86.js
 	./tests/full/run.js


### PR DESCRIPTION
Using an older version of closure to allow builds to succeed instead of using lastest version of closure