### PR TITLE
Replaced the scan code for Home with the correct scan code.

### DIFF
--- a/src/browser/keyboard.js
+++ b/src/browser/keyboard.js
@@ -213,7 +213,7 @@ function KeyboardAdapter(bus)
         "NumpadDivide": 0xe035,
         //"PrintScreen": 0x0063,
         "AltRight": 0xe038,
-        "Home": 0xe04f,
+        "Home": 0xe047,
         "ArrowUp": 0xe048,
         "PageUp": 0xe049,
         "ArrowLeft": 0xe04b,


### PR DESCRIPTION
Before the change, the scan code for Home was the same as for End. I've replaced the lower byte with a correct one (0x47) as per [this page](https://www.fountainware.com/EXPL/bios_key_codes.htm).