### PR TITLE
Exposing the option to specify the second hard disk as a slave

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -57,8 +57,13 @@
             </tr>
 
             <tr>
-                <td>Hard drive disk image</td>
-                <td><input type="file" id="hd_image"><br></td>
+                <td>Master Hard drive disk image</td>
+                <td><input type="file" id="hda_image"><br></td>
+            </tr>
+
+            <tr>
+                <td>Slave Hard drive disk image</td>
+                <td><input type="file" id="hdb_image"><br></td>
             </tr>
 
             <tr>

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -151,11 +151,18 @@
                 settings.cdrom = { buffer: cd_file };
             }
 
-            var hd_file = $("hd_image").files[0];
-            if(hd_file)
+            var hda_file = $("hda_image").files[0];
+            if(hda_file)
             {
-                last_file = hd_file;
-                settings.hda = { buffer: hd_file };
+                last_file = hda_file;
+                settings.hda = { buffer: hda_file };
+            }
+
+            var hdb_file = $("hdb_image").files[0];
+            if(hdb_file)
+            {
+                last_file = hdb_file;
+                settings.hdb = { buffer: hdb_file };
             }
 
             if($("multiboot_image"))
@@ -704,6 +711,7 @@
 
             "fda": settings.fda,
             "hda": settings.hda,
+            "hdb": settings.hdb,
             "cdrom": settings.cdrom,
 
             "multiboot": settings.multiboot,

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -760,17 +760,12 @@ CPU.prototype.init = function(settings, device_bus)
 
         if(settings.hda)
         {
-            this.devices.hda = new IDEDevice(this, settings.hda, false, ide_device_count++, device_bus);
+            this.devices.hda = new IDEDevice(this, settings.hda, settings.hdb, false, ide_device_count++, device_bus);
         }
 
         if(settings.cdrom)
         {
-            this.devices.cdrom = new IDEDevice(this, settings.cdrom, true, ide_device_count++, device_bus);
-        }
-
-        if(settings.hdb)
-        {
-            this.devices.hdb = new IDEDevice(this, settings.hdb, false, ide_device_count++, device_bus);
+            this.devices.cdrom = new IDEDevice(this, settings.cdrom, undefined, true, ide_device_count++, device_bus);
         }
 
         this.devices.pit = new PIT(this, device_bus);

--- a/src/ide.js
+++ b/src/ide.js
@@ -44,10 +44,10 @@ var HD_SECTOR_SIZE = 512;
  * @param {number} nr
  * @param {BusConnector} bus
  * */
-function IDEDevice(cpu, buffer, is_cd, nr, bus)
+function IDEDevice(cpu, masterBuffer, slaveBuffer, is_cd, nr, bus)
 {
-    this.master = new IDEInterface(this, cpu, buffer, is_cd, nr, 0, bus);
-    this.slave = new IDEInterface(this, cpu, undefined, false, nr, 1, bus);
+    this.master = new IDEInterface(this, cpu, masterBuffer, is_cd, nr, 0, bus);
+    this.slave = new IDEInterface(this, cpu, slaveBuffer, is_cd, nr, 1, bus);
 
     this.current_interface = this.master;
 


### PR DESCRIPTION
Fix #353 
This allows a second hard disk to be connected as a slave.