### PR TITLE
An attempt to make v86 ignore endbr32/endbr64 instructions

### DIFF
--- a/src/instructions.js
+++ b/src/instructions.js
@@ -1931,7 +1931,11 @@ t[0x1B] = cpu => { cpu.unimplemented_sse(); };
 t[0x1C] = cpu => { cpu.unimplemented_sse(); };
 t[0x1D] = cpu => { cpu.unimplemented_sse(); };
 // endbr32/endbr64
-t[0x1E] = cpu => { cpu.read_imm8(); };
+t[0x1E] = cpu => { cpu.read_modrm_byte()
+    // multi-byte nop
+    if(cpu.modrm_byte < 0xC0)
+        cpu.modrm_resolve(cpu.modrm_byte);
+};
 t[0x1F] = cpu => { cpu.read_modrm_byte()
     // multi-byte nop
     if(cpu.modrm_byte < 0xC0)

--- a/src/instructions.js
+++ b/src/instructions.js
@@ -1930,7 +1930,8 @@ t[0x1A] = cpu => { cpu.unimplemented_sse(); };
 t[0x1B] = cpu => { cpu.unimplemented_sse(); };
 t[0x1C] = cpu => { cpu.unimplemented_sse(); };
 t[0x1D] = cpu => { cpu.unimplemented_sse(); };
-t[0x1E] = cpu => { cpu.unimplemented_sse(); };
+// endbr32/endbr64
+t[0x1E] = cpu => { cpu.read_imm8(); };
 t[0x1F] = cpu => { cpu.read_modrm_byte()
     // multi-byte nop
     if(cpu.modrm_byte < 0xC0)


### PR DESCRIPTION
The instruction encodings are:

`F3 0F 1E FA` for `ENDBR64` and `F3 0F 1E FB` for `ENDBR32` respectively. 

Therefore. this PR should handle these instructions by:
- Not raising an assert, and
- Gracefully ignore the extra byte

This obviously does not handle all the CET instructions for https://github.com/copy/v86/issues/343, but it deals with the most obvious case.