### PR TITLE
Don't release ACPI builds, also include v86_all.js 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build v86
-        run: make build/libv86.js useacpi=true
+        run: make build/libv86.js
 
       - name: Release to GitHub
         uses: marvinpinto/action-automatic-releases@latest


### PR DESCRIPTION
It doesn't make sense to release ACPI builds when they aren't the default, also, release `v86_all.js` so people can use the included `index.html` file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/copy/v86/367)
<!-- Reviewable:end -->
