### PR TITLE
avoid ending jit_run_interpreted in the middle of a basic block

### DIFF
--- a/src/rust/cpu/cpu.rs
+++ b/src/rust/cpu/cpu.rs
@@ -2846,7 +2846,7 @@ unsafe fn jit_run_interpreted(phys_addr: u32) {
 
     while !jit_block_boundary
         && Page::page_of(*previous_ip as u32) == Page::page_of(*instruction_pointer as u32)
-        && i < INTERPRETER_ITERATION_LIMIT
+        && (i < INTERPRETER_ITERATION_LIMIT || (*previous_ip as u32) <  (*instruction_pointer as u32))
     {
         *previous_ip = *instruction_pointer;
         let opcode = return_on_pagefault!(read_imm8());


### PR DESCRIPTION
Right now jit_run_interpreted may exit on any instruction causing a new entry point to be created at the exit location. This patch avoids that by waiting for a backward jump to exit the function. This in turn avoids unnecessary entry points and unnecessary BB splitting. 