### PR TITLE
Enable building WASM on MacOS

### DIFF
--- a/tools/rust-lld-wrapper
+++ b/tools/rust-lld-wrapper
@@ -5,6 +5,7 @@
 
 import sys
 import subprocess
+import re
 from os import path
 
 def main():
@@ -33,6 +34,16 @@ def main():
 
     result.check_returncode()
 
+def find_host_triplet():
+    rustc = subprocess.run(['rustc', '--version', '--verbose'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    rustc.check_returncode()
+
+    rustc_details = rustc.stdout.decode('utf8')
+    host = re.search(r'host: (.*)', rustc_details)
+    if host is None:
+        raise ValueError('unexpected rustc output')
+    return host.group(1)
+
 def find_rust_lld():
     which = subprocess.run(["rustup", "which", "rustc"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     which.check_returncode()
@@ -41,12 +52,13 @@ def find_rust_lld():
     assert path.basename(rustc_path) == "rustc"
 
     bin_path = path.dirname(rustc_path)
-    rust_lld_path = path.join(bin_path, "../lib/rustlib/x86_64-unknown-linux-gnu/bin/rust-lld")
+    triplet = find_host_triplet()
+    rust_lld_path = path.join(bin_path, "../lib/rustlib", triplet, "bin/rust-lld")
 
     if path.isfile(rust_lld_path):
         return rust_lld_path
 
-    rust_lld_path = path.join(bin_path, "../lib/rustlib/i686-unknown-linux-gnu/bin/rust-lld")
+    rust_lld_path = path.join(bin_path, "../lib/rustlib", triplet, "bin/rust-lld")
     assert path.isfile(rust_lld_path)
 
     return rust_lld_path

--- a/tools/rust-lld-wrapper
+++ b/tools/rust-lld-wrapper
@@ -35,13 +35,13 @@ def main():
     result.check_returncode()
 
 def find_host_triplet():
-    rustc = subprocess.run(['rustc', '--version', '--verbose'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    rustc = subprocess.run(["rustc", "--version", "--verbose"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     rustc.check_returncode()
 
-    rustc_details = rustc.stdout.decode('utf8')
-    host = re.search(r'host: (.*)', rustc_details)
+    rustc_details = rustc.stdout.decode("utf8")
+    host = re.search(r"host: (.*)", rustc_details)
     if host is None:
-        raise ValueError('unexpected rustc output')
+        raise ValueError("unexpected rustc output")
     return host.group(1)
 
 def find_rust_lld():
@@ -54,9 +54,6 @@ def find_rust_lld():
     bin_path = path.dirname(rustc_path)
     triplet = find_host_triplet()
     rust_lld_path = path.join(bin_path, "../lib/rustlib", triplet, "bin/rust-lld")
-
-    if path.isfile(rust_lld_path):
-        return rust_lld_path
 
     rust_lld_path = path.join(bin_path, "../lib/rustlib", triplet, "bin/rust-lld")
     assert path.isfile(rust_lld_path)


### PR DESCRIPTION
The README encourages using the dockerfile to build the application. But ARM laptops cannot run x86 containers, so I have to try installing dependencies with brew and running the makefile from my terminal.

This fails an assertion when the helper script to find the rust-lld executable (it _is_ very strange that rustup does not add it to the path) is unable to find it. This is because the host system triplet is part of the executable path, and in the script this triplet is hard-coded as x86 linux.

This PR simply queries `rustc` to determine the host triplet, and uses substitutes the hard-coded triplet with the queried triplet. Once I do this, the build passes on MacOS.