### PR TITLE
Enable APIC without ACPI

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -715,10 +715,11 @@ CPU.prototype.init = function(settings, device_bus)
         this.devices.pic = new PIC(this);
         this.devices.pci = new PCI(this);
 
-        if(ENABLE_ACPI)
+        this.devices.ioapic = new IOAPIC(this);
+        this.devices.apic = new APIC(this);
+        
+		if(ENABLE_ACPI)
         {
-            this.devices.ioapic = new IOAPIC(this);
-            this.devices.apic = new APIC(this);
             this.devices.acpi = new ACPI(this);
         }
 
@@ -1274,8 +1275,9 @@ CPU.prototype.run_hardware_timers = function(now)
     if(ENABLE_ACPI)
     {
         this.devices.acpi.timer(now);
-        this.devices.apic.timer(now);
     }
+        
+		this.devices.apic.timer(now);
 };
 
 CPU.prototype.clear_prefixes = function()
@@ -3841,7 +3843,7 @@ CPU.prototype.cpuid = function()
                     1 << 8 | 1 << 11 | 1 << 13 | 1 << 15 | // cx8, sep, pge, cmov
                     0 << 23 | 0 << 24 | 0 << 25 | 0 << 26;   // mmx, fxsr, sse, sse2
 
-            if(ENABLE_ACPI && this.apic_enabled)
+            if(this.apic_enabled)
             {
                 edx |= 1 << 9; // apic
             }

--- a/src/instructions.js
+++ b/src/instructions.js
@@ -2390,15 +2390,12 @@ t[0x32] = cpu => {
             break;
 
         case IA32_APIC_BASE_MSR:
-            if(ENABLE_ACPI)
-            {
                 low = APIC_ADDRESS;
 
                 if(cpu.apic_enabled)
                 {
                     low |= IA32_APIC_BASE_EN;
                 }
-            }
             break;
 
         case IA32_BIOS_SIGN_ID:


### PR DESCRIPTION
Related to https://github.com/copy/v86/issues/332
ACPI and APIC are not the same and don't need to be bundled together. 
Now 9front reaches this point (requiring input I don't understand, but seemilying working) 
![image](https://user-images.githubusercontent.com/17304943/92320796-10fa4400-efd9-11ea-9840-28bce10fde25.png)
V.S. the behavior described in the issue
![image](https://user-images.githubusercontent.com/17304943/92320814-3edf8880-efd9-11ea-94a2-e184f573e654.png)
