### PR TITLE
Ne2k Driver Fixes to Support Running in Windows!

### DIFF
--- a/src/ne2k.js
+++ b/src/ne2k.js
@@ -125,9 +125,10 @@ function Ne2k(cpu, bus)
         this.memory[i << 1] = this.memory[i << 1 | 1] = mac[i];
     }
 
-    for(var i = 28; i < 32; i++) {
-      this.memory[i] = 0x57;
-    }
+    // the PROM signature of 0x57, 0x57 is also doubled
+    // resulting in setting the 4 bytes at the end, 28, 29, 30 and 31 to 0x57
+    this.memory[14 << 1] = this.memory[14 << 1 | 1] = 0x57;
+    this.memory[15 << 1] = this.memory[15 << 1 | 1] = 0x57;
 
     dbg_log("Mac: " + h(mac[0], 2) + ":" +
                       h(mac[1], 2) + ":" +


### PR DESCRIPTION
I believe this fix should enable the use of the network card under Windows! I've tested it in Win98 so far.

The fix is includes two components, both based simply on comparing to the logic in the working qemu implementation.

1. The initial buffer setup appears to be incorrect. The 0x57 byte should be set on bytes 28 through 31.
This is simply by comparing to what qemu does in: https://github.com/qemu/qemu/blob/master/hw/net/ne2000.c#L130
I think this is the crux of the fix!

2. The write logic is also slightly off. In qemu's implementation, the command register is always set, and then bitwise op is applied if condition is met: https://github.com/qemu/qemu/blob/master/hw/net/ne2000.c#L281
Also changed an | to and & to match.

I am no expert on this card, basically just compared to what QEMU was doing here to see if I could find any difference, and this is what I found.

I am not sure if 2. is necessary, maybe just 1. is enough to get this to work, but I have been testing with both.

Note: The card is detected as a `Realtek RTL8029(AS) PIC Ethernet NIC` not as NE2000 Compatible, the same as in QEMU. Initially installed the drivers in QEMU and was able to reinstall in v86 with this fix.!

Here's a screenshot of running IE6 in Windows98 with the provided network. (Yes, you can still access msn.com with IE6!)
<img width="1376" alt="Screen Shot 2020-11-29 at 2 00 27 PM" src="https://user-images.githubusercontent.com/1015759/100555154-79f6fe00-324e-11eb-84c7-e5d6fc1093ca.png">

