### PR TITLE
Network Customization, Improved Save/Restore, misc fixes

### DIFF
--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -742,10 +742,8 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
     var worklet_code_end = worklet_string.lastIndexOf("}");
     var worklet_code = worklet_string.substring(worklet_code_start, worklet_code_end);
 
-    if(DEBUG)
-    {
-        worklet_code = "var DEBUG = true;\n" + worklet_code;
-    }
+    // set DEBUG in worker based on current DEBUG setting
+    worklet_code = "var DEBUG = " + (DEBUG ? "true" : "false") + ";\n" + worklet_code;
 
     var worklet_blob = new Blob([worklet_code], { type: "application/javascript" });
     var worklet_url = URL.createObjectURL(worklet_blob);

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -125,7 +125,15 @@ function V86Starter(options)
     settings.uart2 = options["uart2"] || false;
     settings.uart3 = options["uart3"] || false;
 
-    if(options["network_relay_url"])
+    // optional fixed mac address
+    settings.network_mac = null;
+
+    if(options["network_adapter"])
+    {
+        this.network_adapter = options["network_adapter"](adapter_bus);
+        settings.enable_ne2k = true;
+
+    } else if(options["network_relay_url"])
     {
         this.network_adapter = new NetworkAdapter(options["network_relay_url"], adapter_bus);
         settings.enable_ne2k = true;
@@ -157,6 +165,10 @@ function V86Starter(options)
     if(!options["disable_speaker"])
     {
         this.speaker_adapter = new SpeakerAdapter(adapter_bus);
+    }
+    if(options["initial_state"])
+    {
+        settings.initial_state = options.initial_state;
     }
 
     // ugly, but required for closure compiler compilation

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -772,7 +772,7 @@ CPU.prototype.init = function(settings, device_bus)
 
         if(settings.enable_ne2k)
         {
-            this.devices.net = new Ne2k(this, device_bus);
+            this.devices.net = new Ne2k(this, device_bus, settings.network_mac);
         }
 
         if(settings.fs9p)

--- a/src/ne2k.js
+++ b/src/ne2k.js
@@ -56,8 +56,9 @@
  * @constructor
  * @param {CPU} cpu
  * @param {BusConnector} bus
+ * @param {Array} mac_address - Fixed mac address (optional)
  */
-function Ne2k(cpu, bus)
+function Ne2k(cpu, bus, mac_address)
 {
     /** @const @type {CPU} */
     this.cpu = cpu;
@@ -113,7 +114,7 @@ function Ne2k(cpu, bus)
     this.tsr = 1;
 
     // mac address
-    var mac = [
+    var mac = mac_address ? mac_address.slice(0, 6) : [
         0x00, 0x22, 0x15,
         Math.random() * 255 | 0,
         Math.random() * 255 | 0,
@@ -523,6 +524,14 @@ Ne2k.prototype.get_state = function()
     state[9] = this.curpg;
     state[10] = this.boundary;
 
+    state[11] = this.pstop;
+    state[12] = this.rxcr;
+    state[13] = this.txcr;
+    state[14] = this.tsr;
+
+
+    state = state.concat(Array.from(this.memory));
+
     return state;
 };
 
@@ -539,6 +548,13 @@ Ne2k.prototype.set_state = function(state)
     this.pstart = state[8];
     this.curpg = state[9];
     this.boundary = state[10];
+
+    this.pstop = state[11];
+    this.rxcr = state[12];
+    this.txcr = state[13];
+    this.tsr = state[14];
+
+    this.memory = new Uint8Array(state.slice(15));
 };
 
 Ne2k.prototype.do_interrupt = function(ir_mask)


### PR DESCRIPTION
Includes a few fixes for networking as well as a couple additional fixes.

The networking exposes support for a custom `network_adapter` which can be used in place of the `network_relay_url` as well as an optional fixed mac address with `network_mac`.

networking:
- support for custom 'network_adapter' instead of 'network_relay_url' for using custom network adapter
- network state save/restore: save additional registers, full memory buffer (32k)
- support fixed mac address with 'network_mac' init option

sound init: to avoid undefined var, set 'DEBUG = false' in sound worker if DEBUG is false
starter: ensure 'initial_state' is added to settings from V86Starter constructor