### PR TITLE
workaround to support i686 clang

### DIFF
--- a/tools/rust-lld-wrapper
+++ b/tools/rust-lld-wrapper
@@ -43,7 +43,11 @@ def find_rust_lld():
     bin_path = path.dirname(rustc_path)
     rust_lld_path = path.join(bin_path, "../lib/rustlib/x86_64-unknown-linux-gnu/bin/rust-lld")
 
-    assert path.isfile(rust_lld_path)
+    if (path.isfile(rust_lld_path)):
+        return rust_lld_path
+    else:
+        rust_lld_path = path.join(bin_path, "../lib/rustlib/i686-unknown-linux-gnu/bin/rust-lld")
+        assert path.isfile(rust_lld_path)      
     return rust_lld_path
 
 main()


### PR DESCRIPTION
    workaround to support i686 + clang 5.0+
    
    clang version 5.0.0 (http://root.cern.ch/git/clang.git 354b25b5d915ff3b1946479ad07f3f2768ea1621) (http://root.cern.ch/git/llvm.git 9c749361ba8c2d400b83d8cc5c544287465b7489)
    Target: i686-pc-linux-gnu
    Thread model: posix
