### PR TITLE
[WIP] Avoid computing flags even lazy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ src/rust/gen/analyzer0f.rs
 src/rust/gen/jit.rs
 src/rust/gen/jit0f.rs
 bios/seabios
+.vscode/

--- a/gen/generate_analyzer.js
+++ b/gen/generate_analyzer.js
@@ -217,6 +217,23 @@ function gen_instruction_body_after_fixed_g(encoding, size)
     const imm_read = gen_read_imm_call(encoding, size);
     const instruction_postfix = [];
 
+    if (encoding.modified_flags==undefined  && encoding.tested_flags==undefined) {
+        instruction_postfix.push("analysis.has_flags_info = false;");
+        instruction_postfix.push("analysis.tested_flags = 0;");
+        instruction_postfix.push("analysis.modified_flags = 0;");
+    }
+    else {
+        instruction_postfix.push("analysis.has_flags_info = true;");       
+        if (encoding.tested_flags)
+            instruction_postfix.push("analysis.tested_flags = " + encoding.tested_flags + ";");                    
+        else
+            instruction_postfix.push("analysis.tested_flags = 0;");
+        if (encoding.modified_flags)
+            instruction_postfix.push("analysis.modified_flags = " + encoding.modified_flags + ";");
+        else
+            instruction_postfix.push("analysis.modified_flags = 0;");
+    }
+
     if(encoding.custom_sti) {
         instruction_postfix.push("analysis.ty = ::analysis::AnalysisType::STI;");
     }

--- a/gen/x86_table.js
+++ b/gen/x86_table.js
@@ -48,119 +48,127 @@ const sf = 1 << 7;
 // os: the instruction behaves differently depending on the operand size
 // fixed_g: the reg field of the modrm byte selects an instruction
 // skip: skip automatically generated tests (nasmtests)
-// mask_flags: flags bits to mask in generated tests
+// mask_flags : flags bits to mask in generated tests
 // prefix: is a prefix instruction
 // imm8, imm8s, imm16, imm1632, immaddr, extra_imm8, extra_imm16: one or two immediate bytes follows the instruction
 // custom: will callback jit to generate custom code
 // block_boundary: may change eip in a way not handled by the jit
 // no_next_instruction: jit will stop analysing after instruction (e.g., unconditional jump, ret)
+// tested_flags, modified_flags : these will be used by jit to optimize flags calculation includig not 
+// storing data to lazy compute flags when that data will be overwritten by a subsequent instruction
+// data to lazy compute flags will always be available at the end of block
+// all instructions that do not have at least one of these fileds will force presence of data for lazy flag
+// computation from that point on in the BB
+// in case it is known that a instruction does not test or modify flags it should have at least one of the 
+// fields present and set to 0
+
 const encodings = [
-    { opcode: 0x00, custom: 1, e: 1, },
-    { opcode: 0x01, custom: 1, os: 1, e: 1, },
-    { opcode: 0x02, custom: 1, e: 1, },
-    { opcode: 0x03, custom: 1, os: 1, e: 1, },
+    { opcode: 0x00, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x01, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x02, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x03, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
 
-    { opcode: 0x08, custom: 1, e: 1, },
-    { opcode: 0x09, custom: 1, os: 1, e: 1, },
-    { opcode: 0x0A, custom: 1, e: 1, },
-    { opcode: 0x0B, custom: 1, os: 1, e: 1, },
+    { opcode: 0x08, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x09, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x0A, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x0B, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
 
-    { opcode: 0x10, custom: 1, e: 1, },
-    { opcode: 0x11, custom: 1, os: 1, e: 1, },
-    { opcode: 0x12, custom: 1, e: 1, },
-    { opcode: 0x13, custom: 1, os: 1, e: 1, },
+    { opcode: 0x10, custom: 1, e: 1, tested_flags : cf,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x11, custom: 1, os: 1, e: 1, tested_flags : cf,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x12, custom: 1, e: 1, tested_flags : cf,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x13, custom: 1, os: 1, e: 1, tested_flags : cf,  modified_flags :of | sf | zf | af | pf | cf , },
 
-    { opcode: 0x18, custom: 1, e: 1, },
-    { opcode: 0x19, custom: 1, os: 1, e: 1, },
-    { opcode: 0x1A, custom: 1, e: 1, },
-    { opcode: 0x1B, custom: 1, os: 1, e: 1, },
+    { opcode: 0x18, custom: 1, e: 1, tested_flags : cf,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x19, custom: 1, os: 1, e: 1, tested_flags : cf,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x1A, custom: 1, e: 1, tested_flags : cf,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x1B, custom: 1, os: 1, e: 1, tested_flags : cf,  modified_flags :of | sf | zf | af | pf | cf , },
 
-    { opcode: 0x20, custom: 1, e: 1, },
-    { opcode: 0x21, custom: 1, os: 1, e: 1, },
-    { opcode: 0x22, custom: 1, e: 1, },
-    { opcode: 0x23, custom: 1, os: 1, e: 1, },
+    { opcode: 0x20, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x21, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x22, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x23, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
 
-    { opcode: 0x28, custom: 1, e: 1, },
-    { opcode: 0x29, custom: 1, os: 1, e: 1, },
-    { opcode: 0x2A, custom: 1, e: 1, },
-    { opcode: 0x2B, custom: 1, os: 1, e: 1, },
+    { opcode: 0x28, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x29, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x2A, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x2B, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
 
-    { opcode: 0x30, custom: 1, e: 1, },
-    { opcode: 0x31, custom: 1, os: 1, e: 1, },
-    { opcode: 0x32, custom: 1, e: 1, },
-    { opcode: 0x33, custom: 1, os: 1, e: 1, },
+    { opcode: 0x30, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x31, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x32, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x33, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
 
-    { opcode: 0x38, custom: 1, e: 1, },
-    { opcode: 0x39, custom: 1, os: 1, e: 1, },
-    { opcode: 0x3A, custom: 1, e: 1, },
-    { opcode: 0x3B, custom: 1, os: 1, e: 1, },
+    { opcode: 0x38, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x39, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x3A, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x3B, custom: 1, os: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
 
-    { opcode: 0x06, os: 1, custom: 1 },
-    { opcode: 0x07, os: 1, skip: 1, block_boundary: 1, }, // pop es: block_boundary since it uses non-raising cpu exceptions
-    { opcode: 0x0E, os: 1, custom: 1 },
+    { opcode: 0x06, os: 1, custom: 1 , tested_flags: 0 , },
+    { opcode: 0x07, os: 1, skip: 1, block_boundary: 1, tested_flags: 0 , }, // pop es: block_boundary since it uses non-raising cpu exceptions
+    { opcode: 0x0E, os: 1, custom: 1 , tested_flags: 0 , },
     { opcode: 0x0F, os: 1, prefix: 1, },
-    { opcode: 0x16, os: 1, custom: 1 },
-    { opcode: 0x17, block_boundary: 1, os: 1, skip: 1, }, // pop ss
-    { opcode: 0x1E, os: 1, custom: 1 },
-    { opcode: 0x1F, block_boundary: 1, os: 1, skip: 1, }, // pop ds
+    { opcode: 0x16, os: 1, custom: 1 , tested_flags: 0 , },
+    { opcode: 0x17, block_boundary: 1, os: 1, skip: 1, tested_flags: 0 , }, // pop ss
+    { opcode: 0x1E, os: 1, custom: 1 , tested_flags: 0 , },
+    { opcode: 0x1F, block_boundary: 1, os: 1, skip: 1, tested_flags: 0 , }, // pop ds
     { opcode: 0x26, prefix: 1, },
-    { opcode: 0x27, mask_flags: of, },
+    { opcode: 0x27, mask_flags: of, tested_flags : af | cf,  modified_flags :of | sf | zf | af | pf | cf , },
     { opcode: 0x2E, prefix: 1, },
-    { opcode: 0x2F, mask_flags: of, },
+    { opcode: 0x2F, mask_flags: of, tested_flags : af | cf,  modified_flags :of | sf | zf | af | pf | cf , },
     { opcode: 0x36, prefix: 1, },
-    { opcode: 0x37, mask_flags: of | sf | pf | zf, },
+    { opcode: 0x37, mask_flags: of | sf | pf | zf, tested_flags : af,  modified_flags :of | sf | zf | af | pf | cf , },
     { opcode: 0x3E, prefix: 1, },
-    { opcode: 0x3F, mask_flags: of | sf | pf | zf, },
+    { opcode: 0x3F, mask_flags: of | sf | pf | zf, tested_flags : af,  modified_flags :of | sf | zf | af | pf | cf , },
 
-    { opcode: 0x40, os: 1, custom: 1 },
-    { opcode: 0x41, os: 1, custom: 1 },
-    { opcode: 0x42, os: 1, custom: 1 },
-    { opcode: 0x43, os: 1, custom: 1 },
-    { opcode: 0x44, os: 1, custom: 1 },
-    { opcode: 0x45, os: 1, custom: 1 },
-    { opcode: 0x46, os: 1, custom: 1 },
-    { opcode: 0x47, os: 1, custom: 1 },
+    { opcode: 0x40, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x41, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x42, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x43, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x44, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x45, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x46, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x47, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
 
-    { opcode: 0x48, os: 1, custom: 1 },
-    { opcode: 0x49, os: 1, custom: 1 },
-    { opcode: 0x4A, os: 1, custom: 1 },
-    { opcode: 0x4B, os: 1, custom: 1 },
-    { opcode: 0x4C, os: 1, custom: 1 },
-    { opcode: 0x4D, os: 1, custom: 1 },
-    { opcode: 0x4E, os: 1, custom: 1 },
-    { opcode: 0x4F, os: 1, custom: 1 },
+    { opcode: 0x48, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x49, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x4A, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x4B, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x4C, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x4D, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x4E, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
+    { opcode: 0x4F, os: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf , },
 
-    { opcode: 0x50, custom: 1, os: 1 },
-    { opcode: 0x51, custom: 1, os: 1 },
-    { opcode: 0x52, custom: 1, os: 1 },
-    { opcode: 0x53, custom: 1, os: 1 },
-    { opcode: 0x54, custom: 1, os: 1 },
-    { opcode: 0x55, custom: 1, os: 1 },
-    { opcode: 0x56, custom: 1, os: 1 },
-    { opcode: 0x57, custom: 1, os: 1 },
+    { opcode: 0x50, custom: 1, os: 1 , tested_flags: 0 , },
+    { opcode: 0x51, custom: 1, os: 1 , tested_flags: 0 , },
+    { opcode: 0x52, custom: 1, os: 1 , tested_flags: 0 , },
+    { opcode: 0x53, custom: 1, os: 1 , tested_flags: 0 , },
+    { opcode: 0x54, custom: 1, os: 1 , tested_flags: 0 , },
+    { opcode: 0x55, custom: 1, os: 1 , tested_flags: 0 , },
+    { opcode: 0x56, custom: 1, os: 1 , tested_flags: 0 , },
+    { opcode: 0x57, custom: 1, os: 1 , tested_flags: 0 , },
 
-    { opcode: 0x58, custom: 1, os: 1, },
-    { opcode: 0x59, custom: 1, os: 1, },
-    { opcode: 0x5A, custom: 1, os: 1, },
-    { opcode: 0x5B, custom: 1, os: 1, },
-    { opcode: 0x5C, custom: 1, os: 1, },
-    { opcode: 0x5D, custom: 1, os: 1, },
+    { opcode: 0x58, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x59, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x5A, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x5B, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x5C, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x5D, custom: 1, os: 1, tested_flags: 0 , },
     { opcode: 0x5E, custom: 1, os: 1, },
-    { opcode: 0x5F, custom: 1, os: 1, },
+    { opcode: 0x5F, custom: 1, os: 1, tested_flags: 0 , },
 
     { opcode: 0x60, os: 1, },
     { opcode: 0x61, os: 1, },
     { opcode: 0x62, e: 1, skip: 1, },
-    { opcode: 0x63, e: 1, block_boundary: 1, }, // arpl
+    { opcode: 0x63, e: 1, block_boundary: 1, tested_flags: 0 , }, // arpl
     { opcode: 0x64, prefix: 1, },
     { opcode: 0x65, prefix: 1, },
     { opcode: 0x66, prefix: 1, },
     { opcode: 0x67, prefix: 1, },
 
-    { opcode: 0x68, custom: 1, os: 1, imm1632: 1 },
-    { opcode: 0x69, os: 1, e: 1, custom: 1, imm1632: 1, mask_flags: af, }, // zf?
-    { opcode: 0x6A, custom: 1, os: 1, imm8s: 1 },
-    { opcode: 0x6B, os: 1, e: 1, custom: 1, imm8s: 1, mask_flags: af, }, // zf?
+    { opcode: 0x68, custom: 1, os: 1, imm1632: 1 , tested_flags: 0 , },
+    { opcode: 0x69, os: 1, e: 1, custom: 1, imm1632: 1, mask_flags: af,  modified_flags :of | sf | zf | af | pf | cf , }, // zf?
+    { opcode: 0x6A, custom: 1, os: 1, imm8s: 1 , tested_flags: 0 , },
+    { opcode: 0x6B, os: 1, e: 1, custom: 1, imm8s: 1, mask_flags: af,  modified_flags :of | sf | zf | af | pf | cf , }, // zf?
 
     { opcode: 0x6C, block_boundary: 1, custom: 1, is_string: 1, skip: 1, },          // ins
     { opcode: 0xF26C, block_boundary: 1, custom: 1, is_string: 1, skip: 1, },
@@ -176,42 +184,42 @@ const encodings = [
     { opcode: 0xF26F, block_boundary: 1, custom: 1, is_string: 1, os: 1, skip: 1, },
     { opcode: 0xF36F, block_boundary: 1, custom: 1, is_string: 1, os: 1, skip: 1, },
 
-    { opcode: 0x84, custom: 1, e: 1, },
-    { opcode: 0x85, custom: 1, e: 1, os: 1, },
-    { opcode: 0x86, custom: 1, e: 1, },
-    { opcode: 0x87, custom: 1, os: 1, e: 1, },
-    { opcode: 0x88, custom: 1, e: 1, },
-    { opcode: 0x89, custom: 1, os: 1, e: 1, },
-    { opcode: 0x8A, custom: 1, e: 1, },
-    { opcode: 0x8B, custom: 1, os: 1, e: 1, },
+    { opcode: 0x84, custom: 1, e: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x85, custom: 1, e: 1, os: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x86, custom: 1, e: 1, tested_flags: 0 , },
+    { opcode: 0x87, custom: 1, os: 1, e: 1, tested_flags: 0 , },
+    { opcode: 0x88, custom: 1, e: 1, tested_flags: 0 , },
+    { opcode: 0x89, custom: 1, os: 1, e: 1, tested_flags: 0 , },
+    { opcode: 0x8A, custom: 1, e: 1, tested_flags: 0 , },
+    { opcode: 0x8B, custom: 1, os: 1, e: 1, tested_flags: 0 , },
 
-    { opcode: 0x8C, os: 1, e: 1, custom: 1 }, // mov reg, sreg
-    { opcode: 0x8D, reg_ud: 1, os: 1, e: 1, custom_modrm_resolve: 1, custom: 1, }, // lea
-    { opcode: 0x8E, block_boundary: 1, e: 1, skip: 1, }, // mov sreg
-    { opcode: 0x8F, os: 1, e: 1, fixed_g: 0, custom_modrm_resolve: 1, custom: 1, block_boundary: 1, }, // pop r/m
+    { opcode: 0x8C, os: 1, e: 1, custom: 1 , tested_flags: 0 , }, // mov reg, sreg
+    { opcode: 0x8D, reg_ud: 1, os: 1, e: 1, custom_modrm_resolve: 1, custom: 1, tested_flags: 0 , }, // lea
+    { opcode: 0x8E, block_boundary: 1, e: 1, skip: 1, tested_flags: 0 , }, // mov sreg
+    { opcode: 0x8F, os: 1, e: 1, fixed_g: 0, custom_modrm_resolve: 1, custom: 1, block_boundary: 1, tested_flags: 0 , }, // pop r/m
 
-    { opcode: 0x90, custom: 1, },
-    { opcode: 0x91, custom: 1, os: 1, },
-    { opcode: 0x92, custom: 1, os: 1, },
-    { opcode: 0x93, custom: 1, os: 1, },
-    { opcode: 0x94, custom: 1, os: 1, },
-    { opcode: 0x95, custom: 1, os: 1, },
-    { opcode: 0x96, custom: 1, os: 1, },
-    { opcode: 0x97, custom: 1, os: 1, },
+    { opcode: 0x90, custom: 1, tested_flags: 0 , },
+    { opcode: 0x91, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x92, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x93, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x94, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x95, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x96, custom: 1, os: 1, tested_flags: 0 , },
+    { opcode: 0x97, custom: 1, os: 1, tested_flags: 0 , },
 
-    { opcode: 0x98, os: 1, custom: 1 },
-    { opcode: 0x99, os: 1, custom: 1 },
+    { opcode: 0x98, os: 1, custom: 1 , tested_flags: 0 , },
+    { opcode: 0x99, os: 1, custom: 1 , tested_flags: 0 , },
     { opcode: 0x9A, os: 1, imm1632: 1, extra_imm16: 1, skip: 1, block_boundary: 1, }, // callf
     { opcode: 0x9B, block_boundary: 1, skip: 1, }, // fwait: block_boundary since it uses non-raising cpu exceptions
     { opcode: 0x9C, os: 1, custom: 1 },
     { opcode: 0x9D, os: 1, skip: 1, custom: 1, },
-    { opcode: 0x9E, custom: 1 },
-    { opcode: 0x9F, custom: 1 },
+    { opcode: 0x9E, custom: 1 ,  modified_flags :sf | zf | af | pf | cf , },
+    { opcode: 0x9F, custom: 1 , tested_flags : sf | zf | af | pf | cf , },
 
-    { opcode: 0xA0, custom: 1, immaddr: 1 },
-    { opcode: 0xA1, custom: 1, os: 1, immaddr: 1 },
-    { opcode: 0xA2, custom: 1, immaddr: 1 },
-    { opcode: 0xA3, custom: 1, os: 1, immaddr: 1 },
+    { opcode: 0xA0, custom: 1, immaddr: 1 , tested_flags: 0 , },
+    { opcode: 0xA1, custom: 1, os: 1, immaddr: 1 , tested_flags: 0 , },
+    { opcode: 0xA2, custom: 1, immaddr: 1 , tested_flags: 0 , },
+    { opcode: 0xA3, custom: 1, os: 1, immaddr: 1 , tested_flags: 0 , },
 
     // string instructions aren't jumps, but they modify eip due to how they're implemented
     { opcode: 0xA4, block_boundary: 0, custom: 1, is_string: 1, },
@@ -221,15 +229,15 @@ const encodings = [
     { opcode: 0xF2A5, block_boundary: 1, custom: 1, is_string: 1, os: 1, },
     { opcode: 0xF3A5, block_boundary: 1, custom: 1, is_string: 1, os: 1, },
 
-    { opcode: 0xA6, block_boundary: 1, custom: 1, is_string: 1, },
+    { opcode: 0xA6, block_boundary: 1, custom: 1, is_string: 1,  modified_flags :of | sf | zf | af | pf | cf , },
     { opcode: 0xF2A6, block_boundary: 1, custom: 1, is_string: 1, },
     { opcode: 0xF3A6, block_boundary: 1, custom: 1, is_string: 1, },
-    { opcode: 0xA7, block_boundary: 1, custom: 1, is_string: 1, os: 1, },
+    { opcode: 0xA7, block_boundary: 1, custom: 1, is_string: 1, os: 1,  modified_flags :of | sf | zf | af | pf | cf , },
     { opcode: 0xF2A7, block_boundary: 1, custom: 1, is_string: 1, os: 1, },
     { opcode: 0xF3A7, block_boundary: 1, custom: 1, is_string: 1, os: 1, },
 
-    { opcode: 0xA8, custom: 1, imm8: 1, },
-    { opcode: 0xA9, custom: 1, os: 1, imm1632: 1, },
+    { opcode: 0xA8, custom: 1, imm8: 1,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0xA9, custom: 1, os: 1, imm1632: 1,  modified_flags :of | sf | zf | af | pf | cf , },
 
     { opcode: 0xAA, block_boundary: 0, custom: 1, is_string: 1, },
     { opcode: 0xF2AA, block_boundary: 1, custom: 1, is_string: 1, },
@@ -245,38 +253,38 @@ const encodings = [
     { opcode: 0xF2AD, block_boundary: 1, custom: 1, is_string: 1, os: 1, },
     { opcode: 0xF3AD, block_boundary: 1, custom: 1, is_string: 1, os: 1, },
 
-    { opcode: 0xAE, block_boundary: 0, custom: 1, is_string: 1, },
+    { opcode: 0xAE, block_boundary: 0, custom: 1, is_string: 1,  modified_flags :of | sf | zf | af | pf | cf , },
     { opcode: 0xF2AE, block_boundary: 1, custom: 1, is_string: 1, },
     { opcode: 0xF3AE, block_boundary: 1, custom: 1, is_string: 1, },
-    { opcode: 0xAF, block_boundary: 0, custom: 1, is_string: 1, os: 1, },
+    { opcode: 0xAF, block_boundary: 0, custom: 1, is_string: 1, os: 1,  modified_flags :of | sf | zf | af | pf | cf , },
     { opcode: 0xF2AF, block_boundary: 1, custom: 1, is_string: 1, os: 1, },
     { opcode: 0xF3AF, block_boundary: 1, custom: 1, is_string: 1, os: 1, },
 
     { opcode: 0xC2, custom: 1, block_boundary: 1, no_next_instruction: 1, os: 1, absolute_jump: 1, imm16: 1, skip: 1, }, // ret
     { opcode: 0xC3, custom: 1, block_boundary: 1, no_next_instruction: 1, os: 1, absolute_jump: 1, skip: 1, },
 
-    { opcode: 0xC4, block_boundary: 1, os: 1, e: 1, skip: 1, }, // les
-    { opcode: 0xC5, block_boundary: 1, os: 1, e: 1, skip: 1, }, // lds
+    { opcode: 0xC4, block_boundary: 1, os: 1, e: 1, skip: 1, tested_flags: 0 , }, // les
+    { opcode: 0xC5, block_boundary: 1, os: 1, e: 1, skip: 1, tested_flags: 0 , }, // lds
 
-    { opcode: 0xC6, custom: 1, e: 1, fixed_g: 0, imm8: 1 },
-    { opcode: 0xC7, custom: 1, os: 1, e: 1, fixed_g: 0, imm1632: 1 },
+    { opcode: 0xC6, custom: 1, e: 1, fixed_g: 0, imm8: 1 , tested_flags: 0 , },
+    { opcode: 0xC7, custom: 1, os: 1, e: 1, fixed_g: 0, imm1632: 1 , tested_flags: 0 , },
 
     // XXX: Temporary block boundary
-    { opcode: 0xC8, os: 1, imm16: 1, extra_imm8: 1, block_boundary: 1, }, // enter
-    { opcode: 0xC9, custom: 1, os: 1, skip: 1 }, // leave
+    { opcode: 0xC8, os: 1, imm16: 1, extra_imm8: 1, block_boundary: 1, tested_flags: 0 , }, // enter
+    { opcode: 0xC9, custom: 1, os: 1, skip: 1 , tested_flags: 0 , }, // leave
 
     { opcode: 0xCA, block_boundary: 1, no_next_instruction: 1, os: 1, imm16: 1, skip: 1, }, // retf
     { opcode: 0xCB, block_boundary: 1, no_next_instruction: 1, os: 1, skip: 1, },
     { opcode: 0xCC, block_boundary: 1, skip: 1, }, // int
     { opcode: 0xCD, block_boundary: 1, skip: 1, imm8: 1, },
-    { opcode: 0xCE, block_boundary: 1, skip: 1, },
+    { opcode: 0xCE, block_boundary: 1, skip: 1, tested_flags : of , },
     { opcode: 0xCF, block_boundary: 1, no_next_instruction: 1, os: 1, skip: 1, }, // iret
 
-    { opcode: 0xD4, imm8: 1, block_boundary: 1, }, // aam, may trigger #de
-    { opcode: 0xD5, imm8: 1, mask_flags: of | cf | af, },
-    { opcode: 0xD6, },
+    { opcode: 0xD4, imm8: 1, block_boundary: 1,  modified_flags :of | sf | zf | af | pf | cf , }, // aam, may trigger #de
+    { opcode: 0xD5, imm8: 1, mask_flags: of | cf | af,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0xD6, tested_flags : cf , },
 
-    { opcode: 0xD7, skip: 1, custom: 1, },
+    { opcode: 0xD7, skip: 1, custom: 1, tested_flags: 0 , },
 
     { opcode: 0xD8, e: 1, fixed_g: 0, custom: 1, is_fpu: 1, task_switch_test: 1, },
     { opcode: 0xD8, e: 1, fixed_g: 1, custom: 1, is_fpu: 1, task_switch_test: 1, },
@@ -351,8 +359,8 @@ const encodings = [
     { opcode: 0xDF, e: 1, fixed_g: 7, custom: 1, is_fpu: 1, task_switch_test: 1, },
 
     // loop, jcxz, etc.
-    { opcode: 0xE0, os: 1, imm8s: 1, no_block_boundary_in_interpreted: 1, skip: 1, block_boundary: 1, jump_offset_imm: 1, custom: 1, conditional_jump: 1, },
-    { opcode: 0xE1, os: 1, imm8s: 1, no_block_boundary_in_interpreted: 1, skip: 1, block_boundary: 1, jump_offset_imm: 1, custom: 1, conditional_jump: 1, },
+    { opcode: 0xE0, os: 1, imm8s: 1, no_block_boundary_in_interpreted: 1, skip: 1, block_boundary: 1, jump_offset_imm: 1, custom: 1, conditional_jump: 1, tested_flags : zf , },
+    { opcode: 0xE1, os: 1, imm8s: 1, no_block_boundary_in_interpreted: 1, skip: 1, block_boundary: 1, jump_offset_imm: 1, custom: 1, conditional_jump: 1, tested_flags : zf , },
     { opcode: 0xE2, os: 1, imm8s: 1, no_block_boundary_in_interpreted: 1, skip: 1, block_boundary: 1, jump_offset_imm: 1, custom: 1, conditional_jump: 1, },
     { opcode: 0xE3, os: 1, imm8s: 1, no_block_boundary_in_interpreted: 1, skip: 1, block_boundary: 1, jump_offset_imm: 1, custom: 1, conditional_jump: 1, },
 
@@ -377,43 +385,43 @@ const encodings = [
     { opcode: 0xF2, prefix: 1, },
     { opcode: 0xF3, prefix: 1, },
     { opcode: 0xF4, block_boundary: 1, no_next_instruction: 1, skip: 1, }, // hlt
-    { opcode: 0xF5, },
+    { opcode: 0xF5, tested_flags : cf,  modified_flags :cf , },
 
-    { opcode: 0xF6, e: 1, fixed_g: 0, imm8: 1, custom: 1 },
-    { opcode: 0xF6, e: 1, fixed_g: 1, imm8: 1, custom: 1 },
-    { opcode: 0xF6, e: 1, fixed_g: 2, },
-    { opcode: 0xF6, e: 1, fixed_g: 3, },
-    { opcode: 0xF6, e: 1, fixed_g: 4, mask_flags: af | zf, },
-    { opcode: 0xF6, e: 1, fixed_g: 5, mask_flags: af | zf, },
-    { opcode: 0xF6, e: 1, fixed_g: 6, block_boundary: 1, }, // div/idiv: Not a block boundary, but doesn't use control flow exceptions
-    { opcode: 0xF6, e: 1, fixed_g: 7, block_boundary: 1, },
+    { opcode: 0xF6, e: 1, fixed_g: 0, imm8: 1, custom: 1, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF6, e: 1, fixed_g: 1, imm8: 1, custom: 1, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF6, e: 1, fixed_g: 2, modified_flags : 0 },
+    { opcode: 0xF6, e: 1, fixed_g: 3, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF6, e: 1, fixed_g: 4, mask_flags: af | zf, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF6, e: 1, fixed_g: 5, mask_flags: af | zf, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF6, e: 1, fixed_g: 6, block_boundary: 1, modified_flags : of | sf | zf | af | pf | cf }, // div/idiv: Not a block boundary, but doesn't use control flow exceptions
+    { opcode: 0xF6, e: 1, fixed_g: 7, block_boundary: 1, modified_flags : of | sf | zf | af | pf | cf },
 
-    { opcode: 0xF7, os: 1, e: 1, fixed_g: 0, imm1632: 1, custom: 1 },
-    { opcode: 0xF7, os: 1, e: 1, fixed_g: 1, imm1632: 1, custom: 1 },
-    { opcode: 0xF7, os: 1, e: 1, fixed_g: 2, custom: 1 },
-    { opcode: 0xF7, os: 1, e: 1, fixed_g: 3, custom: 1 },
-    { opcode: 0xF7, os: 1, e: 1, fixed_g: 4, mask_flags: zf | af, custom: 1 },
-    { opcode: 0xF7, os: 1, e: 1, fixed_g: 5, mask_flags: zf | af, custom: 1 },
-    { opcode: 0xF7, os: 1, e: 1, fixed_g: 6, custom: 1 },
-    { opcode: 0xF7, os: 1, e: 1, fixed_g: 7, custom: 1 },
+    { opcode: 0xF7, os: 1, e: 1, fixed_g: 0, imm1632: 1, custom: 1, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF7, os: 1, e: 1, fixed_g: 1, imm1632: 1, custom: 1, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF7, os: 1, e: 1, fixed_g: 2, custom: 1, modified_flags : 0 },
+    { opcode: 0xF7, os: 1, e: 1, fixed_g: 3, custom: 1, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF7, os: 1, e: 1, fixed_g: 4, mask_flags: zf | af, custom: 1, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF7, os: 1, e: 1, fixed_g: 5, mask_flags: zf | af, custom: 1, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF7, os: 1, e: 1, fixed_g: 6, custom: 1, modified_flags : of | sf | zf | af | pf | cf },
+    { opcode: 0xF7, os: 1, e: 1, fixed_g: 7, custom: 1, modified_flags : of | sf | zf | af | pf | cf },
 
-    { opcode: 0xF8, custom: 1 },
-    { opcode: 0xF9, custom: 1 },
+    { opcode: 0xF8, custom: 1 ,  modified_flags :cf , },
+    { opcode: 0xF9, custom: 1 ,  modified_flags :cf , },
     { opcode: 0xFA, custom: 1, skip: 1 },
     // STI: Note: Has special handling in jit in order to call handle_irqs safely
     { opcode: 0xFB, custom: 1, custom_sti: 1, skip: 1, },
     { opcode: 0xFC, custom: 1, },
     { opcode: 0xFD, custom: 1, },
 
-    { opcode: 0xFE, e: 1, fixed_g: 0, custom: 1 },
-    { opcode: 0xFE, e: 1, fixed_g: 1, custom: 1 },
-    { opcode: 0xFF, os: 1, e: 1, fixed_g: 0, custom: 1, },
-    { opcode: 0xFF, os: 1, e: 1, fixed_g: 1, custom: 1, },
+    { opcode: 0xFE, e: 1, fixed_g: 0, custom: 1, modified_flags : of | sf | zf | af | pf },
+    { opcode: 0xFE, e: 1, fixed_g: 1, custom: 1, modified_flags : of | sf | zf | af | pf },
+    { opcode: 0xFF, os: 1, e: 1, fixed_g: 0, custom: 1,  modified_flags : of | sf | zf | af | pf },
+    { opcode: 0xFF, os: 1, e: 1, fixed_g: 1, custom: 1,  modified_flags : of | sf | zf | af | pf },
     { opcode: 0xFF, os: 1, e: 1, fixed_g: 2, custom: 1, block_boundary: 1, absolute_jump: 1, skip: 1, },
     { opcode: 0xFF, os: 1, e: 1, fixed_g: 3, block_boundary: 1, skip: 1, },
     { opcode: 0xFF, os: 1, e: 1, fixed_g: 4, custom: 1, block_boundary: 1, absolute_jump: 1, no_next_instruction: 1, skip: 1, },
     { opcode: 0xFF, os: 1, e: 1, fixed_g: 5, block_boundary: 1, no_next_instruction: 1, skip: 1, },
-    { opcode: 0xFF, custom: 1, os: 1, e: 1, fixed_g: 6, },
+    { opcode: 0xFF, custom: 1, os: 1, e: 1, fixed_g: 6, modified_flags: 0},
 
     { opcode: 0x0F00, fixed_g: 0, e: 1, skip: 1, block_boundary: 1, os: 1, }, // sldt, ...
     { opcode: 0x0F00, fixed_g: 1, e: 1, skip: 1, block_boundary: 1, os: 1, },
@@ -430,8 +438,8 @@ const encodings = [
     { opcode: 0x0F01, fixed_g: 6, e: 1, skip: 1, block_boundary: 1, os: 1, },
     { opcode: 0x0F01, fixed_g: 7, e: 1, skip: 1, block_boundary: 1, os: 1, },
 
-    { opcode: 0x0F02, os: 1, e: 1, skip: 1, block_boundary: 1, }, // lar
-    { opcode: 0x0F03, os: 1, e: 1, skip: 1, block_boundary: 1, }, // lsl
+    { opcode: 0x0F02, os: 1, e: 1, skip: 1, block_boundary: 1,  modified_flags :zf , }, // lar
+    { opcode: 0x0F03, os: 1, e: 1, skip: 1, block_boundary: 1,  modified_flags :zf , }, // lsl
     { opcode: 0x0F04, skip: 1, block_boundary: 1, },
     { opcode: 0x0F05, skip: 1, block_boundary: 1, },
     { opcode: 0x0F06, skip: 1, block_boundary: 1, }, // clts
@@ -458,10 +466,10 @@ const encodings = [
     { opcode: 0x0F1E, custom: 1, e: 1, },
     { opcode: 0x0F1F, custom: 1, e: 1, },
 
-    { opcode: 0x0F20, ignore_mod: 1, e: 1, skip: 1, block_boundary: 1, }, // mov reg, creg
-    { opcode: 0x0F21, ignore_mod: 1, e: 1, skip: 1, block_boundary: 1, }, // mov reg, dreg
-    { opcode: 0x0F22, ignore_mod: 1, e: 1, skip: 1, block_boundary: 1, }, // mov creg, reg
-    { opcode: 0x0F23, ignore_mod: 1, e: 1, skip: 1, block_boundary: 1, }, // mov dreg, reg
+    { opcode: 0x0F20, ignore_mod: 1, e: 1, skip: 1, block_boundary: 1,  modified_flags :of | sf | zf | af | pf | cf , }, // mov reg, creg
+    { opcode: 0x0F21, ignore_mod: 1, e: 1, skip: 1, block_boundary: 1,  modified_flags :of | sf | zf | af | pf | cf , }, // mov reg, dreg
+    { opcode: 0x0F22, ignore_mod: 1, e: 1, skip: 1, block_boundary: 1,  modified_flags :of | sf | zf | af | pf | cf , }, // mov creg, reg
+    { opcode: 0x0F23, ignore_mod: 1, e: 1, skip: 1, block_boundary: 1,  modified_flags :of | sf | zf | af | pf | cf , }, // mov dreg, reg
     { opcode: 0x0F24, skip: 1, block_boundary: 1, },
     { opcode: 0x0F25, skip: 1, block_boundary: 1, },
     { opcode: 0x0F26, skip: 1, block_boundary: 1, },
@@ -487,83 +495,83 @@ const encodings = [
     { opcode: 0x0F3E, skip: 1, block_boundary: 1, },
     { opcode: 0x0F3F, skip: 1, block_boundary: 1, },
 
-    { opcode: 0x0F40, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F41, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F42, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F43, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F44, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F45, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F46, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F47, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F48, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F49, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F4A, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F4B, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F4C, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F4D, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F4E, e: 1, os: 1, custom: 1, },
-    { opcode: 0x0F4F, e: 1, os: 1, custom: 1, },
+    { opcode: 0x0F40, e: 1, os: 1, custom: 1, tested_flags : of , },
+    { opcode: 0x0F41, e: 1, os: 1, custom: 1, tested_flags : of , },
+    { opcode: 0x0F42, e: 1, os: 1, custom: 1, tested_flags : cf , },
+    { opcode: 0x0F43, e: 1, os: 1, custom: 1, tested_flags : cf , },
+    { opcode: 0x0F44, e: 1, os: 1, custom: 1, tested_flags : zf , },
+    { opcode: 0x0F45, e: 1, os: 1, custom: 1, tested_flags : zf , },
+    { opcode: 0x0F46, e: 1, os: 1, custom: 1, tested_flags : zf | cf , },
+    { opcode: 0x0F47, e: 1, os: 1, custom: 1, tested_flags : zf | cf , },
+    { opcode: 0x0F48, e: 1, os: 1, custom: 1, tested_flags : sf , },
+    { opcode: 0x0F49, e: 1, os: 1, custom: 1, tested_flags : sf , },
+    { opcode: 0x0F4A, e: 1, os: 1, custom: 1, tested_flags : pf , },
+    { opcode: 0x0F4B, e: 1, os: 1, custom: 1, tested_flags : pf , },
+    { opcode: 0x0F4C, e: 1, os: 1, custom: 1, tested_flags : of | sf , },
+    { opcode: 0x0F4D, e: 1, os: 1, custom: 1, tested_flags : of | sf , },
+    { opcode: 0x0F4E, e: 1, os: 1, custom: 1, tested_flags : of | sf | zf , },
+    { opcode: 0x0F4F, e: 1, os: 1, custom: 1, tested_flags : of | sf | zf , },
 
-    { opcode: 0x0F80, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F81, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F82, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F83, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F84, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F85, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F86, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F87, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F88, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F89, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F8A, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F8B, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F8C, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F8D, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F8E, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
-    { opcode: 0x0F8F, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, },
+    { opcode: 0x0F80, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : of , },
+    { opcode: 0x0F81, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : of , },
+    { opcode: 0x0F82, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : cf , },
+    { opcode: 0x0F83, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : cf , },
+    { opcode: 0x0F84, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : zf , },
+    { opcode: 0x0F85, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : zf , },
+    { opcode: 0x0F86, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : zf | cf , },
+    { opcode: 0x0F87, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : zf | cf , },
+    { opcode: 0x0F88, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : sf , },
+    { opcode: 0x0F89, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : sf , },
+    { opcode: 0x0F8A, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : pf , },
+    { opcode: 0x0F8B, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : pf , },
+    { opcode: 0x0F8C, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : of | sf , },
+    { opcode: 0x0F8D, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : of | sf , },
+    { opcode: 0x0F8E, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : of | sf | zf , },
+    { opcode: 0x0F8F, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, imm1632: 1, os: 1, custom: 1, skip: 1, tested_flags : of | sf | zf , },
 
-    { opcode: 0x0F90, e: 1, custom: 1, },
-    { opcode: 0x0F91, e: 1, custom: 1, },
-    { opcode: 0x0F92, e: 1, custom: 1, },
-    { opcode: 0x0F93, e: 1, custom: 1, },
-    { opcode: 0x0F94, e: 1, custom: 1, },
-    { opcode: 0x0F95, e: 1, custom: 1, },
-    { opcode: 0x0F96, e: 1, custom: 1, },
-    { opcode: 0x0F97, e: 1, custom: 1, },
-    { opcode: 0x0F98, e: 1, custom: 1, },
-    { opcode: 0x0F99, e: 1, custom: 1, },
-    { opcode: 0x0F9A, e: 1, custom: 1, },
-    { opcode: 0x0F9B, e: 1, custom: 1, },
-    { opcode: 0x0F9C, e: 1, custom: 1, },
-    { opcode: 0x0F9D, e: 1, custom: 1, },
-    { opcode: 0x0F9E, e: 1, custom: 1, },
-    { opcode: 0x0F9F, e: 1, custom: 1, },
+    { opcode: 0x0F90, e: 1, custom: 1, tested_flags : of , },
+    { opcode: 0x0F91, e: 1, custom: 1, tested_flags : of , },
+    { opcode: 0x0F92, e: 1, custom: 1, tested_flags : cf , },
+    { opcode: 0x0F93, e: 1, custom: 1, tested_flags : cf , },
+    { opcode: 0x0F94, e: 1, custom: 1, tested_flags : zf , },
+    { opcode: 0x0F95, e: 1, custom: 1, tested_flags : zf , },
+    { opcode: 0x0F96, e: 1, custom: 1, tested_flags : zf | cf , },
+    { opcode: 0x0F97, e: 1, custom: 1, tested_flags : zf | cf , },
+    { opcode: 0x0F98, e: 1, custom: 1, tested_flags : sf , },
+    { opcode: 0x0F99, e: 1, custom: 1, tested_flags : sf , },
+    { opcode: 0x0F9A, e: 1, custom: 1, tested_flags : pf , },
+    { opcode: 0x0F9B, e: 1, custom: 1, tested_flags : pf , },
+    { opcode: 0x0F9C, e: 1, custom: 1, tested_flags : of | sf , },
+    { opcode: 0x0F9D, e: 1, custom: 1, tested_flags : of | sf , },
+    { opcode: 0x0F9E, e: 1, custom: 1, tested_flags : of | sf | zf , },
+    { opcode: 0x0F9F, e: 1, custom: 1, tested_flags : of | sf | zf , },
 
-    { opcode: 0x0FA0, os: 1, custom: 1, },
-    { opcode: 0x0FA1, os: 1, block_boundary: 1, skip: 1, }, // pop fs: block_boundary since it uses non-raising cpu exceptions
+    { opcode: 0x0FA0, os: 1, custom: 1, tested_flags: 0 , },
+    { opcode: 0x0FA1, os: 1, block_boundary: 1, skip: 1, tested_flags: 0 , }, // pop fs: block_boundary since it uses non-raising cpu exceptions
 
     { opcode: 0x0FA2, skip: 1, },
 
-    { opcode: 0x0FA8, os: 1, custom: 1, },
-    { opcode: 0x0FA9, os: 1, block_boundary: 1, skip: 1, }, // pop gs
+    { opcode: 0x0FA8, os: 1, custom: 1, tested_flags: 0 , },
+    { opcode: 0x0FA9, os: 1, block_boundary: 1, skip: 1, tested_flags: 0 , }, // pop gs
 
-    { opcode: 0x0FA3, os: 1, e: 1, custom: 1, skip_mem: 1 }, // bt (can also index memory, but not supported by test right now)
-    { opcode: 0x0FAB, os: 1, e: 1, custom: 1, skip_mem: 1 },
-    { opcode: 0x0FB3, os: 1, e: 1, custom: 1, skip_mem: 1 },
-    { opcode: 0x0FBB, os: 1, e: 1, custom: 1, skip_mem: 1 },
+    { opcode: 0x0FA3, os: 1, e: 1, custom: 1, skip_mem: 1 ,  modified_flags :of | sf | zf | af | pf | cf , }, // bt (can also index memory, but not supported by test right now)
+    { opcode: 0x0FAB, os: 1, e: 1, custom: 1, skip_mem: 1 ,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x0FB3, os: 1, e: 1, custom: 1, skip_mem: 1 ,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x0FBB, os: 1, e: 1, custom: 1, skip_mem: 1 ,  modified_flags :of | sf | zf | af | pf | cf , },
 
     { opcode: 0x0FBA, os: 1, e: 1, fixed_g: 4, imm8: 1, custom: 1 }, // bt
     { opcode: 0x0FBA, os: 1, e: 1, fixed_g: 5, imm8: 1, custom: 1 },
     { opcode: 0x0FBA, os: 1, e: 1, fixed_g: 6, imm8: 1, custom: 1 },
     { opcode: 0x0FBA, os: 1, e: 1, fixed_g: 7, imm8: 1, custom: 1 },
 
-    { opcode: 0x0FBC, os: 1, e: 1, mask_flags: af, custom: 1 }, // bsf
-    { opcode: 0x0FBD, os: 1, e: 1, mask_flags: af, custom: 1 },
+    { opcode: 0x0FBC, os: 1, e: 1, mask_flags: af, custom: 1 ,  modified_flags :of | sf | zf | af | pf | cf , }, // bsf
+    { opcode: 0x0FBD, os: 1, e: 1, mask_flags: af, custom: 1 ,  modified_flags :of | sf | zf | af | pf | cf , },
 
     // note: overflow flag only undefined if shift is > 1
-    { opcode: 0x0FA4, os: 1, e: 1, custom: 1, imm8: 1, mask_flags: af | of, }, // shld
-    { opcode: 0x0FA5, os: 1, e: 1, custom: 1, mask_flags: af | of, },
-    { opcode: 0x0FAC, os: 1, e: 1, custom: 1, imm8: 1, mask_flags: af | of, },
-    { opcode: 0x0FAD, os: 1, e: 1, custom: 1, mask_flags: af | of, },
+    { opcode: 0x0FA4, os: 1, e: 1, custom: 1, imm8: 1, mask_flags: af | of,  modified_flags :of | sf | zf | af | pf | cf , }, // shld
+    { opcode: 0x0FA5, os: 1, e: 1, custom: 1, mask_flags: af | of,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x0FAC, os: 1, e: 1, custom: 1, imm8: 1, mask_flags: af | of,  modified_flags :of | sf | zf | af | pf | cf , },
+    { opcode: 0x0FAD, os: 1, e: 1, custom: 1, mask_flags: af | of,  modified_flags :of | sf | zf | af | pf | cf , },
 
     { opcode: 0x0FA6, skip: 1, block_boundary: 1, }, // ud
     { opcode: 0x0FA7, skip: 1, block_boundary: 1, }, // ud
@@ -580,38 +588,38 @@ const encodings = [
     { opcode: 0x0FAE, e: 1, fixed_g: 6, skip: 1, block_boundary: 1, }, // mfence (reg, only 0), xsaveopt (mem, not implemented)
     { opcode: 0x0FAE, e: 1, fixed_g: 7, skip: 1, block_boundary: 1, }, // sfence (reg, only 0), clflush (mem)
 
-    { opcode: 0x0FAF, os: 1, e: 1, mask_flags: af | zf, custom: 1, }, // imul
+    { opcode: 0x0FAF, os: 1, e: 1, mask_flags: af | zf, custom: 1,  modified_flags :of | sf | zf | af | pf | cf , }, // imul
 
-    { opcode: 0x0FB0, e: 1 }, // cmxchg
-    { opcode: 0x0FB1, os: 1, e: 1, custom: 1 },
+    { opcode: 0x0FB0, e: 1 ,  modified_flags :of | sf | zf | af | pf | cf , }, // cmxchg
+    { opcode: 0x0FB1, os: 1, e: 1, custom: 1 ,  modified_flags :of | sf | zf | af | pf | cf , },
     { opcode: 0x0FC7, e: 1, fixed_g: 1, os: 1, reg_ud: 1, custom: 1 }, // cmpxchg8b (memory)
     { opcode: 0x0FC7, e: 1, fixed_g: 6, os: 1, mem_ud: 1, skip: 1, }, // rdrand
 
-    { opcode: 0x0FB2, block_boundary: 1, os: 1, e: 1, skip: 1, }, // lss
-    { opcode: 0x0FB4, block_boundary: 1, os: 1, e: 1, skip: 1, }, // lfs
-    { opcode: 0x0FB5, block_boundary: 1, os: 1, e: 1, skip: 1, }, // lgs
+    { opcode: 0x0FB2, block_boundary: 1, os: 1, e: 1, skip: 1, tested_flags: 0 , }, // lss
+    { opcode: 0x0FB4, block_boundary: 1, os: 1, e: 1, skip: 1, tested_flags: 0 , }, // lfs
+    { opcode: 0x0FB5, block_boundary: 1, os: 1, e: 1, skip: 1, tested_flags: 0 , }, // lgs
 
-    { opcode: 0x0FB6, os: 1, e: 1, custom: 1 }, // movzx
-    { opcode: 0x0FB7, os: 1, e: 1, custom: 1 },
+    { opcode: 0x0FB6, os: 1, e: 1, custom: 1 , tested_flags: 0 , }, // movzx
+    { opcode: 0x0FB7, os: 1, e: 1, custom: 1 , tested_flags: 0 , },
 
     { opcode: 0xF30FB8, os: 1, e: 1, custom: 1 }, // popcnt
-    { opcode: 0x0FB8, os: 1, e: 1, block_boundary: 1, }, // ud
+    { opcode: 0x0FB8, os: 1, e: 1, block_boundary: 1,  modified_flags :of | sf | zf | af | pf | cf , }, // ud
 
     { opcode: 0x0FB9, block_boundary: 1, }, // ud2
 
-    { opcode: 0x0FBE, os: 1, e: 1, custom: 1 }, // movsx
-    { opcode: 0x0FBF, os: 1, e: 1, custom: 1 },
+    { opcode: 0x0FBE, os: 1, e: 1, custom: 1 , tested_flags: 0 , }, // movsx
+    { opcode: 0x0FBF, os: 1, e: 1, custom: 1 , tested_flags: 0 , },
 
-    { opcode: 0x0FC0, e: 1, }, // xadd
+    { opcode: 0x0FC0, e: 1,  modified_flags :of | sf | zf | af | pf | cf , }, // xadd
     { opcode: 0x0FC1, os: 1, e: 1, custom: 1 },
 
-    { opcode: 0x0FC8, custom: 1 }, // bswap
-    { opcode: 0x0FC9, custom: 1 },
-    { opcode: 0x0FCA, custom: 1 },
-    { opcode: 0x0FCB, custom: 1 },
-    { opcode: 0x0FCC, custom: 1 },
-    { opcode: 0x0FCD, custom: 1 },
-    { opcode: 0x0FCE, custom: 1 },
+    { opcode: 0x0FC8, custom: 1 , tested_flags: 0 , }, // bswap
+    { opcode: 0x0FC9, custom: 1 , tested_flags: 0 , },
+    { opcode: 0x0FCA, custom: 1 , tested_flags: 0 , },
+    { opcode: 0x0FCB, custom: 1 , tested_flags: 0 , },
+    { opcode: 0x0FCC, custom: 1 , tested_flags: 0 , },
+    { opcode: 0x0FCD, custom: 1 , tested_flags: 0 , },
+    { opcode: 0x0FCE, custom: 1 , tested_flags: 0 , },
     { opcode: 0x0FCF, custom: 1 },
 
 
@@ -936,34 +944,49 @@ const encodings = [
     { sse: 1, opcode: 0x0FFE, e: 1, custom: 1 },
     { sse: 1, opcode: 0x660FFE, e: 1, custom: 1 },
 
+    { opcode: 0x70 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : of},
+    { opcode: 0x71 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : of},
+    { opcode: 0x72 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : cf},
+    { opcode: 0x73 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : cf},
+    { opcode: 0x74 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : zf},
+    { opcode: 0x75 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : zf},
+    { opcode: 0x76 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : zf | cf},
+    { opcode: 0x77 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : zf | cf},
+    { opcode: 0x78 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : sf},
+    { opcode: 0x79 , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : sf},
+    { opcode: 0x7A , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : pf},
+    { opcode: 0x7B , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : pf},
+    { opcode: 0x7C , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : of | sf},
+    { opcode: 0x7D , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : of | sf},    
+    { opcode: 0x7E , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : of | sf | zf},
+    { opcode: 0x7F , block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, tested_flags : of | sf | zf},
+        
     { opcode: 0x0FFF, block_boundary: 1, }, // ud
 ];
 
 for(let i = 0; i < 8; i++)
 {
+    let tested_flags = (i==2)||(i==3) ? cf : 0;
     encodings.push.apply(encodings, [
-        { opcode: 0x04 | i << 3, custom: 1, imm8: 1, },
-        { opcode: 0x05 | i << 3, custom: 1, os: 1, imm1632: 1, },
+        { opcode: 0x04 | i << 3, custom: 1, imm8: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf },
+        { opcode: 0x05 | i << 3, custom: 1, os: 1, imm1632: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf },
 
-        { opcode: 0x70 | i, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, },
-        { opcode: 0x78 | i, block_boundary: 1, no_block_boundary_in_interpreted: 1, jump_offset_imm: 1, conditional_jump: 1, os: 1, imm8s: 1, custom: 1, skip: 1, },
+        { opcode: 0x80, e: 1, fixed_g: i, imm8: 1, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf  },
+        { opcode: 0x81, os: 1, e: 1, fixed_g: i, imm1632: 1, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf  },
+        { opcode: 0x82, e: 1, fixed_g: i, imm8: 1, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf  },
+        { opcode: 0x83, os: 1, e: 1, fixed_g: i, imm8s: 1, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf  },
 
-        { opcode: 0x80, e: 1, fixed_g: i, imm8: 1, custom: 1, },
-        { opcode: 0x81, os: 1, e: 1, fixed_g: i, imm1632: 1, custom: 1, },
-        { opcode: 0x82, e: 1, fixed_g: i, imm8: 1, custom: 1, },
-        { opcode: 0x83, os: 1, e: 1, fixed_g: i, imm8s: 1, custom: 1, },
-
-        { opcode: 0xB0 | i, custom: 1, imm8: 1, },
-        { opcode: 0xB8 | i, custom: 1, os: 1, imm1632: 1, },
+        { opcode: 0xB0 | i, custom: 1, imm8: 1, tested_flags: 0 },
+        { opcode: 0xB8 | i, custom: 1, os: 1, imm1632: 1, tested_flags: 0 },
 
         // note: overflow flag only undefined if shift is > 1
         // note: the adjust flag is undefined for shifts > 0 and unaffected by rotates
-        { opcode: 0xC0, e: 1, fixed_g: i, imm8: 1, mask_flags: of | af, custom: 1, },
-        { opcode: 0xC1, os: 1, e: 1, fixed_g: i, imm8: 1, mask_flags: of | af, custom: 1, },
-        { opcode: 0xD0, e: 1, fixed_g: i, mask_flags: af, custom: 1 },
-        { opcode: 0xD1, os: 1, e: 1, fixed_g: i, mask_flags: af, custom: 1, },
-        { opcode: 0xD2, e: 1, fixed_g: i, mask_flags: of | af, custom: 1 },
-        { opcode: 0xD3, os: 1, e: 1, fixed_g: i, mask_flags: of | af, custom: 1, },
+        { opcode: 0xC0, e: 1, fixed_g: i, imm8: 1, mask_flags: of | af, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf  },
+        { opcode: 0xC1, os: 1, e: 1, fixed_g: i, imm8: 1, mask_flags: of | af, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf  },
+        { opcode: 0xD0, e: 1, fixed_g: i, mask_flags: af, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf  },
+        { opcode: 0xD1, os: 1, e: 1, fixed_g: i, mask_flags: af, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf  },
+        { opcode: 0xD2, e: 1, fixed_g: i, mask_flags: of | af, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf  },
+        { opcode: 0xD3, os: 1, e: 1, fixed_g: i, mask_flags: of | af, custom: 1, tested_flags : tested_flags, modified_flags : of | sf | zf | af | pf | cf },
     ]);
 }
 

--- a/src/rust/analysis.rs
+++ b/src/rust/analysis.rs
@@ -20,6 +20,9 @@ pub struct Analysis {
     pub no_next_instruction: bool,
     pub absolute_jump: bool,
     pub ty: AnalysisType,
+    pub has_flags_info: bool,
+    pub tested_flags: i32,
+    pub modified_flags: i32,
 }
 
 pub fn analyze_step(mut cpu: &mut CpuContext) -> Analysis {
@@ -27,6 +30,9 @@ pub fn analyze_step(mut cpu: &mut CpuContext) -> Analysis {
         no_next_instruction: false,
         absolute_jump: false,
         ty: AnalysisType::Normal,
+        has_flags_info : false,
+        modified_flags : 0,
+        tested_flags : 0,
     };
     cpu.prefixes = 0;
     let opcode = cpu.read_imm8() as u32 | (cpu.osize_32() as u32) << 8;

--- a/src/rust/cpu/arith.rs
+++ b/src/rust/cpu/arith.rs
@@ -13,6 +13,12 @@ pub unsafe fn add(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
     *flags_changed = FLAGS_ALL;
     return res;
 }
+
+pub unsafe fn add_noflags(dest_operand: i32, source_operand: i32, _op_size: i32) -> i32 {
+    let res = dest_operand + source_operand;
+    return res;
+}
+
 pub unsafe fn adc(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
     let cf = getcf() as i32;
     let res = dest_operand + source_operand + cf;
@@ -27,6 +33,13 @@ pub unsafe fn adc(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
         | ((source_operand ^ res) & (dest_operand ^ res)) >> op_size << 11 & FLAG_OVERFLOW;
     return res;
 }
+
+pub unsafe fn adc_noflags(dest_operand: i32, source_operand: i32, _op_size: i32) -> i32 {
+    let cf = getcf() as i32;
+    let res = dest_operand + source_operand + cf;
+    return res;
+}
+
 pub unsafe fn sub(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
     let res = dest_operand - source_operand;
     *last_op1 = dest_operand;
@@ -35,6 +48,12 @@ pub unsafe fn sub(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
     *flags_changed = FLAGS_ALL | FLAG_SUB;
     return res;
 }
+
+pub unsafe fn sub_noflags(dest_operand: i32, source_operand: i32, _op_size: i32) -> i32 {
+    let res = dest_operand - source_operand;
+    return res;
+}
+
 pub unsafe fn sbb(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
     let cf = getcf() as i32;
     let res = dest_operand - source_operand - cf;
@@ -49,27 +68,57 @@ pub unsafe fn sbb(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
         | ((source_operand ^ dest_operand) & (res ^ dest_operand)) >> op_size << 11 & FLAG_OVERFLOW;
     return res;
 }
+
+pub unsafe fn sbb_noflags(dest_operand: i32, source_operand: i32, _op_size: i32) -> i32 {
+    let cf = getcf() as i32;
+    let res = dest_operand - source_operand - cf;
+    return res;
+}
+
+#[no_mangle]
 pub unsafe fn add8(x: i32, y: i32) -> i32 { return add(x, y, OPSIZE_8); }
+#[no_mangle]
+pub unsafe fn add8_noflags(x: i32, y: i32) -> i32 { return add_noflags(x, y, OPSIZE_8); }
 #[no_mangle]
 pub unsafe fn add16(x: i32, y: i32) -> i32 { return add(x, y, OPSIZE_16); }
 pub unsafe fn add32(x: i32, y: i32) -> i32 { return add(x, y, OPSIZE_32); }
+#[no_mangle]
+pub unsafe fn add16_noflags(x: i32, y: i32) -> i32 { return add_noflags(x, y, OPSIZE_16); }
+pub unsafe fn add32_noflags(x: i32, y: i32) -> i32 { return add_noflags(x, y, OPSIZE_32); }
+#[no_mangle]
 pub unsafe fn sub8(x: i32, y: i32) -> i32 { return sub(x, y, OPSIZE_8); }
+#[no_mangle]
+pub unsafe fn sub8_noflags(x: i32, y: i32) -> i32 { return sub_noflags(x, y, OPSIZE_8); }
 #[no_mangle]
 pub unsafe fn sub16(x: i32, y: i32) -> i32 { return sub(x, y, OPSIZE_16); }
 pub unsafe fn sub32(x: i32, y: i32) -> i32 { return sub(x, y, OPSIZE_32); }
 #[no_mangle]
+pub unsafe fn sub16_noflags(x: i32, y: i32) -> i32 { return sub_noflags(x, y, OPSIZE_16); }
+pub unsafe fn sub32_noflags(x: i32, y: i32) -> i32 { return sub_noflags(x, y, OPSIZE_32); }
+#[no_mangle]
 pub unsafe fn adc8(x: i32, y: i32) -> i32 { return adc(x, y, OPSIZE_8); }
+#[no_mangle]
+pub unsafe fn adc8_noflags(x: i32, y: i32) -> i32 { return adc_noflags(x, y, OPSIZE_8); }
 #[no_mangle]
 pub unsafe fn adc16(x: i32, y: i32) -> i32 { return adc(x, y, OPSIZE_16); }
 pub unsafe fn adc32(x: i32, y: i32) -> i32 { return adc(x, y, OPSIZE_32); }
 #[no_mangle]
+pub unsafe fn adc16_noflags(x: i32, y: i32) -> i32 { return adc_noflags(x, y, OPSIZE_16); }
+pub unsafe fn adc32_noflags(x: i32, y: i32) -> i32 { return adc_noflags(x, y, OPSIZE_32); }
+#[no_mangle]
 pub unsafe fn sbb8(x: i32, y: i32) -> i32 { return sbb(x, y, OPSIZE_8); }
+#[no_mangle]
+pub unsafe fn sbb8_noflags(x: i32, y: i32) -> i32 { return sbb_noflags(x, y, OPSIZE_8); }
 #[no_mangle]
 pub unsafe fn sbb16(x: i32, y: i32) -> i32 { return sbb(x, y, OPSIZE_16); }
 pub unsafe fn sbb32(x: i32, y: i32) -> i32 { return sbb(x, y, OPSIZE_32); }
+#[no_mangle]
+pub unsafe fn sbb16_noflags(x: i32, y: i32) -> i32 { return sbb_noflags(x, y, OPSIZE_16); }
+pub unsafe fn sbb32_noflags(x: i32, y: i32) -> i32 { return sbb_noflags(x, y, OPSIZE_32); }
 pub unsafe fn cmp8(x: i32, y: i32) { sub(x, y, OPSIZE_8); }
 pub unsafe fn cmp16(x: i32, y: i32) { sub(x, y, OPSIZE_16); }
 pub unsafe fn cmp32(x: i32, y: i32) { sub(x, y, OPSIZE_32); }
+
 pub unsafe fn inc(dest_operand: i32, op_size: i32) -> i32 {
     *flags = *flags & !1 | getcf() as i32;
     let res = dest_operand + 1;
@@ -79,6 +128,12 @@ pub unsafe fn inc(dest_operand: i32, op_size: i32) -> i32 {
     *flags_changed = FLAGS_ALL & !1;
     return res;
 }
+
+pub unsafe fn inc_noflags(dest_operand: i32, _op_size: i32) -> i32 {
+    let res = dest_operand + 1;
+    return res;
+}
+
 pub unsafe fn dec(dest_operand: i32, op_size: i32) -> i32 {
     *flags = *flags & !1 | getcf() as i32;
     let res = dest_operand - 1;
@@ -88,21 +143,41 @@ pub unsafe fn dec(dest_operand: i32, op_size: i32) -> i32 {
     *flags_changed = FLAGS_ALL & !1 | FLAG_SUB;
     return res;
 }
+
+pub unsafe fn dec_noflags(dest_operand: i32, _op_size: i32) -> i32 {
+    let res = dest_operand - 1;
+    return res;
+}
+
 #[no_mangle]
 pub unsafe fn inc8(x: i32) -> i32 { return inc(x, OPSIZE_8); }
 pub unsafe fn inc16(x: i32) -> i32 { return inc(x, OPSIZE_16); }
 pub unsafe fn inc32(x: i32) -> i32 { return inc(x, OPSIZE_32); }
 #[no_mangle]
+pub unsafe fn inc8_noflags(x: i32) -> i32 { return inc_noflags(x, OPSIZE_8); }
+pub unsafe fn inc16_noflags(x: i32) -> i32 { return inc_noflags(x, OPSIZE_16); }
+pub unsafe fn inc32_noflags(x: i32) -> i32 { return inc_noflags(x, OPSIZE_32); }
+#[no_mangle]
 pub unsafe fn dec8(x: i32) -> i32 { return dec(x, OPSIZE_8); }
 pub unsafe fn dec16(x: i32) -> i32 { return dec(x, OPSIZE_16); }
 pub unsafe fn dec32(x: i32) -> i32 { return dec(x, OPSIZE_32); }
+#[no_mangle]
+pub unsafe fn dec8_noflags(x: i32) -> i32 { return dec_noflags(x, OPSIZE_8); }
+pub unsafe fn dec16_noflags(x: i32) -> i32 { return dec_noflags(x, OPSIZE_16); }
+pub unsafe fn dec32_noflags(x: i32) -> i32 { return dec_noflags(x, OPSIZE_32); }
 
 pub unsafe fn neg(dest_operand: i32, op_size: i32) -> i32 { sub(0, dest_operand, op_size) }
+pub unsafe fn neg_noflags(dest_operand: i32, op_size: i32) -> i32 { sub_noflags(0, dest_operand, op_size) }
 #[no_mangle]
 pub unsafe fn neg8(x: i32) -> i32 { return neg(x, OPSIZE_8); }
 #[no_mangle]
+pub unsafe fn neg8_noflags(x: i32) -> i32 { return neg_noflags(x, OPSIZE_8); }
+#[no_mangle]
 pub unsafe fn neg16(x: i32) -> i32 { return neg(x, OPSIZE_16); }
 pub unsafe fn neg32(x: i32) -> i32 { return neg(x, OPSIZE_32); }
+#[no_mangle]
+pub unsafe fn neg16_noflags(x: i32) -> i32 { return neg_noflags(x, OPSIZE_16); }
+pub unsafe fn neg32_noflags(x: i32) -> i32 { return neg_noflags(x, OPSIZE_32); }
 
 #[no_mangle]
 pub unsafe fn mul8(source_operand: i32) {
@@ -119,6 +194,11 @@ pub unsafe fn mul8(source_operand: i32) {
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
 }
 #[no_mangle]
+pub unsafe fn mul8_noflags(source_operand: i32) {
+    let result = source_operand * read_reg8(AL);
+    write_reg16(AX, result);
+}
+#[no_mangle]
 pub unsafe fn imul8(source_operand: i32) {
     let result = source_operand * (read_reg8(AL) << 24 >> 24);
     write_reg16(AX, result);
@@ -131,6 +211,11 @@ pub unsafe fn imul8(source_operand: i32) {
         *flags &= !1 & !FLAG_OVERFLOW
     }
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
+}
+#[no_mangle]
+pub unsafe fn imul8_noflags(source_operand: i32) {
+    let result = source_operand * (read_reg8(AL) << 24 >> 24);
+    write_reg16(AX, result);
 }
 #[no_mangle]
 pub unsafe fn mul16(source_operand: u32) {
@@ -149,6 +234,13 @@ pub unsafe fn mul16(source_operand: u32) {
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
 }
 #[no_mangle]
+pub unsafe fn mul16_noflags(source_operand: u32) {
+    let result = source_operand.wrapping_mul(read_reg16(AX) as u32);
+    let high_result = result >> 16;
+    write_reg16(AX, result as i32);
+    write_reg16(DX, high_result as i32);
+}
+#[no_mangle]
 pub unsafe fn imul16(source_operand: i32) {
     let result = source_operand * (read_reg16(AX) << 16 >> 16);
     write_reg16(AX, result);
@@ -164,6 +256,12 @@ pub unsafe fn imul16(source_operand: i32) {
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
 }
 #[no_mangle]
+pub unsafe fn imul16_noflags(source_operand: i32) {
+    let result = source_operand * (read_reg16(AX) << 16 >> 16);
+    write_reg16(AX, result);
+    write_reg16(DX, result >> 16);
+}
+#[no_mangle]
 pub unsafe fn imul_reg16(mut operand1: i32, mut operand2: i32) -> i32 {
     operand1 = operand1 << 16 >> 16;
     operand2 = operand2 << 16 >> 16;
@@ -177,6 +275,13 @@ pub unsafe fn imul_reg16(mut operand1: i32, mut operand2: i32) -> i32 {
         *flags &= !1 & !FLAG_OVERFLOW
     }
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
+    return result;
+}
+#[no_mangle]
+pub unsafe fn imul_reg16_noflags(mut operand1: i32, mut operand2: i32) -> i32 {
+    operand1 = operand1 << 16 >> 16;
+    operand2 = operand2 << 16 >> 16;
+    let result = operand1 * operand2;
     return result;
 }
 #[no_mangle]
@@ -197,6 +302,15 @@ pub unsafe fn mul32(source_operand: i32) {
     }
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
 }
+#[no_mangle]
+pub unsafe fn mul32_noflags(source_operand: i32) {
+    let dest_operand = read_reg32(EAX);
+    let result = (dest_operand as u32 as u64).wrapping_mul(source_operand as u32 as u64);
+    let result_low = result as i32;
+    let result_high = (result >> 32) as i32;
+    write_reg32(EAX, result_low);
+    write_reg32(EDX, result_high);
+}
 pub unsafe fn imul32(source_operand: i32) {
     let dest_operand = read_reg32(EAX);
     let result = dest_operand as i64 * source_operand as i64;
@@ -214,6 +328,14 @@ pub unsafe fn imul32(source_operand: i32) {
     }
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
 }
+pub unsafe fn imul32_noflags(source_operand: i32) {
+    let dest_operand = read_reg32(EAX);
+    let result = dest_operand as i64 * source_operand as i64;
+    let result_low = result as i32;
+    let result_high = (result >> 32) as i32;
+    write_reg32(EAX, result_low);
+    write_reg32(EDX, result_high);
+}
 pub unsafe fn imul_reg32(operand1: i32, operand2: i32) -> i32 {
     let result = operand1 as i64 * operand2 as i64;
     let result_low = result as i32;
@@ -229,6 +351,11 @@ pub unsafe fn imul_reg32(operand1: i32, operand2: i32) -> i32 {
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
     return result_low;
 }
+pub unsafe fn imul_reg32_noflags(operand1: i32, operand2: i32) -> i32 {
+    let result = operand1 as i64 * operand2 as i64;
+    let result_low = result as i32;    
+    return result_low;
+}
 
 #[no_mangle]
 pub unsafe fn xadd8(source_operand: i32, reg: i32) -> i32 {
@@ -237,15 +364,32 @@ pub unsafe fn xadd8(source_operand: i32, reg: i32) -> i32 {
     return add(source_operand, tmp, OPSIZE_8);
 }
 #[no_mangle]
+pub unsafe fn xadd8_noflags(source_operand: i32, reg: i32) -> i32 {
+    let tmp = read_reg8(reg);
+    write_reg8(reg, source_operand);
+    return add_noflags(source_operand, tmp, OPSIZE_8);
+}
+#[no_mangle]
 pub unsafe fn xadd16(source_operand: i32, reg: i32) -> i32 {
     let tmp = read_reg16(reg);
     write_reg16(reg, source_operand);
     return add(source_operand, tmp, OPSIZE_16);
 }
+#[no_mangle]
+pub unsafe fn xadd16_noflags(source_operand: i32, reg: i32) -> i32 {
+    let tmp = read_reg16(reg);
+    write_reg16(reg, source_operand);
+    return add_noflags(source_operand, tmp, OPSIZE_16);
+}
 pub unsafe fn xadd32(source_operand: i32, reg: i32) -> i32 {
     let tmp = read_reg32(reg);
     write_reg32(reg, source_operand);
     return add(source_operand, tmp, OPSIZE_32);
+}
+pub unsafe fn xadd32_noflags(source_operand: i32, reg: i32) -> i32 {
+    let tmp = read_reg32(reg);
+    write_reg32(reg, source_operand);
+    return add_noflags(source_operand, tmp, OPSIZE_32);
 }
 
 #[no_mangle]
@@ -381,12 +525,20 @@ pub unsafe fn and(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW & !FLAG_ADJUST;
     return result;
 }
+pub unsafe fn and_noflags(dest_operand: i32, source_operand: i32, _op_size: i32) -> i32 {
+    let result = dest_operand & source_operand;
+    return result;
+}
 pub unsafe fn or(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
     let result = dest_operand | source_operand;
     *last_result = result;
     *last_op_size = op_size;
     *flags &= !1 & !FLAG_OVERFLOW & !FLAG_ADJUST;
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW & !FLAG_ADJUST;
+    return result;
+}
+pub unsafe fn or_noflags(dest_operand: i32, source_operand: i32, _op_size: i32) -> i32 {
+    let result = dest_operand | source_operand;
     return result;
 }
 pub unsafe fn xor(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
@@ -397,21 +549,46 @@ pub unsafe fn xor(dest_operand: i32, source_operand: i32, op_size: i32) -> i32 {
     *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW & !FLAG_ADJUST;
     return result;
 }
+pub unsafe fn xor_noflags(dest_operand: i32, source_operand: i32, _op_size: i32) -> i32 {
+    let result = dest_operand ^ source_operand;
+    return result;
+}
+#[no_mangle]
 pub unsafe fn and8(x: i32, y: i32) -> i32 { return and(x, y, OPSIZE_8); }
+#[no_mangle]
+pub unsafe fn and8_noflags(x: i32, y: i32) -> i32 { return and_noflags(x, y, OPSIZE_8); }
 #[no_mangle]
 pub unsafe fn and16(x: i32, y: i32) -> i32 { return and(x, y, OPSIZE_16); }
 pub unsafe fn and32(x: i32, y: i32) -> i32 { return and(x, y, OPSIZE_32); }
 pub unsafe fn test8(x: i32, y: i32) { and(x, y, OPSIZE_8); }
 pub unsafe fn test16(x: i32, y: i32) { and(x, y, OPSIZE_16); }
 pub unsafe fn test32(x: i32, y: i32) { and(x, y, OPSIZE_32); }
+#[no_mangle]
+pub unsafe fn and16_noflags(x: i32, y: i32) -> i32 { return and_noflags(x, y, OPSIZE_16); }
+pub unsafe fn and32_noflags(x: i32, y: i32) -> i32 { return and_noflags(x, y, OPSIZE_32); }
+pub unsafe fn test8_noflags(x: i32, y: i32) { and_noflags(x, y, OPSIZE_8); }
+pub unsafe fn test16_noflags(x: i32, y: i32) { and_noflags(x, y, OPSIZE_16); }
+pub unsafe fn test32_noflags(x: i32, y: i32) { and_noflags(x, y, OPSIZE_32); }
+#[no_mangle]
 pub unsafe fn or8(x: i32, y: i32) -> i32 { return or(x, y, OPSIZE_8); }
+#[no_mangle]
+pub unsafe fn or8_noflags(x: i32, y: i32) -> i32 { return or_noflags(x, y, OPSIZE_8); }
 #[no_mangle]
 pub unsafe fn or16(x: i32, y: i32) -> i32 { return or(x, y, OPSIZE_16); }
 pub unsafe fn or32(x: i32, y: i32) -> i32 { return or(x, y, OPSIZE_32); }
+#[no_mangle]
+pub unsafe fn or16_noflags(x: i32, y: i32) -> i32 { return or_noflags(x, y, OPSIZE_16); }
+pub unsafe fn or32_noflags(x: i32, y: i32) -> i32 { return or_noflags(x, y, OPSIZE_32); }
+#[no_mangle]
 pub unsafe fn xor8(x: i32, y: i32) -> i32 { return xor(x, y, OPSIZE_8); }
+#[no_mangle]
+pub unsafe fn xor8_noflags(x: i32, y: i32) -> i32 { return xor_noflags(x, y, OPSIZE_8); }
 #[no_mangle]
 pub unsafe fn xor16(x: i32, y: i32) -> i32 { return xor(x, y, OPSIZE_16); }
 pub unsafe fn xor32(x: i32, y: i32) -> i32 { return xor(x, y, OPSIZE_32); }
+#[no_mangle]
+pub unsafe fn xor16_noflags(x: i32, y: i32) -> i32 { return xor_noflags(x, y, OPSIZE_16); }
+pub unsafe fn xor32_noflags(x: i32, y: i32) -> i32 { return xor_noflags(x, y, OPSIZE_32); }
 
 #[no_mangle]
 pub unsafe fn rol8(dest_operand: i32, mut count: i32) -> i32 {
@@ -426,6 +603,18 @@ pub unsafe fn rol8(dest_operand: i32, mut count: i32) -> i32 {
         *flags = *flags & !1 & !FLAG_OVERFLOW
             | result & 1
             | (result << 11 ^ result << 4) & FLAG_OVERFLOW;
+        return result;
+    };
+}
+#[no_mangle]
+pub unsafe fn rol8_noflags(dest_operand: i32, mut count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        count &= 7;
+        let result = dest_operand << count | dest_operand >> 8 - count;
         return result;
     };
 }
@@ -446,6 +635,18 @@ pub unsafe fn rol16(dest_operand: i32, mut count: i32) -> i32 {
     };
 }
 #[no_mangle]
+pub unsafe fn rol16_noflags(dest_operand: i32, mut count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        count &= 15;
+        let result = dest_operand << count | dest_operand >> 16 - count;
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn rol32(dest_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if 0 == count {
@@ -457,6 +658,17 @@ pub unsafe fn rol32(dest_operand: i32, count: i32) -> i32 {
         *flags = *flags & !1 & !FLAG_OVERFLOW
             | result & 1
             | (result << 11 ^ result >> 20) & FLAG_OVERFLOW;
+        return result;
+    };
+}
+#[no_mangle]
+pub unsafe fn rol32_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        let result = ((dest_operand << count) as u32 | dest_operand as u32 >> 32 - count) as i32;
         return result;
     };
 }
@@ -478,6 +690,19 @@ pub unsafe fn rcl8(dest_operand: i32, mut count: i32) -> i32 {
     };
 }
 #[no_mangle]
+pub unsafe fn rcl8_noflags(dest_operand: i32, mut count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    count %= 9;
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        let result =
+            dest_operand << count | (getcf() as i32) << count - 1 | dest_operand >> 9 - count;        
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn rcl16(dest_operand: i32, mut count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     count %= 17;
@@ -491,6 +716,19 @@ pub unsafe fn rcl16(dest_operand: i32, mut count: i32) -> i32 {
         *flags = *flags & !1 & !FLAG_OVERFLOW
             | result >> 16 & 1
             | (result >> 5 ^ result >> 4) & FLAG_OVERFLOW;
+        return result;
+    };
+}
+#[no_mangle]
+pub unsafe fn rcl16_noflags(dest_operand: i32, mut count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    count %= 17;
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        let result =
+            dest_operand << count | (getcf() as i32) << count - 1 | dest_operand >> 17 - count;
         return result;
     };
 }
@@ -512,6 +750,20 @@ pub unsafe fn rcl32(dest_operand: i32, count: i32) -> i32 {
     };
 }
 #[no_mangle]
+pub unsafe fn rcl32_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        let mut result: i32 = dest_operand << count | (getcf() as i32) << count - 1;
+        if count > 1 {
+            result = (result as u32 | dest_operand as u32 >> 33 - count) as i32
+        }
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn ror8(dest_operand: i32, mut count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if 0 == count {
@@ -524,6 +776,18 @@ pub unsafe fn ror8(dest_operand: i32, mut count: i32) -> i32 {
         *flags = *flags & !1 & !FLAG_OVERFLOW
             | result >> 7 & 1
             | (result << 4 ^ result << 5) & FLAG_OVERFLOW;
+        return result;
+    };
+}
+#[no_mangle]
+pub unsafe fn ror8_noflags(dest_operand: i32, mut count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        count &= 7;
+        let result = dest_operand >> count | dest_operand << 8 - count;
         return result;
     };
 }
@@ -544,6 +808,18 @@ pub unsafe fn ror16(dest_operand: i32, mut count: i32) -> i32 {
     };
 }
 #[no_mangle]
+pub unsafe fn ror16_noflags(dest_operand: i32, mut count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        count &= 15;
+        let result = dest_operand >> count | dest_operand << 16 - count;
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn ror32(dest_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if 0 == count {
@@ -555,6 +831,17 @@ pub unsafe fn ror32(dest_operand: i32, count: i32) -> i32 {
         *flags = *flags & !1 & !FLAG_OVERFLOW
             | result >> 31 & 1
             | (result >> 20 ^ result >> 19) & FLAG_OVERFLOW;
+        return result;
+    };
+}
+#[no_mangle]
+pub unsafe fn ror32_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        let result = (dest_operand as u32 >> count | (dest_operand << 32 - count) as u32) as i32;
         return result;
     };
 }
@@ -576,6 +863,19 @@ pub unsafe fn rcr8(dest_operand: i32, mut count: i32) -> i32 {
     };
 }
 #[no_mangle]
+pub unsafe fn rcr8_noflags(dest_operand: i32, mut count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    count %= 9;
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        let result =
+            dest_operand >> count | (getcf() as i32) << 8 - count | dest_operand << 9 - count;
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn rcr16(dest_operand: i32, mut count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     count %= 17;
@@ -589,6 +889,19 @@ pub unsafe fn rcr16(dest_operand: i32, mut count: i32) -> i32 {
         *flags = *flags & !1 & !FLAG_OVERFLOW
             | result >> 16 & 1
             | (result >> 4 ^ result >> 3) & FLAG_OVERFLOW;
+        return result;
+    };
+}
+#[no_mangle]
+pub unsafe fn rcr16_noflags(dest_operand: i32, mut count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    count %= 17;
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        let result =
+            dest_operand >> count | (getcf() as i32) << 16 - count | dest_operand << 17 - count;
         return result;
     };
 }
@@ -608,6 +921,21 @@ pub unsafe fn rcr32(dest_operand: i32, count: i32) -> i32 {
         *flags = *flags & !1 & !FLAG_OVERFLOW
             | dest_operand >> count - 1 & 1
             | (result >> 20 ^ result >> 19) & FLAG_OVERFLOW;
+        return result;
+    };
+}
+#[no_mangle]
+pub unsafe fn rcr32_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if 0 == count {
+        return dest_operand;
+    }
+    else {
+        let mut result: i32 =
+            (dest_operand as u32 >> count | ((getcf() as i32) << 32 - count) as u32) as i32;
+        if count > 1 {
+            result |= dest_operand << 33 - count
+        }
         return result;
     };
 }
@@ -759,6 +1087,17 @@ pub unsafe fn shl8(dest_operand: i32, count: i32) -> i32 {
     };
 }
 #[no_mangle]
+pub unsafe fn shl8_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result = dest_operand << count;
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn shl16(dest_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if count == 0 {
@@ -775,6 +1114,17 @@ pub unsafe fn shl16(dest_operand: i32, count: i32) -> i32 {
         return result;
     };
 }
+#[no_mangle]
+pub unsafe fn shl16_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result = dest_operand << count;
+        return result;
+    };
+}
 pub unsafe fn shl32(dest_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if count == 0 {
@@ -787,6 +1137,16 @@ pub unsafe fn shl32(dest_operand: i32, count: i32) -> i32 {
         *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
         let b = dest_operand >> 32 - count & 1;
         *flags = *flags & !1 & !FLAG_OVERFLOW | b | (b ^ result >> 31) << 11 & FLAG_OVERFLOW;
+        return result;
+    };
+}
+pub unsafe fn shl32_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result = dest_operand << count;
         return result;
     };
 }
@@ -808,6 +1168,17 @@ pub unsafe fn shr8(dest_operand: i32, count: i32) -> i32 {
     };
 }
 #[no_mangle]
+pub unsafe fn shr8_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result = dest_operand >> count;
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn shr16(dest_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if count == 0 {
@@ -824,6 +1195,18 @@ pub unsafe fn shr16(dest_operand: i32, count: i32) -> i32 {
         return result;
     };
 }
+
+#[no_mangle]
+pub unsafe fn shr16_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result = dest_operand >> count;
+        return result;
+    };
+}
 pub unsafe fn shr32(dest_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if count == 0 {
@@ -837,6 +1220,16 @@ pub unsafe fn shr32(dest_operand: i32, count: i32) -> i32 {
         *flags = (*flags & !1 & !FLAG_OVERFLOW)
             | (dest_operand as u32 >> count - 1 & 1) as i32
             | (dest_operand >> 20 & FLAG_OVERFLOW);
+        return result;
+    };
+}
+pub unsafe fn shr32_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result = (dest_operand as u32 >> count) as i32;
         return result;
     };
 }
@@ -864,6 +1257,23 @@ pub unsafe fn sar8(dest_operand: i32, count: i32) -> i32 {
     };
 }
 #[no_mangle]
+pub unsafe fn sar8_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result;
+        if count < 8 {
+            result = dest_operand << 24 >> count + 24;
+        }
+        else {
+            result = dest_operand << 24 >> 31;
+        }
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn sar16(dest_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if count == 0 {
@@ -885,6 +1295,23 @@ pub unsafe fn sar16(dest_operand: i32, count: i32) -> i32 {
         return result;
     };
 }
+#[no_mangle]
+pub unsafe fn sar16_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result;
+        if count < 16 {
+            result = dest_operand << 16 >> count + 16;
+        }
+        else {
+            result = dest_operand << 16 >> 31;
+        }
+        return result;
+    };
+}
 pub unsafe fn sar32(dest_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if count == 0 {
@@ -896,6 +1323,16 @@ pub unsafe fn sar32(dest_operand: i32, count: i32) -> i32 {
         *last_op_size = OPSIZE_32;
         *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
         *flags = (*flags & !1 & !FLAG_OVERFLOW) | (dest_operand as u32 >> count - 1 & 1) as i32;
+        return result;
+    };
+}
+pub unsafe fn sar32_noflags(dest_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result = dest_operand >> count;
         return result;
     };
 }
@@ -924,6 +1361,23 @@ pub unsafe fn shrd16(dest_operand: i32, source_operand: i32, count: i32) -> i32 
     };
 }
 #[no_mangle]
+pub unsafe fn shrd16_noflags(dest_operand: i32, source_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result;
+        if count <= 16 {
+            result = dest_operand >> count | source_operand << 16 - count;
+        }
+        else {
+            result = dest_operand << 32 - count | source_operand >> count - 16;
+        }
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn shrd32(dest_operand: i32, source_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if count == 0 {
@@ -936,6 +1390,17 @@ pub unsafe fn shrd32(dest_operand: i32, source_operand: i32, count: i32) -> i32 
         *flags_changed = FLAGS_ALL & !1 & !FLAG_OVERFLOW;
         *flags = ((*flags & !1 & !FLAG_OVERFLOW) | (dest_operand as u32 >> count - 1 & 1) as i32)
             | (result ^ dest_operand) >> 20 & FLAG_OVERFLOW;
+        return result;
+    };
+}
+#[no_mangle]
+pub unsafe fn shrd32_noflags(dest_operand: i32, source_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result = (dest_operand as u32 >> count | (source_operand << 32 - count) as u32) as i32;
         return result;
     };
 }
@@ -963,6 +1428,23 @@ pub unsafe fn shld16(dest_operand: i32, source_operand: i32, count: i32) -> i32 
     };
 }
 #[no_mangle]
+pub unsafe fn shld16_noflags(dest_operand: i32, source_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result;
+        if count <= 16 {
+            result = ((dest_operand << count) as u32 | source_operand as u32 >> 16 - count) as i32;
+        }
+        else {
+            result = dest_operand >> 32 - count | source_operand << count - 16;
+        }
+        return result;
+    };
+}
+#[no_mangle]
 pub unsafe fn shld32(dest_operand: i32, source_operand: i32, count: i32) -> i32 {
     dbg_assert!(count >= 0 && count < 32);
     if count == 0 {
@@ -983,24 +1465,47 @@ pub unsafe fn shld32(dest_operand: i32, source_operand: i32, count: i32) -> i32 
         return result;
     };
 }
+#[no_mangle]
+pub unsafe fn shld32_noflags(dest_operand: i32, source_operand: i32, count: i32) -> i32 {
+    dbg_assert!(count >= 0 && count < 32);
+    if count == 0 {
+        return dest_operand;
+    }
+    else {
+        let result = ((dest_operand << count) as u32 | source_operand as u32 >> 32 - count) as i32;
+        return result;
+    };
+}
 
 pub unsafe fn bt_reg(bit_base: i32, bit_offset: i32) {
     *flags = *flags & !1 | bit_base >> bit_offset & 1;
     *flags_changed &= !1;
 }
+
 pub unsafe fn btc_reg(bit_base: i32, bit_offset: i32) -> i32 {
     *flags = *flags & !1 | bit_base >> bit_offset & 1;
     *flags_changed &= !1;
     return bit_base ^ 1 << bit_offset;
 }
+pub unsafe fn btc_reg_noflags(bit_base: i32, bit_offset: i32) -> i32 {
+    return bit_base ^ 1 << bit_offset;
+}
+
 pub unsafe fn bts_reg(bit_base: i32, bit_offset: i32) -> i32 {
     *flags = *flags & !1 | bit_base >> bit_offset & 1;
     *flags_changed &= !1;
     return bit_base | 1 << bit_offset;
 }
+pub unsafe fn bts_reg_noflags(bit_base: i32, bit_offset: i32) -> i32 {
+    return bit_base | 1 << bit_offset;
+}
+
 pub unsafe fn btr_reg(bit_base: i32, bit_offset: i32) -> i32 {
     *flags = *flags & !1 | bit_base >> bit_offset & 1;
     *flags_changed &= !1;
+    return bit_base & !(1 << bit_offset);
+}
+pub unsafe fn btr_reg_noflags(bit_base: i32, bit_offset: i32) -> i32 {
     return bit_base & !(1 << bit_offset);
 }
 
@@ -1010,6 +1515,7 @@ pub unsafe fn bt_mem(virt_addr: i32, mut bit_offset: i32) {
     *flags = *flags & !1 | bit_base >> bit_offset & 1;
     *flags_changed &= !1;
 }
+
 pub unsafe fn btc_mem(virt_addr: i32, mut bit_offset: i32) {
     let phys_addr = return_on_pagefault!(translate_address_write(virt_addr + (bit_offset >> 3)));
     let bit_base = read8(phys_addr);
@@ -1018,6 +1524,13 @@ pub unsafe fn btc_mem(virt_addr: i32, mut bit_offset: i32) {
     *flags_changed &= !1;
     write8(phys_addr, bit_base ^ 1 << bit_offset);
 }
+pub unsafe fn btc_mem_noflags(virt_addr: i32, mut bit_offset: i32) {
+    let phys_addr = return_on_pagefault!(translate_address_write(virt_addr + (bit_offset >> 3)));
+    let bit_base = read8(phys_addr);
+    bit_offset &= 7;
+    write8(phys_addr, bit_base ^ 1 << bit_offset);
+}
+
 pub unsafe fn btr_mem(virt_addr: i32, mut bit_offset: i32) {
     let phys_addr = return_on_pagefault!(translate_address_write(virt_addr + (bit_offset >> 3)));
     let bit_base = read8(phys_addr);
@@ -1026,12 +1539,25 @@ pub unsafe fn btr_mem(virt_addr: i32, mut bit_offset: i32) {
     *flags_changed &= !1;
     write8(phys_addr, bit_base & !(1 << bit_offset));
 }
+pub unsafe fn btr_mem_noflags(virt_addr: i32, mut bit_offset: i32) {
+    let phys_addr = return_on_pagefault!(translate_address_write(virt_addr + (bit_offset >> 3)));
+    let bit_base = read8(phys_addr);
+    bit_offset &= 7;
+    write8(phys_addr, bit_base & !(1 << bit_offset));
+}
+
 pub unsafe fn bts_mem(virt_addr: i32, mut bit_offset: i32) {
     let phys_addr = return_on_pagefault!(translate_address_write(virt_addr + (bit_offset >> 3)));
     let bit_base = read8(phys_addr);
     bit_offset &= 7;
     *flags = *flags & !1 | bit_base >> bit_offset & 1;
     *flags_changed &= !1;
+    write8(phys_addr, bit_base | 1 << bit_offset);
+}
+pub unsafe fn bts_mem_noflags(virt_addr: i32, mut bit_offset: i32) {
+    let phys_addr = return_on_pagefault!(translate_address_write(virt_addr + (bit_offset >> 3)));
+    let bit_base = read8(phys_addr);
+    bit_offset &= 7;
     write8(phys_addr, bit_base | 1 << bit_offset);
 }
 
@@ -1052,6 +1578,18 @@ pub unsafe fn bsf16(old: i32, bit_base: i32) -> i32 {
         return *last_result;
     };
 }
+
+#[no_mangle]
+pub unsafe fn bsf16_noflags(old: i32, bit_base: i32) -> i32 {
+    if bit_base == 0 {
+        // not defined in the docs, but value doesn't change on my intel machine
+        return old;
+    }
+    else {        
+        return int_log2(-bit_base & bit_base);
+    };
+}
+
 #[no_mangle]
 pub unsafe fn bsf32(old: i32, bit_base: i32) -> i32 {
     *flags_changed = FLAGS_ALL & !FLAG_ZERO & !FLAG_CARRY;
@@ -1068,6 +1606,18 @@ pub unsafe fn bsf32(old: i32, bit_base: i32) -> i32 {
         return *last_result;
     };
 }
+
+#[no_mangle]
+pub unsafe fn bsf32_noflags(old: i32, bit_base: i32) -> i32 {
+    if bit_base == 0 {
+        return old;
+    }
+    else {
+        
+        return int_log2(-bit_base & bit_base);
+    };
+}
+
 #[no_mangle]
 pub unsafe fn bsr16(old: i32, bit_base: i32) -> i32 {
     *flags_changed = FLAGS_ALL & !FLAG_ZERO & !FLAG_CARRY;
@@ -1082,6 +1632,15 @@ pub unsafe fn bsr16(old: i32, bit_base: i32) -> i32 {
         *flags &= !FLAG_ZERO;
         *last_result = int_log2(bit_base);
         return *last_result;
+    };
+}
+#[no_mangle]
+pub unsafe fn bsr16_noflags(old: i32, bit_base: i32) -> i32 {
+    if bit_base == 0 {
+        return old;
+    }
+    else {         
+        return int_log2(bit_base);
     };
 }
 #[no_mangle]
@@ -1101,6 +1660,16 @@ pub unsafe fn bsr32(old: i32, bit_base: i32) -> i32 {
     };
 }
 #[no_mangle]
+pub unsafe fn bsr32_noflags(old: i32, bit_base: i32) -> i32 {
+    if bit_base == 0 {
+        return old;
+    }
+    else {
+        return int_log2(bit_base);
+    };
+}
+
+#[no_mangle]
 pub unsafe fn popcnt(v: i32) -> i32 {
     *flags_changed = 0;
     *flags &= !FLAGS_ALL;
@@ -1109,6 +1678,15 @@ pub unsafe fn popcnt(v: i32) -> i32 {
     }
     else {
         *flags |= FLAG_ZERO;
+        return 0;
+    };
+}
+#[no_mangle]
+pub unsafe fn popcnt_noflags(v: i32) -> i32 {
+    if 0 != v {
+        return v.count_ones() as i32;
+    }
+    else {
         return 0;
     };
 }

--- a/src/rust/cpu/cpu.rs
+++ b/src/rust/cpu/cpu.rs
@@ -1746,7 +1746,7 @@ pub fn translate_address_read_no_side_effects(address: i32) -> Option<u32> {
     let entry = unsafe { tlb_data[(address as u32 >> 12) as usize] };
     let user = unsafe { *cpl } == 3;
     if entry & (TLB_VALID | if user { TLB_NO_USER } else { 0 }) == TLB_VALID {
-        Some((entry & !0xFFF ^ address) as u32)
+        Some((entry & !0xFFF ^ address) as u32 - unsafe {memory::mem8} as u32)
     }
     else {
         match unsafe { do_page_walk(address, false, user, false) } {
@@ -1760,7 +1760,7 @@ pub fn translate_address_read(address: i32) -> OrPageFault<u32> {
     let entry = unsafe { tlb_data[(address as u32 >> 12) as usize] };
     let user = unsafe { *cpl == 3 };
     if entry & (TLB_VALID | if user { TLB_NO_USER } else { 0 }) == TLB_VALID {
-        Ok((entry & !0xFFF ^ address) as u32)
+        Ok((entry & !0xFFF ^ address) as u32 - unsafe {memory::mem8} as u32)
     }
     else {
         Ok((unsafe { do_page_translation(address, false, user) }? | address & 0xFFF) as u32)
@@ -1771,7 +1771,7 @@ pub unsafe fn translate_address_read_jit(address: i32) -> OrPageFault<u32> {
     let entry = tlb_data[(address as u32 >> 12) as usize];
     let user = *cpl == 3;
     if entry & (TLB_VALID | if user { TLB_NO_USER } else { 0 }) == TLB_VALID {
-        Ok((entry & !0xFFF ^ address) as u32)
+        Ok((entry & !0xFFF ^ address) as u32 - memory::mem8 as u32)
     }
     else {
         match do_page_walk(address, false, user, true) {
@@ -1965,7 +1965,9 @@ pub unsafe fn do_page_walk(
         | if has_code { TLB_HAS_CODE } else { 0 };
     dbg_assert!((high ^ page << 12) & 0xFFF == 0);
     if side_effects {
-        tlb_data[page as usize] = high ^ page << 12 | info_bits
+        // bake in the addition with memory::mem8 to save an instruction from the fast path
+        // of memory accesses
+        tlb_data[page as usize] = (high + memory::mem8 as i32) ^ page << 12 | info_bits as i32;
     }
     return Ok(high);
 }
@@ -2130,7 +2132,7 @@ pub unsafe fn translate_address_write_and_can_skip_dirty(address: i32) -> OrPage
     let entry = tlb_data[(address as u32 >> 12) as usize];
     let user = *cpl == 3;
     if entry & (TLB_VALID | if user { TLB_NO_USER } else { 0 } | TLB_READONLY) == TLB_VALID {
-        return Ok(((entry & !0xFFF ^ address) as u32, entry & TLB_HAS_CODE == 0));
+        return Ok(((entry & !0xFFF ^ address) as u32 - memory::mem8 as u32, entry & TLB_HAS_CODE == 0));        
     }
     else {
         return Ok((
@@ -2144,7 +2146,7 @@ pub unsafe fn translate_address_write(address: i32) -> OrPageFault<u32> {
     let entry = tlb_data[(address as u32 >> 12) as usize];
     let user = *cpl == 3;
     if entry & (TLB_VALID | if user { TLB_NO_USER } else { 0 } | TLB_READONLY) == TLB_VALID {
-        return Ok((entry & !0xFFF ^ address) as u32);
+        return Ok((entry & !0xFFF ^ address) as u32 - memory::mem8 as u32);
     }
     else {
         return Ok((do_page_translation(address, true, user)? | address & 0xFFF) as u32);
@@ -2155,7 +2157,7 @@ pub unsafe fn translate_address_write_jit(address: i32) -> OrPageFault<u32> {
     let entry = tlb_data[(address as u32 >> 12) as usize];
     let user = *cpl == 3;
     if entry & (TLB_VALID | if user { TLB_NO_USER } else { 0 } | TLB_READONLY) == TLB_VALID {
-        Ok((entry & !0xFFF ^ address) as u32)
+        Ok((entry & !0xFFF ^ address) as u32 - memory::mem8 as u32)
     }
     else {
         match do_page_walk(address, true, user, true) {
@@ -2174,7 +2176,7 @@ pub fn tlb_set_has_code(physical_page: Page, has_code: bool) {
         let page = unsafe { valid_tlb_entries[i as usize] };
         let entry = unsafe { tlb_data[page as usize] };
         if 0 != entry {
-            let tlb_physical_page = entry as u32 >> 12 ^ page as u32;
+            let tlb_physical_page = (entry as u32 >> 12 ^ page as u32) - (unsafe {memory::mem8} as u32 >> 12);
             if physical_page == tlb_physical_page {
                 unsafe {
                     tlb_data[page as usize] =
@@ -2201,7 +2203,7 @@ pub fn check_tlb_invariants() {
             continue;
         }
 
-        let target = (entry ^ page << 12) as u32;
+        let target = (entry ^ page << 12) as u32 - unsafe { memory::mem8 } as u32;
         dbg_assert!(!in_mapped_range(target));
 
         let entry_has_code = entry & TLB_HAS_CODE != 0;
@@ -3203,7 +3205,7 @@ pub unsafe fn safe_read_slow_jit(addr: i32, bitsize: i32, start_eip: i32, is_wri
             *(scratch as *mut u8).offset((0x1000 | s & 0xFFF) as isize) = read8(s) as u8
         }
 
-        (((scratch - mem8 as u32) as i32) ^ addr) & !0xFFF
+        ((scratch as i32) ^ addr) & !0xFFF
     }
     else if in_mapped_range(addr_low) {
         let scratch = jit_paging_scratch_buffer.0.as_mut_ptr() as u32;
@@ -3213,10 +3215,10 @@ pub unsafe fn safe_read_slow_jit(addr: i32, bitsize: i32, start_eip: i32, is_wri
             *(scratch as *mut u8).offset((s & 0xFFF) as isize) = read8(s) as u8
         }
 
-        (((scratch - mem8 as u32) as i32) ^ addr) & !0xFFF
+        ((scratch as i32) ^ addr) & !0xFFF
     }
     else {
-        (addr_low as i32 ^ addr) & !0xFFF
+        ((addr_low as i32 + memory::mem8 as i32) ^ addr) & !0xFFF
     }
 }
 
@@ -3326,7 +3328,7 @@ pub unsafe fn safe_write_slow_jit(
 
         let scratch = jit_paging_scratch_buffer.0.as_mut_ptr() as u32;
         dbg_assert!(scratch & 0xFFF == 0);
-        ((scratch as i32 - mem8 as i32) ^ addr) & !0xFFF
+        ((scratch as i32) ^ addr) & !0xFFF
     }
     else if in_mapped_range(addr_low) {
         match bitsize {
@@ -3346,11 +3348,11 @@ pub unsafe fn safe_write_slow_jit(
 
         let scratch = jit_paging_scratch_buffer.0.as_mut_ptr() as u32;
         dbg_assert!(scratch & 0xFFF == 0);
-        ((scratch as i32 - mem8 as i32) ^ addr) & !0xFFF
+        ((scratch as i32) ^ addr) & !0xFFF
     }
     else {
         jit::jit_dirty_page(jit::get_jit_state(), Page::page_of(addr_low));
-        (addr_low as i32 ^ addr) & !0xFFF
+        ((addr_low as i32 + memory::mem8 as i32) ^ addr) & !0xFFF
     }
 }
 
@@ -3864,7 +3866,7 @@ pub unsafe fn get_valid_global_tlb_entries_count() -> i32 {
 pub unsafe fn translate_address_system_read(address: i32) -> OrPageFault<u32> {
     let entry = tlb_data[(address as u32 >> 12) as usize];
     if 0 != entry & TLB_VALID {
-        return Ok((entry & !0xFFF ^ address) as u32);
+        return Ok((entry & !0xFFF ^ address) as u32 - memory::mem8 as u32);
     }
     else {
         return Ok((do_page_translation(address, false, false)? | address & 0xFFF) as u32);
@@ -3874,7 +3876,7 @@ pub unsafe fn translate_address_system_read(address: i32) -> OrPageFault<u32> {
 pub unsafe fn translate_address_system_write(address: i32) -> OrPageFault<u32> {
     let entry = tlb_data[(address as u32 >> 12) as usize];
     if entry & (TLB_VALID | TLB_READONLY) == TLB_VALID {
-        return Ok((entry & !0xFFF ^ address) as u32);
+        return Ok((entry & !0xFFF ^ address) as u32 - memory::mem8 as u32);
     }
     else {
         return Ok((do_page_translation(address, true, false)? | address & 0xFFF) as u32);

--- a/src/rust/jit.rs
+++ b/src/rust/jit.rs
@@ -472,7 +472,7 @@ fn jit_find_basic_blocks(
             let has_next_instruction = !analysis.no_next_instruction;
             current_address = cpu.eip;
 
-            if more_flags && analysis.has_flags_info && comp_flags_len<=MAX_COMP_FLAGS_LEN {
+            if more_flags && analysis.has_flags_info && comp_flags_len<MAX_COMP_FLAGS_LEN {
                     modified_flags[comp_flags_len] = analysis.modified_flags;
                     tested_flags[comp_flags_len] = analysis.tested_flags;                    
                     comp_flags_len = comp_flags_len + 1;

--- a/src/rust/jit.rs
+++ b/src/rust/jit.rs
@@ -1204,7 +1204,9 @@ fn jit_generate_module(
                         // Check if we can stay in this module, if not exit
                         codegen::gen_get_eip(ctx.builder);
                         let new_eip = ctx.builder.set_new_local();
-                        codegen::gen_get_phys_eip(ctx, &new_eip);
+                        codegen::gen_get_phys_eip_plus_mem(ctx, &new_eip);
+                        ctx.builder.const_i32(unsafe { memory::mem8 } as i32);
+                        ctx.builder.sub_i32();
                         ctx.builder.free_local(new_eip);
 
                         ctx.builder.const_i32(wasm_table_index.to_u16() as i32);

--- a/src/rust/jit_instructions.rs
+++ b/src/rust/jit_instructions.rs
@@ -269,7 +269,12 @@ fn group_arith_al_imm8(
 fn group_arith_ax_imm16(ctx: &mut JitContext, op: &str, imm16: u32) {
     codegen::gen_get_reg16(ctx, regs::AX);
     ctx.builder.const_i32(imm16 as i32);
-    ctx.builder.call_fn2_ret(op);
+    if ctx.comp_lazy_flags {
+        ctx.builder.call_fn2_ret(op);
+    }
+    else {
+        ctx.builder.call_fn2_ret(&format!("{}_noflags", op));
+    }
     codegen::gen_set_reg16(ctx, regs::AX);
 }
 
@@ -440,14 +445,24 @@ macro_rules! define_instruction_write_reg16(
         pub fn $name_mem(ctx: &mut JitContext, modrm_byte: ModrmByte, r: u32) {
             codegen::gen_get_reg16(ctx, r);
             codegen::gen_modrm_resolve_safe_read16(ctx, modrm_byte);
-            ctx.builder.call_fn2_ret($fn);
+            if ctx.comp_lazy_flags {
+                ctx.builder.call_fn2_ret($fn);
+            }
+            else {
+                ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+            }
             codegen::gen_set_reg16(ctx, r);
         }
 
         pub fn $name_reg(ctx: &mut JitContext, r1: u32, r2: u32) {
             codegen::gen_get_reg16(ctx, r2);
             codegen::gen_get_reg16(ctx, r1);
-            ctx.builder.call_fn2_ret($fn);
+            if ctx.comp_lazy_flags {
+                ctx.builder.call_fn2_ret($fn);
+            }
+            else {
+                ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+            }
             codegen::gen_set_reg16(ctx, r2);
         }
     )
@@ -515,7 +530,12 @@ macro_rules! define_instruction_read_write_mem8(
             let address_local = ctx.builder.set_new_local();
             codegen::gen_safe_read_write(ctx, BitSize::BYTE, &address_local, &|ref mut ctx| {
                 ctx.builder.const_i32(1);
-                ctx.builder.call_fn2_ret($fn);
+                if ctx.comp_lazy_flags {
+                    ctx.builder.call_fn2_ret($fn);
+                }
+                else {
+                    ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+                }
             });
             ctx.builder.free_local(address_local);
         }
@@ -523,7 +543,12 @@ macro_rules! define_instruction_read_write_mem8(
         pub fn $name_reg(ctx: &mut JitContext, r1: u32) {
             codegen::gen_get_reg8(ctx, r1);
             ctx.builder.const_i32(1);
-            ctx.builder.call_fn2_ret($fn);
+            if ctx.comp_lazy_flags {
+                ctx.builder.call_fn2_ret($fn);
+            }
+            else {
+                ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+            }
             codegen::gen_set_reg8(ctx, r1);
         }
     );
@@ -536,7 +561,12 @@ macro_rules! define_instruction_read_write_mem8(
                 codegen::gen_get_reg8(ctx, regs::CL);
                 ctx.builder.const_i32(31);
                 ctx.builder.and_i32();
-                ctx.builder.call_fn2_ret($fn);
+                if ctx.comp_lazy_flags {
+                    ctx.builder.call_fn2_ret($fn);
+                }
+                else {
+                    ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+                }
             });
             ctx.builder.free_local(address_local);
         }
@@ -546,7 +576,12 @@ macro_rules! define_instruction_read_write_mem8(
             codegen::gen_get_reg8(ctx, regs::CL);
             ctx.builder.const_i32(31);
             ctx.builder.and_i32();
-            ctx.builder.call_fn2_ret($fn);
+            if ctx.comp_lazy_flags {
+                ctx.builder.call_fn2_ret($fn);
+            }
+            else {
+                ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+            }
             codegen::gen_set_reg8(ctx, r1);
         }
     );
@@ -595,7 +630,12 @@ macro_rules! define_instruction_read_write_mem8(
             let imm = mask_imm!(imm, $imm) as i32;
             codegen::gen_safe_read_write(ctx, BitSize::BYTE, &address_local, &|ref mut ctx| {
                 ctx.builder.const_i32(imm as i32);
-                ctx.builder.call_fn2_ret($fn);
+                if ctx.comp_lazy_flags {
+                    ctx.builder.call_fn2_ret($fn);
+                }
+                else {
+                    ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+                }
             });
             ctx.builder.free_local(address_local);
         }
@@ -604,7 +644,12 @@ macro_rules! define_instruction_read_write_mem8(
             let imm = mask_imm!(imm, $imm);
             codegen::gen_get_reg8(ctx, r1);
             ctx.builder.const_i32(imm as i32);
-            ctx.builder.call_fn2_ret($fn);
+            if ctx.comp_lazy_flags {
+                ctx.builder.call_fn2_ret($fn);
+            }
+            else {
+                ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+            }
             codegen::gen_set_reg8(ctx, r1);
         }
     );
@@ -617,7 +662,12 @@ macro_rules! define_instruction_read_write_mem16(
             let address_local = ctx.builder.set_new_local();
             codegen::gen_safe_read_write(ctx, BitSize::WORD, &address_local, &|ref mut ctx| {
                 codegen::gen_get_reg16(ctx, r);
-                ctx.builder.call_fn2_ret($fn);
+                if ctx.comp_lazy_flags {
+                    ctx.builder.call_fn2_ret($fn);
+                }
+                else {
+                    ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+                }
             });
             ctx.builder.free_local(address_local);
         }
@@ -625,7 +675,12 @@ macro_rules! define_instruction_read_write_mem16(
         pub fn $name_reg(ctx: &mut JitContext, r1: u32, r2: u32) {
             codegen::gen_get_reg16(ctx, r1);
             codegen::gen_get_reg16(ctx, r2);
-            ctx.builder.call_fn2_ret($fn);
+            if ctx.comp_lazy_flags {
+                ctx.builder.call_fn2_ret($fn);
+            }
+            else {
+                ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+            }
             codegen::gen_set_reg16(ctx, r1);
         }
     );
@@ -636,7 +691,12 @@ macro_rules! define_instruction_read_write_mem16(
             let address_local = ctx.builder.set_new_local();
             codegen::gen_safe_read_write(ctx, BitSize::WORD, &address_local, &|ref mut ctx| {
                 ctx.builder.const_i32(1);
-                ctx.builder.call_fn2_ret($fn);
+                if ctx.comp_lazy_flags {
+                    ctx.builder.call_fn2_ret($fn);
+                }
+                else {
+                    ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+                }
             });
             ctx.builder.free_local(address_local);
         }
@@ -644,7 +704,12 @@ macro_rules! define_instruction_read_write_mem16(
         pub fn $name_reg(ctx: &mut JitContext, r1: u32) {
             codegen::gen_get_reg16(ctx, r1);
             ctx.builder.const_i32(1);
-            ctx.builder.call_fn2_ret($fn);
+            if ctx.comp_lazy_flags {
+                ctx.builder.call_fn2_ret($fn);
+            }
+            else {
+                ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+            }
             codegen::gen_set_reg16(ctx, r1);
         }
     );
@@ -657,7 +722,12 @@ macro_rules! define_instruction_read_write_mem16(
                 codegen::gen_get_reg8(ctx, regs::CL);
                 ctx.builder.const_i32(31);
                 ctx.builder.and_i32();
-                ctx.builder.call_fn2_ret($fn);
+                if ctx.comp_lazy_flags {
+                    ctx.builder.call_fn2_ret($fn);
+                }
+                else {
+                    ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+                }
             });
             ctx.builder.free_local(address_local);
         }
@@ -667,7 +737,12 @@ macro_rules! define_instruction_read_write_mem16(
             codegen::gen_get_reg8(ctx, regs::CL);
                 ctx.builder.const_i32(31);
                 ctx.builder.and_i32();
-            ctx.builder.call_fn2_ret($fn);
+            if ctx.comp_lazy_flags {
+                ctx.builder.call_fn2_ret($fn);
+            }
+            else {
+                ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+            }
             codegen::gen_set_reg16(ctx, r1);
         }
     );
@@ -745,7 +820,12 @@ macro_rules! define_instruction_read_write_mem16(
             let imm = mask_imm!(imm, $imm) as i32;
             codegen::gen_safe_read_write(ctx, BitSize::WORD, &address_local, &|ref mut ctx| {
                 ctx.builder.const_i32(imm as i32);
-                ctx.builder.call_fn2_ret($fn);
+                if ctx.comp_lazy_flags {
+                    ctx.builder.call_fn2_ret($fn);
+                }
+                else {
+                    ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+                }
             });
             ctx.builder.free_local(address_local);
         }
@@ -754,7 +834,12 @@ macro_rules! define_instruction_read_write_mem16(
             let imm = mask_imm!(imm, $imm);
             codegen::gen_get_reg16(ctx, r1);
             ctx.builder.const_i32(imm as i32);
-            ctx.builder.call_fn2_ret($fn);
+            if ctx.comp_lazy_flags {
+                ctx.builder.call_fn2_ret($fn);
+            }
+            else {
+                ctx.builder.call_fn2_ret(&format!("{}_noflags", $fn));
+            }
             codegen::gen_set_reg16(ctx, r1);
         }
     );
@@ -927,79 +1012,106 @@ macro_rules! define_instruction_read_write_mem32(
 );
 
 fn gen_add8(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
+    if ctx.comp_lazy_flags {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
 
-    ctx.builder.const_i32(global_pointers::last_op1 as i32);
-    ctx.builder.get_local(dest_operand);
-    ctx.builder.const_i32(0xFF);
-    ctx.builder.and_i32();
-    ctx.builder.store_aligned_i32(0);
+        ctx.builder.const_i32(global_pointers::last_op1 as i32);
+        ctx.builder.get_local(dest_operand);
+        ctx.builder.const_i32(0xFF);
+        ctx.builder.and_i32();
+        ctx.builder.store_aligned_i32(0);
 
-    ctx.builder.const_i32(global_pointers::last_result as i32);
-    ctx.builder.get_local(dest_operand);
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.add_i32();
-    ctx.builder.const_i32(0xFF);
-    ctx.builder.and_i32();
-    ctx.builder.store_aligned_i32(0);
+        ctx.builder.const_i32(global_pointers::last_result as i32);
+        ctx.builder.get_local(dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.add_i32();
+        ctx.builder.const_i32(0xFF);
+        ctx.builder.and_i32();
+        ctx.builder.store_aligned_i32(0);
 
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
-    codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
+        codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL);
 
-    ctx.builder
-        .load_fixed_u8(global_pointers::last_result as u32);
+        ctx.builder.load_fixed_u8(global_pointers::last_result as u32);
+    }
+    else {        
+        ctx.builder.get_local(dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.add_i32();
+        ctx.builder.const_i32(0xFF);
+        ctx.builder.and_i32();
+    }
 }
 fn gen_add32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_32 };
-
-    codegen::gen_set_last_op1(ctx.builder, &dest_operand);
+    if ctx.comp_lazy_flags    
+    {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_32 };
+        codegen::gen_set_last_op1(ctx.builder, &dest_operand);
+    }
 
     ctx.builder.get_local(&dest_operand);
     source_operand.gen_get(ctx.builder);
     ctx.builder.add_i32();
     ctx.builder.set_local(dest_operand);
 
-    codegen::gen_set_last_result(ctx.builder, &dest_operand);
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL);
+    if ctx.comp_lazy_flags
+    {
+        codegen::gen_set_last_result(ctx.builder, &dest_operand);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL);
+    }
 }
-
 fn gen_sub8(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
+    if ctx.comp_lazy_flags {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
 
-    ctx.builder.const_i32(global_pointers::last_op1 as i32);
-    ctx.builder.get_local(dest_operand);
-    ctx.builder.const_i32(0xFF);
-    ctx.builder.and_i32();
-    ctx.builder.store_aligned_i32(0);
+        ctx.builder.const_i32(global_pointers::last_op1 as i32);
+        ctx.builder.get_local(dest_operand);
+        ctx.builder.const_i32(0xFF);
+        ctx.builder.and_i32();
+        ctx.builder.store_aligned_i32(0);
 
-    ctx.builder.const_i32(global_pointers::last_result as i32);
-    ctx.builder.get_local(dest_operand);
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.sub_i32();
-    ctx.builder.const_i32(0xFF);
-    ctx.builder.and_i32();
-    ctx.builder.store_aligned_i32(0);
+        ctx.builder.const_i32(global_pointers::last_result as i32);
+        ctx.builder.get_local(dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.sub_i32();
+        ctx.builder.const_i32(0xFF);
+        ctx.builder.and_i32();
+        ctx.builder.store_aligned_i32(0);
 
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
-    codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL | FLAG_SUB);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
+        codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL | FLAG_SUB);
 
-    ctx.builder
-        .load_fixed_u8(global_pointers::last_result as u32);
+        ctx.builder
+            .load_fixed_u8(global_pointers::last_result as u32);
+    }
+    else {
+        ctx.builder.get_local(dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.sub_i32();
+        ctx.builder.const_i32(0xFF);
+        ctx.builder.and_i32();        
+    }
 }
-fn gen_sub32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Sub { opsize: OPSIZE_32 };
 
-    codegen::gen_set_last_op1(ctx.builder, &dest_operand);
+fn gen_sub32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
+    if ctx.comp_lazy_flags    
+    {
+        ctx.last_instruction = Instruction::Sub { opsize: OPSIZE_32 };
+        codegen::gen_set_last_op1(ctx.builder, &dest_operand);
+    }
 
     ctx.builder.get_local(&dest_operand);
     source_operand.gen_get(ctx.builder);
     ctx.builder.sub_i32();
     ctx.builder.set_local(dest_operand);
 
-    codegen::gen_set_last_result(ctx.builder, &dest_operand);
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL | FLAG_SUB);
+    if ctx.comp_lazy_flags
+    {
+        codegen::gen_set_last_result(ctx.builder, &dest_operand);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL | FLAG_SUB);
+    }
 }
 
 fn gen_cmp(
@@ -1008,6 +1120,8 @@ fn gen_cmp(
     source_operand: &LocalOrImmediate,
     size: i32,
 ) {
+    // no point in checking regular code for dummy cmp to avoid flags calculation ....
+
     ctx.last_instruction = Instruction::Cmp {
         dest: if ctx.register_locals.iter().any(|l| l == dest_operand) {
             InstructionOperand::WasmLocal(dest_operand.unsafe_clone())
@@ -1071,7 +1185,12 @@ fn gen_adc8(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Loc
     ctx.builder.const_i32(0xFF);
     ctx.builder.and_i32();
     source_operand.gen_get_mask255(ctx.builder);
-    ctx.builder.call_fn2_ret("adc8");
+    if ctx.comp_lazy_flags {
+        ctx.builder.call_fn2_ret("adc8");
+    } 
+    else {
+        ctx.builder.call_fn2_ret("adc8_noflags");
+    } 
     ctx.builder.const_i32(0xFF);
     ctx.builder.and_i32();
 }
@@ -1081,74 +1200,84 @@ fn gen_adc32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
     ctx.builder.add_i32();
     codegen::gen_getcf_unoptimised(ctx.builder);
     ctx.builder.add_i32();
-    let res = ctx.builder.set_new_local();
 
-    codegen::gen_set_last_result(ctx.builder, &res);
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(
-        ctx.builder,
-        FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
-    );
+    if ctx.comp_lazy_flags    
+    {
+        let res = ctx.builder.set_new_local();
 
-    ctx.builder.const_i32(global_pointers::flags as i32);
-    codegen::gen_get_flags(ctx.builder);
-    ctx.builder
-        .const_i32(!FLAG_CARRY & !FLAG_ADJUST & !FLAG_OVERFLOW);
-    ctx.builder.and_i32();
+        codegen::gen_set_last_result(ctx.builder, &res);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(
+            ctx.builder,
+            FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
+        );
 
-    // cf: (dest_operand ^ ((dest_operand ^ source_operand) & (source_operand ^ res))) >> op_size & FLAG_CARRY
-    ctx.builder.get_local(&dest_operand);
-    ctx.builder.get_local(&dest_operand);
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.xor_i32();
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.get_local(&res);
-    ctx.builder.xor_i32();
-    ctx.builder.and_i32();
-    ctx.builder.xor_i32();
-    ctx.builder.const_i32(31);
-    ctx.builder.shr_u_i32();
-    ctx.builder.const_i32(FLAG_CARRY);
-    ctx.builder.and_i32();
-    ctx.builder.or_i32();
+        ctx.builder.const_i32(global_pointers::flags as i32);
+        codegen::gen_get_flags(ctx.builder);
+        ctx.builder
+            .const_i32(!FLAG_CARRY & !FLAG_ADJUST & !FLAG_OVERFLOW);
+        ctx.builder.and_i32();
 
-    // af: (dest_operand ^ source_operand ^ res) & FLAG_ADJUST
-    ctx.builder.get_local(&dest_operand);
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.get_local(&res);
-    ctx.builder.xor_i32();
-    ctx.builder.xor_i32();
-    ctx.builder.const_i32(FLAG_ADJUST);
-    ctx.builder.and_i32();
-    ctx.builder.or_i32();
+        // cf: (dest_operand ^ ((dest_operand ^ source_operand) & (source_operand ^ res))) >> op_size & FLAG_CARRY
+        ctx.builder.get_local(&dest_operand);
+        ctx.builder.get_local(&dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.xor_i32();
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.get_local(&res);
+        ctx.builder.xor_i32();
+        ctx.builder.and_i32();
+        ctx.builder.xor_i32();
+        ctx.builder.const_i32(31);
+        ctx.builder.shr_u_i32();
+        ctx.builder.const_i32(FLAG_CARRY);
+        ctx.builder.and_i32();
+        ctx.builder.or_i32();
 
-    // of: ((source_operand ^ res) & (dest_operand ^ res)) >> op_size << 11 & FLAG_OVERFLOW
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.get_local(&res);
-    ctx.builder.xor_i32();
-    ctx.builder.get_local(&dest_operand);
-    ctx.builder.get_local(&res);
-    ctx.builder.xor_i32();
-    ctx.builder.and_i32();
-    ctx.builder.const_i32(31 - 11);
-    ctx.builder.shr_u_i32();
-    ctx.builder.const_i32(FLAG_OVERFLOW);
-    ctx.builder.and_i32();
-    ctx.builder.or_i32();
+        // af: (dest_operand ^ source_operand ^ res) & FLAG_ADJUST
+        ctx.builder.get_local(&dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.get_local(&res);
+        ctx.builder.xor_i32();
+        ctx.builder.xor_i32();
+        ctx.builder.const_i32(FLAG_ADJUST);
+        ctx.builder.and_i32();
+        ctx.builder.or_i32();
 
-    ctx.builder.store_aligned_i32(0);
+        // of: ((source_operand ^ res) & (dest_operand ^ res)) >> op_size << 11 & FLAG_OVERFLOW
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.get_local(&res);
+        ctx.builder.xor_i32();
+        ctx.builder.get_local(&dest_operand);
+        ctx.builder.get_local(&res);
+        ctx.builder.xor_i32();
+        ctx.builder.and_i32();
+        ctx.builder.const_i32(31 - 11);
+        ctx.builder.shr_u_i32();
+        ctx.builder.const_i32(FLAG_OVERFLOW);
+        ctx.builder.and_i32();
+        ctx.builder.or_i32();
 
-    ctx.builder.get_local(&res);
+        ctx.builder.store_aligned_i32(0);
+
+        ctx.builder.get_local(&res);
+
+        ctx.builder.free_local(res);
+    }
+
     ctx.builder.set_local(dest_operand);
-    ctx.builder.free_local(res);
 }
-
 fn gen_sbb8(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
     ctx.builder.get_local(dest_operand);
     ctx.builder.const_i32(0xFF);
     ctx.builder.and_i32();
     source_operand.gen_get_mask255(ctx.builder);
-    ctx.builder.call_fn2_ret("sbb8");
+    if ctx.comp_lazy_flags {
+        ctx.builder.call_fn2_ret("sbb8");
+    }
+    else {
+        ctx.builder.call_fn2_ret("sbb8_noflags");
+    }
     ctx.builder.const_i32(0xFF);
     ctx.builder.and_i32();
 }
@@ -1158,102 +1287,122 @@ fn gen_sbb32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
     ctx.builder.sub_i32();
     codegen::gen_getcf_unoptimised(ctx.builder);
     ctx.builder.sub_i32();
-    let res = ctx.builder.set_new_local();
+    
+    if ctx.comp_lazy_flags
+    {
+        let res = ctx.builder.set_new_local();
+    
+        codegen::gen_set_last_result(ctx.builder, &res);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(
+            ctx.builder,
+            FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
+        );
 
-    codegen::gen_set_last_result(ctx.builder, &res);
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(
-        ctx.builder,
-        FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
-    );
+        ctx.builder.const_i32(global_pointers::flags as i32);
+        codegen::gen_get_flags(ctx.builder);
+        ctx.builder
+            .const_i32(!FLAG_CARRY & !FLAG_ADJUST & !FLAG_OVERFLOW);
+        ctx.builder.and_i32();
 
-    ctx.builder.const_i32(global_pointers::flags as i32);
-    codegen::gen_get_flags(ctx.builder);
-    ctx.builder
-        .const_i32(!FLAG_CARRY & !FLAG_ADJUST & !FLAG_OVERFLOW);
-    ctx.builder.and_i32();
+        // cf: (res ^ ((res ^ source_operand) & (source_operand ^ dest_operand))) >> op_size & FLAG_CARRY
+        ctx.builder.get_local(&res);
+        ctx.builder.get_local(&res);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.xor_i32();
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.get_local(&dest_operand);
+        ctx.builder.xor_i32();
+        ctx.builder.and_i32();
+        ctx.builder.xor_i32();
+        ctx.builder.const_i32(31);
+        ctx.builder.shr_u_i32();
+        ctx.builder.const_i32(FLAG_CARRY);
+        ctx.builder.and_i32();
+        ctx.builder.or_i32();
 
-    // cf: (res ^ ((res ^ source_operand) & (source_operand ^ dest_operand))) >> op_size & FLAG_CARRY
-    ctx.builder.get_local(&res);
-    ctx.builder.get_local(&res);
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.xor_i32();
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.get_local(&dest_operand);
-    ctx.builder.xor_i32();
-    ctx.builder.and_i32();
-    ctx.builder.xor_i32();
-    ctx.builder.const_i32(31);
-    ctx.builder.shr_u_i32();
-    ctx.builder.const_i32(FLAG_CARRY);
-    ctx.builder.and_i32();
-    ctx.builder.or_i32();
+        // af: (dest_operand ^ source_operand ^ res) & FLAG_ADJUST
+        ctx.builder.get_local(&dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.get_local(&res);
+        ctx.builder.xor_i32();
+        ctx.builder.xor_i32();
+        ctx.builder.const_i32(FLAG_ADJUST);
+        ctx.builder.and_i32();
+        ctx.builder.or_i32();
 
-    // af: (dest_operand ^ source_operand ^ res) & FLAG_ADJUST
-    ctx.builder.get_local(&dest_operand);
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.get_local(&res);
-    ctx.builder.xor_i32();
-    ctx.builder.xor_i32();
-    ctx.builder.const_i32(FLAG_ADJUST);
-    ctx.builder.and_i32();
-    ctx.builder.or_i32();
+        // of: ((source_operand ^ dest_operand) & (res ^ dest_operand)) >> op_size << 11 & FLAG_OVERFLOW
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.get_local(&dest_operand);
+        ctx.builder.xor_i32();
+        ctx.builder.get_local(&res);
+        ctx.builder.get_local(&dest_operand);
+        ctx.builder.xor_i32();
+        ctx.builder.and_i32();
+        ctx.builder.const_i32(31 - 11);
+        ctx.builder.shr_u_i32();
+        ctx.builder.const_i32(FLAG_OVERFLOW);
+        ctx.builder.and_i32();
+        ctx.builder.or_i32();
 
-    // of: ((source_operand ^ dest_operand) & (res ^ dest_operand)) >> op_size << 11 & FLAG_OVERFLOW
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.get_local(&dest_operand);
-    ctx.builder.xor_i32();
-    ctx.builder.get_local(&res);
-    ctx.builder.get_local(&dest_operand);
-    ctx.builder.xor_i32();
-    ctx.builder.and_i32();
-    ctx.builder.const_i32(31 - 11);
-    ctx.builder.shr_u_i32();
-    ctx.builder.const_i32(FLAG_OVERFLOW);
-    ctx.builder.and_i32();
-    ctx.builder.or_i32();
+        ctx.builder.store_aligned_i32(0);
 
-    ctx.builder.store_aligned_i32(0);
-
-    ctx.builder.get_local(&res);
-    ctx.builder.set_local(dest_operand);
-    ctx.builder.free_local(res);
+        ctx.builder.get_local(&res);
+        ctx.builder.free_local(res);
+    }
+    
+    ctx.builder.set_local(dest_operand);    
 }
 
 fn gen_and8(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
+    if ctx.comp_lazy_flags {    
+        ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
 
-    ctx.builder.const_i32(global_pointers::last_result as i32);
-    ctx.builder.get_local(dest_operand);
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.and_i32();
-    ctx.builder.store_aligned_i32(0);
+        ctx.builder.const_i32(global_pointers::last_result as i32);
+        ctx.builder.get_local(dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.and_i32();
+        ctx.builder.store_aligned_i32(0);
 
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
-    codegen::gen_set_flags_changed(
-        ctx.builder,
-        FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
-    );
-    codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
+        codegen::gen_set_flags_changed(
+            ctx.builder,
+            FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
+        );
+        codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
 
-    ctx.builder
-        .load_fixed_u8(global_pointers::last_result as u32);
+        ctx.builder
+            .load_fixed_u8(global_pointers::last_result as u32);
+    }
+    else {
+        ctx.builder.get_local(dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.and_i32();
+        ctx.builder.const_i32(0xFF);
+        ctx.builder.and_i32();
+    }
 }
+
 fn gen_and32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_32 };
+    if ctx.comp_lazy_flags {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_32 };
+    }
 
     ctx.builder.get_local(&dest_operand);
     source_operand.gen_get(ctx.builder);
     ctx.builder.and_i32();
     ctx.builder.set_local(dest_operand);
 
-    codegen::gen_set_last_result(ctx.builder, &dest_operand);
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(
-        ctx.builder,
-        FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
-    );
-    codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
+    if ctx.comp_lazy_flags
+    {
+        codegen::gen_set_last_result(ctx.builder, &dest_operand);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(
+            ctx.builder,
+            FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
+        );
+        codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
+    }
 }
 
 fn gen_test(
@@ -1262,6 +1411,8 @@ fn gen_test(
     source_operand: &LocalOrImmediate,
     size: i32,
 ) {
+    // no point in optimizing test to not output flags
+
     ctx.last_instruction = Instruction::Arithmetic { opsize: size };
 
     ctx.builder.const_i32(global_pointers::last_result as i32);
@@ -1293,62 +1444,87 @@ fn gen_test32(ctx: &mut JitContext, dest: &WasmLocal, source: &LocalOrImmediate)
 }
 
 fn gen_or8(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
+    if ctx.comp_lazy_flags
+    {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
 
-    ctx.builder.const_i32(global_pointers::last_result as i32);
-    ctx.builder.get_local(dest_operand);
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.or_i32();
-    ctx.builder.store_aligned_i32(0);
+        ctx.builder.const_i32(global_pointers::last_result as i32);
+        ctx.builder.get_local(dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.or_i32();
+        ctx.builder.store_aligned_i32(0);
 
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
-    codegen::gen_set_flags_changed(
-        ctx.builder,
-        FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
-    );
-    codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
+        codegen::gen_set_flags_changed(
+            ctx.builder,
+            FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
+        );
+        codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
 
-    ctx.builder
-        .load_fixed_u8(global_pointers::last_result as u32);
+        ctx.builder
+            .load_fixed_u8(global_pointers::last_result as u32);
+    }
+    else {
+        ctx.builder.get_local(dest_operand);        
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.or_i32();
+        ctx.builder.const_i32(0xff);
+        ctx.builder.and_i32();
+    }
 }
 fn gen_or32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_32 };
+    if ctx.comp_lazy_flags {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_32 };
+    }
 
     ctx.builder.get_local(&dest_operand);
     source_operand.gen_get(ctx.builder);
     ctx.builder.or_i32();
     ctx.builder.set_local(dest_operand);
 
-    codegen::gen_set_last_result(ctx.builder, &dest_operand);
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(
-        ctx.builder,
-        FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
-    );
-    codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
+    if ctx.comp_lazy_flags
+    {
+        codegen::gen_set_last_result(ctx.builder, &dest_operand);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(
+            ctx.builder,
+            FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
+        );
+        codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
+    }
 }
-
 fn gen_xor8(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
+    if ctx.comp_lazy_flags {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_8 };
 
-    ctx.builder.const_i32(global_pointers::last_result as i32);
-    ctx.builder.get_local(dest_operand);
-    source_operand.gen_get(ctx.builder);
-    ctx.builder.xor_i32();
-    ctx.builder.store_aligned_i32(0);
+        ctx.builder.const_i32(global_pointers::last_result as i32);
+        ctx.builder.get_local(dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.xor_i32();
+        ctx.builder.store_aligned_i32(0);
 
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
-    codegen::gen_set_flags_changed(
-        ctx.builder,
-        FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
-    );
-    codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_8);
+        codegen::gen_set_flags_changed(
+            ctx.builder,
+            FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
+        );
+        codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
 
-    ctx.builder
-        .load_fixed_u8(global_pointers::last_result as u32);
+        ctx.builder
+            .load_fixed_u8(global_pointers::last_result as u32);
+    }
+    else {
+        ctx.builder.get_local(dest_operand);
+        source_operand.gen_get(ctx.builder);
+        ctx.builder.xor_i32();
+        ctx.builder.const_i32(0xff);
+        ctx.builder.and_i32();        
+    }
 }
 fn gen_xor32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_32 };
+    if ctx.comp_lazy_flags {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: OPSIZE_32 };
+    }
 
     if source_operand.eq_local(dest_operand) {
         ctx.builder.const_i32(0);
@@ -1364,13 +1540,16 @@ fn gen_xor32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
         ctx.builder.set_local(dest_operand);
     }
 
-    codegen::gen_set_last_result(ctx.builder, &dest_operand);
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(
-        ctx.builder,
-        FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
-    );
-    codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
+    if ctx.comp_lazy_flags
+    {
+        codegen::gen_set_last_result(ctx.builder, &dest_operand);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(
+            ctx.builder,
+            FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW & !FLAG_ADJUST,
+        );
+        codegen::gen_clear_flags_bits(ctx.builder, FLAG_CARRY | FLAG_OVERFLOW | FLAG_ADJUST);
+    }
 }
 
 fn gen_rol32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
@@ -1388,7 +1567,12 @@ fn gen_rol32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
     }
     builder.const_i32(31);
     builder.and_i32();
-    builder.call_fn2_ret("rol32");
+    if ctx.comp_lazy_flags {
+        builder.call_fn2_ret("rol32");
+    }
+    else {
+        builder.call_fn2_ret("rol32_noflags");
+    }
     builder.set_local(dest_operand);
 }
 fn gen_ror32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
@@ -1406,7 +1590,12 @@ fn gen_ror32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
     }
     builder.const_i32(31);
     builder.and_i32();
-    builder.call_fn2_ret("ror32");
+    if ctx.comp_lazy_flags {
+        builder.call_fn2_ret("ror32");
+    }
+    else {
+        builder.call_fn2_ret("ror32_noflags");
+    }
     builder.set_local(dest_operand);
 }
 
@@ -1425,7 +1614,12 @@ fn gen_rcl32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
     }
     builder.const_i32(31);
     builder.and_i32();
-    builder.call_fn2_ret("rcl32");
+    if ctx.comp_lazy_flags {
+        builder.call_fn2_ret("rcl32");
+    }
+    else {
+        builder.call_fn2_ret("rcl32_noflags");
+    }
     builder.set_local(dest_operand);
 }
 fn gen_rcr32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
@@ -1443,7 +1637,12 @@ fn gen_rcr32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
     }
     builder.const_i32(31);
     builder.and_i32();
-    builder.call_fn2_ret("rcr32");
+    if ctx.comp_lazy_flags {
+        builder.call_fn2_ret("rcr32");
+    }
+    else {
+        builder.call_fn2_ret("rcr32_noflags");
+    }
     builder.set_local(dest_operand);
 }
 
@@ -1501,43 +1700,52 @@ fn gen_shl32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
         },
     };
 
-    builder.get_local(&dest_operand);
-    ShiftCount::gen_get_thirtytwo_minus(builder, &count);
-    builder.shr_u_i32();
-    builder.const_i32(1);
-    builder.and_i32();
-    let b = builder.set_new_local();
+    if ctx.comp_lazy_flags {
 
-    builder.get_local(dest_operand);
-    ShiftCount::gen_get(builder, &count);
-    builder.shl_i32();
-    builder.set_local(dest_operand);
-
-    codegen::gen_set_last_result(builder, dest_operand);
-    codegen::gen_set_last_op_size(builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(builder, FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW);
-
-    builder.const_i32(global_pointers::flags as i32);
-    codegen::gen_get_flags(builder);
-    builder.const_i32(!(FLAG_CARRY | FLAG_OVERFLOW));
-    builder.and_i32();
-    builder.get_local(&b);
-    builder.or_i32();
-    {
-        builder.get_local(&b);
         builder.get_local(&dest_operand);
-        builder.const_i32(31);
+        ShiftCount::gen_get_thirtytwo_minus(builder, &count);
         builder.shr_u_i32();
-        builder.xor_i32();
-        builder.const_i32(11);
-        builder.shl_i32();
-        builder.const_i32(FLAG_OVERFLOW);
+        builder.const_i32(1);
         builder.and_i32();
-        builder.or_i32();
-    }
-    builder.store_aligned_i32(0);
+        let b = builder.set_new_local();
 
-    builder.free_local(b);
+        builder.get_local(dest_operand);
+        ShiftCount::gen_get(builder, &count);
+        builder.shl_i32();
+        builder.set_local(dest_operand);
+
+        codegen::gen_set_last_result(builder, dest_operand);
+        codegen::gen_set_last_op_size(builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(builder, FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW);
+
+        builder.const_i32(global_pointers::flags as i32);
+        codegen::gen_get_flags(builder);
+        builder.const_i32(!(FLAG_CARRY | FLAG_OVERFLOW));
+        builder.and_i32();
+        builder.get_local(&b);
+        builder.or_i32();
+        {
+            builder.get_local(&b);
+            builder.get_local(&dest_operand);
+            builder.const_i32(31);
+            builder.shr_u_i32();
+            builder.xor_i32();
+            builder.const_i32(11);
+            builder.shl_i32();
+            builder.const_i32(FLAG_OVERFLOW);
+            builder.and_i32();
+            builder.or_i32();
+        }
+        builder.store_aligned_i32(0);
+
+        builder.free_local(b);
+    }
+    else {
+        builder.get_local(dest_operand);
+        ShiftCount::gen_get(builder, &count);
+        builder.shl_i32();
+        builder.set_local(dest_operand);
+    }
 
     if let ShiftCount::Local(l) = count {
         builder.block_end();
@@ -1565,36 +1773,44 @@ fn gen_shr32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
         },
     };
 
-    builder.const_i32(global_pointers::flags as i32);
-    codegen::gen_get_flags(builder);
-    builder.const_i32(!(FLAG_CARRY | FLAG_OVERFLOW));
-    builder.and_i32();
-    {
-        builder.get_local(dest_operand);
-        ShiftCount::gen_get_minus_one(builder, &count);
-        builder.shr_u_i32();
-        builder.const_i32(1);
+    if ctx.comp_lazy_flags {
+        builder.const_i32(global_pointers::flags as i32);
+        codegen::gen_get_flags(builder);
+        builder.const_i32(!(FLAG_CARRY | FLAG_OVERFLOW));
         builder.and_i32();
-        builder.or_i32()
-    }
-    {
+        {
+            builder.get_local(dest_operand);
+            ShiftCount::gen_get_minus_one(builder, &count);
+            builder.shr_u_i32();
+            builder.const_i32(1);
+            builder.and_i32();
+            builder.or_i32()
+        }
+        {
+            builder.get_local(dest_operand);
+            builder.const_i32(20);
+            builder.shr_u_i32();
+            builder.const_i32(FLAG_OVERFLOW);
+            builder.and_i32();
+            builder.or_i32()
+        }
+        builder.store_aligned_i32(0);
+
         builder.get_local(dest_operand);
-        builder.const_i32(20);
+        ShiftCount::gen_get(builder, &count);
         builder.shr_u_i32();
-        builder.const_i32(FLAG_OVERFLOW);
-        builder.and_i32();
-        builder.or_i32()
+        builder.set_local(dest_operand);
+
+        codegen::gen_set_last_result(builder, dest_operand);
+        codegen::gen_set_last_op_size(builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(builder, FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW);
     }
-    builder.store_aligned_i32(0);
-
-    builder.get_local(dest_operand);
-    ShiftCount::gen_get(builder, &count);
-    builder.shr_u_i32();
-    builder.set_local(dest_operand);
-
-    codegen::gen_set_last_result(builder, dest_operand);
-    codegen::gen_set_last_op_size(builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(builder, FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW);
+    else {
+        builder.get_local(dest_operand);
+        ShiftCount::gen_get(builder, &count);
+        builder.shr_u_i32();
+        builder.set_local(dest_operand);
+    }
 
     if let ShiftCount::Local(l) = count {
         builder.block_end();
@@ -1622,28 +1838,36 @@ fn gen_sar32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &Lo
         },
     };
 
-    builder.const_i32(global_pointers::flags as i32);
-    codegen::gen_get_flags(builder);
-    builder.const_i32(!(FLAG_CARRY | FLAG_OVERFLOW));
-    builder.and_i32();
-    {
-        builder.get_local(dest_operand);
-        ShiftCount::gen_get_minus_one(builder, &count);
-        builder.shr_u_i32();
-        builder.const_i32(1);
+    if ctx.comp_lazy_flags {
+        builder.const_i32(global_pointers::flags as i32);
+        codegen::gen_get_flags(builder);
+        builder.const_i32(!(FLAG_CARRY | FLAG_OVERFLOW));
         builder.and_i32();
-        builder.or_i32()
+        {
+            builder.get_local(dest_operand);
+            ShiftCount::gen_get_minus_one(builder, &count);
+            builder.shr_u_i32();
+            builder.const_i32(1);
+            builder.and_i32();
+            builder.or_i32()
+        }
+        builder.store_aligned_i32(0);
+
+        builder.get_local(dest_operand);
+        ShiftCount::gen_get(builder, &count);
+        builder.shr_s_i32();
+        builder.set_local(dest_operand);
+
+        codegen::gen_set_last_result(builder, dest_operand);
+        codegen::gen_set_last_op_size(builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(builder, FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW);
     }
-    builder.store_aligned_i32(0);
-
-    builder.get_local(dest_operand);
-    ShiftCount::gen_get(builder, &count);
-    builder.shr_s_i32();
-    builder.set_local(dest_operand);
-
-    codegen::gen_set_last_result(builder, dest_operand);
-    codegen::gen_set_last_op_size(builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(builder, FLAGS_ALL & !FLAG_CARRY & !FLAG_OVERFLOW);
+    else {
+        builder.get_local(dest_operand);
+        ShiftCount::gen_get(builder, &count);
+        builder.shr_s_i32();
+        builder.set_local(dest_operand);
+    }
 
     if let ShiftCount::Local(l) = count {
         builder.block_end();
@@ -1699,16 +1923,18 @@ fn gen_mul32(ctx: &mut JitContext) {
     ctx.builder.wrap_i64_to_i32();
     codegen::gen_set_reg32(ctx, regs::EAX);
 
-    codegen::gen_get_reg32(ctx, regs::EDX);
-    ctx.builder.if_void();
-    codegen::gen_set_flags_bits(ctx.builder, 1 | FLAG_OVERFLOW);
-    ctx.builder.else_();
-    codegen::gen_clear_flags_bits(ctx.builder, 1 | FLAG_OVERFLOW);
-    ctx.builder.block_end();
+    if ctx.comp_lazy_flags {
+        codegen::gen_get_reg32(ctx, regs::EDX);
+        ctx.builder.if_void();
+        codegen::gen_set_flags_bits(ctx.builder, 1 | FLAG_OVERFLOW);
+        ctx.builder.else_();
+        codegen::gen_clear_flags_bits(ctx.builder, 1 | FLAG_OVERFLOW);
+        ctx.builder.block_end();
 
-    codegen::gen_set_last_result(ctx.builder, &ctx.register_locals[regs::EAX as usize]);
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL & !1 & !FLAG_OVERFLOW);
+        codegen::gen_set_last_result(ctx.builder, &ctx.register_locals[regs::EAX as usize]);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL & !1 & !FLAG_OVERFLOW);
+    }
 }
 
 fn gen_imul32(ctx: &mut JitContext) {
@@ -1729,20 +1955,22 @@ fn gen_imul32(ctx: &mut JitContext) {
     ctx.builder.wrap_i64_to_i32();
     codegen::gen_set_reg32(ctx, regs::EAX);
 
-    codegen::gen_get_reg32(ctx, regs::EDX);
-    codegen::gen_get_reg32(ctx, regs::EAX);
-    ctx.builder.const_i32(31);
-    ctx.builder.shr_s_i32();
-    ctx.builder.eq_i32();
-    ctx.builder.if_void();
-    codegen::gen_clear_flags_bits(ctx.builder, 1 | FLAG_OVERFLOW);
-    ctx.builder.else_();
-    codegen::gen_set_flags_bits(ctx.builder, 1 | FLAG_OVERFLOW);
-    ctx.builder.block_end();
+    if ctx.comp_lazy_flags {
+        codegen::gen_get_reg32(ctx, regs::EDX);
+        codegen::gen_get_reg32(ctx, regs::EAX);
+        ctx.builder.const_i32(31);
+        ctx.builder.shr_s_i32();
+        ctx.builder.eq_i32();
+        ctx.builder.if_void();
+        codegen::gen_clear_flags_bits(ctx.builder, 1 | FLAG_OVERFLOW);
+        ctx.builder.else_();
+        codegen::gen_set_flags_bits(ctx.builder, 1 | FLAG_OVERFLOW);
+        ctx.builder.block_end();
 
-    codegen::gen_set_last_result(ctx.builder, &ctx.register_locals[regs::EAX as usize]);
-    codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL & !1 & !FLAG_OVERFLOW);
+        codegen::gen_set_last_result(ctx.builder, &ctx.register_locals[regs::EAX as usize]);
+        codegen::gen_set_last_op_size(ctx.builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(ctx.builder, FLAGS_ALL & !1 & !FLAG_OVERFLOW);
+    }
 }
 
 fn gen_imul_reg32(
@@ -1750,7 +1978,7 @@ fn gen_imul_reg32(
     dest_operand: &WasmLocal,
     source_operand: &LocalOrImmediate,
 ) {
-    gen_imul3_reg32(ctx.builder, dest_operand, dest_operand, source_operand);
+    gen_imul3_reg32(ctx.builder, dest_operand, dest_operand, source_operand, ctx.comp_lazy_flags);
 }
 
 fn gen_imul3_reg32(
@@ -1758,6 +1986,7 @@ fn gen_imul3_reg32(
     dest_operand: &WasmLocal,
     source_operand1: &WasmLocal,
     source_operand2: &LocalOrImmediate,
+    comp_lazy_flags: bool
 ) {
     builder.get_local(&source_operand1);
     builder.extend_signed_i32_to_i64();
@@ -1769,23 +1998,25 @@ fn gen_imul3_reg32(
     builder.wrap_i64_to_i32();
     builder.set_local(&dest_operand);
 
-    codegen::gen_set_last_result(builder, &dest_operand);
-    codegen::gen_set_last_op_size(builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(builder, FLAGS_ALL & !1 & !FLAG_OVERFLOW);
+    if comp_lazy_flags {
+        codegen::gen_set_last_result(builder, &dest_operand);
+        codegen::gen_set_last_op_size(builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(builder, FLAGS_ALL & !1 & !FLAG_OVERFLOW);
 
-    builder.const_i32(global_pointers::flags as i32);
-    builder.get_local_i64(&result);
-    builder.wrap_i64_to_i32();
-    builder.extend_signed_i32_to_i64();
-    builder.get_local_i64(&result);
-    builder.ne_i64();
-    builder.const_i32(1 | FLAG_OVERFLOW);
-    builder.mul_i32();
-    codegen::gen_get_flags(builder);
-    builder.const_i32(!1 & !FLAG_OVERFLOW);
-    builder.and_i32();
-    builder.or_i32();
-    builder.store_aligned_i32(0);
+        builder.const_i32(global_pointers::flags as i32);
+        builder.get_local_i64(&result);
+        builder.wrap_i64_to_i32();
+        builder.extend_signed_i32_to_i64();
+        builder.get_local_i64(&result);
+        builder.ne_i64();
+        builder.const_i32(1 | FLAG_OVERFLOW);
+        builder.mul_i32();
+        codegen::gen_get_flags(builder);
+        builder.const_i32(!1 & !FLAG_OVERFLOW);
+        builder.and_i32();
+        builder.or_i32();
+        builder.store_aligned_i32(0);
+    }
 
     builder.free_local_i64(result);
 }
@@ -1971,14 +2202,24 @@ fn gen_bit_rmw(
 fn gen_bsf32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
     ctx.builder.get_local(&dest_operand);
     source_operand.gen_get(ctx.builder);
-    ctx.builder.call_fn2_ret("bsf32");
+    if ctx.comp_lazy_flags {
+        ctx.builder.call_fn2_ret("bsf32");
+    }
+    else {
+        ctx.builder.call_fn2_ret("bsf32_noflags");
+    }
     ctx.builder.set_local(dest_operand);
 }
 
 fn gen_bsr32(ctx: &mut JitContext, dest_operand: &WasmLocal, source_operand: &LocalOrImmediate) {
     ctx.builder.get_local(&dest_operand);
     source_operand.gen_get(ctx.builder);
-    ctx.builder.call_fn2_ret("bsr32");
+    if ctx.comp_lazy_flags {        
+        ctx.builder.call_fn2_ret("bsr32");
+    }
+    else {
+        ctx.builder.call_fn2_ret("bsr32_noflags");
+    }
     ctx.builder.set_local(dest_operand);
 }
 
@@ -2194,44 +2435,58 @@ pub fn instr32_3D_jit(ctx: &mut JitContext, imm32: u32) {
 }
 
 fn gen_inc(ctx: &mut JitContext, dest_operand: &WasmLocal, size: i32) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: size };
-
     let builder = &mut ctx.builder;
-    builder.const_i32(global_pointers::flags as i32);
-    codegen::gen_get_flags(builder);
-    builder.const_i32(!1);
-    builder.and_i32();
-    codegen::gen_getcf_unoptimised(builder);
-    builder.or_i32();
-    builder.store_aligned_i32(0);
+    
+    if ctx.comp_lazy_flags {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: size };
 
-    builder.const_i32(global_pointers::last_op1 as i32);
-    builder.get_local(&dest_operand);
-    if size == OPSIZE_8 || size == OPSIZE_16 {
-        builder.const_i32(if size == OPSIZE_8 { 0xFF } else { 0xFFFF });
+        builder.const_i32(global_pointers::flags as i32);
+        codegen::gen_get_flags(builder);
+        builder.const_i32(!1);
         builder.and_i32();
-    }
-    builder.store_aligned_i32(0);
+        codegen::gen_getcf_unoptimised(builder);
+        builder.or_i32();
+        builder.store_aligned_i32(0);
 
-    builder.get_local(dest_operand);
-    builder.const_i32(1);
-    builder.add_i32();
-    if size == OPSIZE_16 {
-        codegen::gen_set_reg16_local(builder, dest_operand);
+        builder.const_i32(global_pointers::last_op1 as i32);
+        builder.get_local(&dest_operand);
+        if size == OPSIZE_8 || size == OPSIZE_16 {
+            builder.const_i32(if size == OPSIZE_8 { 0xFF } else { 0xFFFF });
+            builder.and_i32();
+        }
+        builder.store_aligned_i32(0);
+
+        builder.get_local(dest_operand);
+        builder.const_i32(1);
+        builder.add_i32();
+        if size == OPSIZE_16 {
+            codegen::gen_set_reg16_local(builder, dest_operand);
+        }
+        else {
+            builder.set_local(dest_operand);
+        }
+
+        builder.const_i32(global_pointers::last_result as i32);
+        builder.get_local(&dest_operand);
+        if size == OPSIZE_16 {
+            builder.const_i32(0xFFFF);
+            builder.and_i32();
+        }
+        builder.store_aligned_i32(0);
+        codegen::gen_set_last_op_size(builder, size);
+        codegen::gen_set_flags_changed(builder, FLAGS_ALL & !1);
     }
     else {
-        builder.set_local(dest_operand);
+        builder.get_local(dest_operand);
+        builder.const_i32(1);
+        builder.add_i32();
+        if size == OPSIZE_16 {
+            codegen::gen_set_reg16_local(builder, dest_operand);
+        }
+        else {
+            builder.set_local(dest_operand);
+        }        
     }
-
-    builder.const_i32(global_pointers::last_result as i32);
-    builder.get_local(&dest_operand);
-    if size == OPSIZE_16 {
-        builder.const_i32(0xFFFF);
-        builder.and_i32();
-    }
-    builder.store_aligned_i32(0);
-    codegen::gen_set_last_op_size(builder, size);
-    codegen::gen_set_flags_changed(builder, FLAGS_ALL & !1);
 }
 fn gen_inc16(ctx: &mut JitContext, dest_operand: &WasmLocal) {
     gen_inc(ctx, dest_operand, OPSIZE_16);
@@ -2241,44 +2496,58 @@ fn gen_inc32(ctx: &mut JitContext, dest_operand: &WasmLocal) {
 }
 
 fn gen_dec(ctx: &mut JitContext, dest_operand: &WasmLocal, size: i32) {
-    ctx.last_instruction = Instruction::Arithmetic { opsize: size };
-
     let builder = &mut ctx.builder;
-    builder.const_i32(global_pointers::flags as i32);
-    codegen::gen_get_flags(builder);
-    builder.const_i32(!1);
-    builder.and_i32();
-    codegen::gen_getcf_unoptimised(builder);
-    builder.or_i32();
-    builder.store_aligned_i32(0);
 
-    builder.const_i32(global_pointers::last_op1 as i32);
-    builder.get_local(&dest_operand);
-    if size == OPSIZE_8 || size == OPSIZE_16 {
-        builder.const_i32(if size == OPSIZE_8 { 0xFF } else { 0xFFFF });
+    if ctx.comp_lazy_flags {
+        ctx.last_instruction = Instruction::Arithmetic { opsize: size };
+    
+        builder.const_i32(global_pointers::flags as i32);
+        codegen::gen_get_flags(builder);
+        builder.const_i32(!1);
         builder.and_i32();
-    }
-    builder.store_aligned_i32(0);
+        codegen::gen_getcf_unoptimised(builder);
+        builder.or_i32();
+        builder.store_aligned_i32(0);
 
-    builder.get_local(dest_operand);
-    builder.const_i32(1);
-    builder.sub_i32();
-    if size == OPSIZE_16 {
-        codegen::gen_set_reg16_local(builder, dest_operand);
+        builder.const_i32(global_pointers::last_op1 as i32);
+        builder.get_local(&dest_operand);
+        if size == OPSIZE_8 || size == OPSIZE_16 {
+            builder.const_i32(if size == OPSIZE_8 { 0xFF } else { 0xFFFF });
+            builder.and_i32();
+        }
+        builder.store_aligned_i32(0);
+
+        builder.get_local(dest_operand);
+        builder.const_i32(1);
+        builder.sub_i32();
+        if size == OPSIZE_16 {
+            codegen::gen_set_reg16_local(builder, dest_operand);
+        }
+        else {
+            builder.set_local(dest_operand);
+        }
+
+        builder.const_i32(global_pointers::last_result as i32);
+        builder.get_local(&dest_operand);
+        if size == OPSIZE_16 {
+            builder.const_i32(0xFFFF);
+            builder.and_i32();
+        }
+        builder.store_aligned_i32(0);
+        codegen::gen_set_last_op_size(builder, size);
+        codegen::gen_set_flags_changed(builder, FLAGS_ALL & !1 | FLAG_SUB);
     }
     else {
-        builder.set_local(dest_operand);
+        builder.get_local(dest_operand);
+        builder.const_i32(1);
+        builder.sub_i32();
+        if size == OPSIZE_16 {
+            codegen::gen_set_reg16_local(builder, dest_operand);
+        }
+        else {
+            builder.set_local(dest_operand);
+        }        
     }
-
-    builder.const_i32(global_pointers::last_result as i32);
-    builder.get_local(&dest_operand);
-    if size == OPSIZE_16 {
-        builder.const_i32(0xFFFF);
-        builder.and_i32();
-    }
-    builder.store_aligned_i32(0);
-    codegen::gen_set_last_op_size(builder, size);
-    codegen::gen_set_flags_changed(builder, FLAGS_ALL & !1 | FLAG_SUB);
 }
 fn gen_dec16(ctx: &mut JitContext, dest_operand: &WasmLocal) {
     gen_dec(ctx, dest_operand, OPSIZE_16)
@@ -2310,23 +2579,31 @@ fn gen_not32(ctx: &mut JitContext, dest_operand: &WasmLocal) {
 fn gen_neg16(ctx: &mut JitContext, dest_operand: &WasmLocal) {
     let builder = &mut ctx.builder;
     builder.get_local(dest_operand);
-    builder.call_fn1_ret("neg16");
+    if ctx.comp_lazy_flags {
+        builder.call_fn1_ret("neg16");
+    }
+    else {
+        builder.call_fn1_ret("neg16_noflags");
+    }
     codegen::gen_set_reg16_local(builder, dest_operand);
 }
 fn gen_neg32(ctx: &mut JitContext, dest_operand: &WasmLocal) {
     let builder = &mut ctx.builder;
-    builder.const_i32(global_pointers::last_op1 as i32);
-    builder.const_i32(0);
-    builder.store_aligned_i32(0);
 
     builder.const_i32(0);
     builder.get_local(&dest_operand);
     builder.sub_i32();
     builder.set_local(dest_operand);
 
-    codegen::gen_set_last_result(builder, &dest_operand);
-    codegen::gen_set_last_op_size(builder, OPSIZE_32);
-    codegen::gen_set_flags_changed(builder, FLAGS_ALL | FLAG_SUB);
+    if ctx.comp_lazy_flags {
+        builder.const_i32(global_pointers::last_op1 as i32);
+        builder.const_i32(0);
+        builder.store_aligned_i32(0);
+
+        codegen::gen_set_last_result(builder, &dest_operand);
+        codegen::gen_set_last_op_size(builder, OPSIZE_32);
+        codegen::gen_set_flags_changed(builder, FLAGS_ALL | FLAG_SUB);
+    }
 }
 
 pub fn instr16_06_jit(ctx: &mut JitContext) {
@@ -2457,13 +2734,23 @@ pub fn instr32_6A_jit(ctx: &mut JitContext, imm32: u32) { push32_imm_jit(ctx, im
 pub fn instr16_69_mem_jit(ctx: &mut JitContext, modrm_byte: ModrmByte, r: u32, imm16: u32) {
     codegen::gen_modrm_resolve_safe_read16(ctx, modrm_byte);
     ctx.builder.const_i32(imm16 as i32);
-    ctx.builder.call_fn2_ret("imul_reg16");
+    if ctx.comp_lazy_flags {
+        ctx.builder.call_fn2_ret("imul_reg16");
+    }
+    else {
+        ctx.builder.call_fn2_ret("imul_reg16_noflags");
+    }
     codegen::gen_set_reg16(ctx, r);
 }
 pub fn instr16_69_reg_jit(ctx: &mut JitContext, r1: u32, r2: u32, imm16: u32) {
     codegen::gen_get_reg16(ctx, r1);
     ctx.builder.const_i32(imm16 as i32);
-    ctx.builder.call_fn2_ret("imul_reg16");
+    if ctx.comp_lazy_flags {
+        ctx.builder.call_fn2_ret("imul_reg16");
+    }
+    else {
+        ctx.builder.call_fn2_ret("imul_reg16_noflags");
+    }
     codegen::gen_set_reg16(ctx, r2);
 }
 
@@ -2475,6 +2762,7 @@ pub fn instr32_69_mem_jit(ctx: &mut JitContext, modrm_byte: ModrmByte, r: u32, i
         &ctx.register_locals[r as usize],
         &value_local,
         &LocalOrImmediate::Immediate(imm32 as i32),
+        ctx.comp_lazy_flags
     );
     ctx.builder.free_local(value_local);
 }
@@ -2484,19 +2772,30 @@ pub fn instr32_69_reg_jit(ctx: &mut JitContext, r1: u32, r2: u32, imm32: u32) {
         &ctx.register_locals[r2 as usize],
         &ctx.register_locals[r1 as usize],
         &LocalOrImmediate::Immediate(imm32 as i32),
+        ctx.comp_lazy_flags
     );
 }
 
 pub fn instr16_6B_mem_jit(ctx: &mut JitContext, modrm_byte: ModrmByte, r: u32, imm8s: u32) {
     codegen::gen_modrm_resolve_safe_read16(ctx, modrm_byte);
     ctx.builder.const_i32(imm8s as i32);
-    ctx.builder.call_fn2_ret("imul_reg16");
+    if ctx.comp_lazy_flags {
+        ctx.builder.call_fn2_ret("imul_reg16");
+    }
+    else {
+        ctx.builder.call_fn2_ret("imul_reg16_noflags");
+    }
     codegen::gen_set_reg16(ctx, r);
 }
 pub fn instr16_6B_reg_jit(ctx: &mut JitContext, r1: u32, r2: u32, imm8s: u32) {
     codegen::gen_get_reg16(ctx, r1);
     ctx.builder.const_i32(imm8s as i32);
-    ctx.builder.call_fn2_ret("imul_reg16");
+    if ctx.comp_lazy_flags {
+        ctx.builder.call_fn2_ret("imul_reg16");
+    }
+    else {
+        ctx.builder.call_fn2_ret("imul_reg16_noflags");
+    }
     codegen::gen_set_reg16(ctx, r2);
 }
 
@@ -2508,6 +2807,7 @@ pub fn instr32_6B_mem_jit(ctx: &mut JitContext, modrm_byte: ModrmByte, r: u32, i
         &ctx.register_locals[r as usize],
         &value_local,
         &LocalOrImmediate::Immediate(imm8s as i32),
+        ctx.comp_lazy_flags,
     );
     ctx.builder.free_local(value_local);
 }
@@ -2517,6 +2817,7 @@ pub fn instr32_6B_reg_jit(ctx: &mut JitContext, r1: u32, r2: u32, imm8s: u32) {
         &ctx.register_locals[r2 as usize],
         &ctx.register_locals[r1 as usize],
         &LocalOrImmediate::Immediate(imm8s as i32),
+        ctx.comp_lazy_flags,
     );
 }
 

--- a/tests/expect/tests/call-ret.wast
+++ b/tests/expect/tests/call-ret.wast
@@ -119,13 +119,11 @@
                         (i32.const 0)))
                     (i32.const 1))))
               (i32.store align=1
-                (i32.add
-                  (i32.xor
-                    (i32.and
-                      (get_local $l12)
-                      (i32.const -4096))
-                    (get_local $l11))
-                  (i32.const 18247680))
+                (i32.xor
+                  (i32.and
+                    (get_local $l12)
+                    (i32.const -4096))
+                  (get_local $l11))
                 (get_local $l9))
               (set_local $l4
                 (get_local $l10))
@@ -214,13 +212,11 @@
                         (i32.const 7)))
                     (i32.const 1))))
               (i32.load align=1
-                (i32.add
-                  (i32.xor
-                    (i32.and
-                      (get_local $l10)
-                      (i32.const -4096))
-                    (get_local $l9))
-                  (i32.const 18247680)))
+                (i32.xor
+                  (i32.and
+                    (get_local $l10)
+                    (i32.const -4096))
+                  (get_local $l9)))
               (set_local $l4
                 (i32.add
                   (get_local $l4)
@@ -248,18 +244,26 @@
                 (br_if $B1
                   (i32.and
                     (tee_local $l10
-                      (call $e.get_phys_eip_slow_jit
+                      (i32.xor
+                        (i32.add
+                          (i32.xor
+                            (call $e.get_phys_eip_slow_jit
+                              (get_local $l9))
+                            (get_local $l9))
+                          (i32.const 18247680))
                         (get_local $l9)))
                     (i32.const 1))))
               (br_if $L2
                 (i32.ge_s
                   (tee_local $p0
                     (call $e.jit_find_cache_entry_in_page
-                      (i32.xor
-                        (i32.and
-                          (get_local $l10)
-                          (i32.const -4096))
-                        (get_local $l9))
+                      (i32.sub
+                        (i32.xor
+                          (i32.and
+                            (get_local $l10)
+                            (i32.const -4096))
+                          (get_local $l9))
+                        (i32.const 18247680))
                       (i32.const 899)
                       (i32.const 3)))
                   (i32.const 0)))

--- a/tests/expect/tests/do-while.wast
+++ b/tests/expect/tests/do-while.wast
@@ -24,7 +24,7 @@
   (import "e" "trigger_fault_end_jit" (func $e.trigger_fault_end_jit (type $t0)))
   (import "e" "m" (memory $e.m 128))
   (func $f (export "f") (type $t1) (param $p0 i32)
-    (local $l0 i32) (local $l1 i32) (local $l2 i32) (local $l3 i32) (local $l4 i32) (local $l5 i32) (local $l6 i32) (local $l7 i32) (local $l8 i32) (local $l9 i32)
+    (local $l0 i32) (local $l1 i32) (local $l2 i32) (local $l3 i32) (local $l4 i32) (local $l5 i32) (local $l6 i32) (local $l7 i32) (local $l8 i32)
     (set_local $l0
       (i32.load
         (i32.const 64)))
@@ -79,54 +79,10 @@
                   (i32.add
                     (get_local $l8)
                     (i32.const 3)))
-                (i32.store
-                  (i32.const 120)
-                  (i32.or
-                    (i32.and
-                      (i32.load
-                        (i32.const 120))
-                      (i32.const -2))
-                    (if $I7 (result i32)
-                      (i32.and
-                        (tee_local $l9
-                          (i32.load
-                            (i32.const 116)))
-                        (i32.const 1))
-                      (then
-                        (set_local $l9
-                          (i32.shr_s
-                            (get_local $l9)
-                            (i32.const 31)))
-                        (i32.lt_u
-                          (i32.xor
-                            (i32.load
-                              (i32.const 112))
-                            (get_local $l9))
-                          (i32.xor
-                            (i32.load
-                              (i32.const 96))
-                            (get_local $l9))))
-                      (else
-                        (i32.and
-                          (i32.load
-                            (i32.const 120))
-                          (i32.const 1))))))
-                (i32.store
-                  (i32.const 96)
-                  (get_local $l3))
                 (set_local $l3
                   (i32.add
                     (get_local $l3)
                     (i32.const 1)))
-                (i32.store
-                  (i32.const 112)
-                  (get_local $l3))
-                (i32.store
-                  (i32.const 104)
-                  (i32.const 31))
-                (i32.store
-                  (i32.const 116)
-                  (i32.const 2260))
                 (i32.store
                   (i32.const 112)
                   (i32.sub

--- a/tests/expect/tests/indirect-call.wast
+++ b/tests/expect/tests/indirect-call.wast
@@ -186,13 +186,11 @@
             (set_local $l9
               (i32.add
                 (i32.load align=1
-                  (i32.add
-                    (i32.xor
-                      (i32.and
-                        (get_local $l10)
-                        (i32.const -4096))
-                      (get_local $l9))
-                    (i32.const 18247680)))
+                  (i32.xor
+                    (i32.and
+                      (get_local $l10)
+                      (i32.const -4096))
+                    (get_local $l9)))
                 (i32.load
                   (i32.const 740))))
             (set_local $l10
@@ -241,13 +239,11 @@
                       (i32.const 0)))
                   (i32.const 1))))
             (i32.store align=1
-              (i32.add
-                (i32.xor
-                  (i32.and
-                    (get_local $l13)
-                    (i32.const -4096))
-                  (get_local $l12))
-                (i32.const 18247680))
+              (i32.xor
+                (i32.and
+                  (get_local $l13)
+                  (i32.const -4096))
+                (get_local $l12))
               (get_local $l10))
             (set_local $l4
               (get_local $l11))
@@ -273,18 +269,26 @@
               (br_if $B1
                 (i32.and
                   (tee_local $l10
-                    (call $e.get_phys_eip_slow_jit
+                    (i32.xor
+                      (i32.add
+                        (i32.xor
+                          (call $e.get_phys_eip_slow_jit
+                            (get_local $l9))
+                          (get_local $l9))
+                        (i32.const 18247680))
                       (get_local $l9)))
                   (i32.const 1))))
             (br_if $L2
               (i32.ge_s
                 (tee_local $p0
                   (call $e.jit_find_cache_entry_in_page
-                    (i32.xor
-                      (i32.and
-                        (get_local $l10)
-                        (i32.const -4096))
-                      (get_local $l9))
+                    (i32.sub
+                      (i32.xor
+                        (i32.and
+                          (get_local $l10)
+                          (i32.const -4096))
+                        (get_local $l9))
+                      (i32.const 18247680))
                     (i32.const 899)
                     (i32.const 3)))
                 (i32.const 0)))

--- a/tests/expect/tests/mem32r.wast
+++ b/tests/expect/tests/mem32r.wast
@@ -110,13 +110,11 @@
                   (i32.const 1))))
             (set_local $l0
               (i32.load align=1
-                (i32.add
-                  (i32.xor
-                    (i32.and
-                      (get_local $l10)
-                      (i32.const -4096))
-                    (get_local $l9))
-                  (i32.const 18247680))))
+                (i32.xor
+                  (i32.and
+                    (get_local $l10)
+                    (i32.const -4096))
+                  (get_local $l9))))
             (i32.store
               (i32.const 560)
               (i32.or

--- a/tests/expect/tests/mem32rmw.wast
+++ b/tests/expect/tests/mem32rmw.wast
@@ -114,13 +114,11 @@
             (set_local $l12
               (i32.load align=1
                 (tee_local $l10
-                  (i32.add
-                    (i32.xor
-                      (i32.and
-                        (get_local $l10)
-                        (i32.const -4096))
-                      (get_local $l9))
-                    (i32.const 18247680)))))
+                  (i32.xor
+                    (i32.and
+                      (get_local $l10)
+                      (i32.const -4096))
+                    (get_local $l9)))))
             (i32.store
               (i32.const 120)
               (i32.or

--- a/tests/expect/tests/mem32w.wast
+++ b/tests/expect/tests/mem32w.wast
@@ -110,13 +110,11 @@
                       (i32.const 0)))
                   (i32.const 1))))
             (i32.store align=1
-              (i32.add
-                (i32.xor
-                  (i32.and
-                    (get_local $l10)
-                    (i32.const -4096))
-                  (get_local $l9))
-                (i32.const 18247680))
+              (i32.xor
+                (i32.and
+                  (get_local $l10)
+                  (i32.const -4096))
+                (get_local $l9))
               (get_local $l0))
             (i32.store
               (i32.const 560)

--- a/tests/expect/tests/mov-immoffs.wast
+++ b/tests/expect/tests/mov-immoffs.wast
@@ -108,13 +108,11 @@
                   (i32.const 1))))
             (set_local $l0
               (i32.load align=1
-                (i32.add
-                  (i32.xor
-                    (i32.and
-                      (get_local $l10)
-                      (i32.const -4096))
-                    (get_local $l9))
-                  (i32.const 18247680))))
+                (i32.xor
+                  (i32.and
+                    (get_local $l10)
+                    (i32.const -4096))
+                  (get_local $l9))))
             (i32.store
               (i32.const 560)
               (i32.or

--- a/tests/expect/tests/pop.wast
+++ b/tests/expect/tests/pop.wast
@@ -98,13 +98,11 @@
                       (i32.const 0)))
                   (i32.const 1))))
             (i32.load align=1
-              (i32.add
-                (i32.xor
-                  (i32.and
-                    (get_local $l10)
-                    (i32.const -4096))
-                  (get_local $l9))
-                (i32.const 18247680)))
+              (i32.xor
+                (i32.and
+                  (get_local $l10)
+                  (i32.const -4096))
+                (get_local $l9)))
             (set_local $l4
               (i32.add
                 (get_local $l4)

--- a/tests/expect/tests/push.wast
+++ b/tests/expect/tests/push.wast
@@ -102,13 +102,11 @@
                       (i32.const 0)))
                   (i32.const 1))))
             (i32.store align=1
-              (i32.add
-                (i32.xor
-                  (i32.and
-                    (get_local $l11)
-                    (i32.const -4096))
-                  (get_local $l10))
-                (i32.const 18247680))
+              (i32.xor
+                (i32.and
+                  (get_local $l11)
+                  (i32.const -4096))
+                (get_local $l10))
               (get_local $l0))
             (set_local $l4
               (get_local $l9))

--- a/tools/docker/debian/build-container.sh
+++ b/tools/docker/debian/build-container.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 set -veu
 
-OUT_ROOTFS_TAR=$(dirname "$0")/../../images/debian-9p-rootfs.tar
-OUT_ROOTFS_FLAT=$(dirname "$0")/../../images/debian-9p-rootfs-flat
-OUT_FSJSON=$(dirname "$0")/../../images/debian-base-fs.json
+OUT_ROOTFS_TAR=$(dirname "$0")/../../../images/debian-9p-rootfs.tar
+OUT_ROOTFS_FLAT=$(dirname "$0")/../../../images/debian-9p-rootfs-flat
+OUT_FSJSON=$(dirname "$0")/../../../images/debian-base-fs.json
 CONTAINER_NAME=debian-full
 IMAGE_NAME=i386/debian-full
 
-docker build . --rm --tag "$IMAGE_NAME"
+docker build . --rm --tag "$IMAGE_NAME" --build-arg ARCH=i386
 docker rm "$CONTAINER_NAME" || true
-docker create -t -i --name "$CONTAINER_NAME" "$IMAGE_NAME" bash
+docker create -t -i --platform i386 --name "$CONTAINER_NAME" "$IMAGE_NAME" bash
 
 docker export "$CONTAINER_NAME" > "$OUT_ROOTFS_TAR"
 
-$(dirname "$0")/../../tools/fs2json.py --out "$OUT_FSJSON" "$OUT_ROOTFS_TAR"
+$(dirname "$0")/../../../tools/fs2json.py --out "$OUT_FSJSON" "$OUT_ROOTFS_TAR"
 
 # Note: Not deleting old files here
 mkdir -p "$OUT_ROOTFS_FLAT"
-$(dirname "$0")/../../tools/copy-to-sha256.py "$OUT_ROOTFS_TAR" "$OUT_ROOTFS_FLAT"
+$(dirname "$0")/../../../tools/copy-to-sha256.py "$OUT_ROOTFS_TAR" "$OUT_ROOTFS_FLAT"
 
 echo "$OUT_ROOTFS_TAR", "$OUT_ROOTFS_FLAT" and "$OUT_FSJSON" created.

--- a/tools/docker/debian/build-state.js
+++ b/tools/docker/debian/build-state.js
@@ -56,7 +56,7 @@ emulator.add_listener("serial0-output-char", function(c)
         booted = true;
 
         // sync and drop caches: Makes it safer to change the filesystem as fewer files are rendered
-        // emulator.serial0_send("sync;echo 3 >/proc/sys/vm/drop_caches\n");
+        emulator.serial0_send("sync;echo 3 >/proc/sys/vm/drop_caches\n");
 
         setTimeout(function ()
             {
@@ -71,7 +71,7 @@ emulator.add_listener("serial0-output-char", function(c)
                             {
                                 if(e) throw e;
                                 console.error("Saved as " + OUTPUT_FILE);
-                                // stop();
+                                stop();
                             });
                     });
             }, 10 * 1000);

--- a/tools/docker/debian/build-state.js
+++ b/tools/docker/debian/build-state.js
@@ -56,7 +56,7 @@ emulator.add_listener("serial0-output-char", function(c)
         booted = true;
 
         // sync and drop caches: Makes it safer to change the filesystem as fewer files are rendered
-        // emulator.serial0_send("sync;echo 3 >/proc/sys/vm/drop_caches\n");
+        emulator.serial0_send("sync;echo 3 >/proc/sys/vm/drop_caches\n");
 
         setTimeout(function ()
             {
@@ -71,7 +71,7 @@ emulator.add_listener("serial0-output-char", function(c)
                             {
                                 if(e) throw e;
                                 console.error("Saved as " + OUTPUT_FILE);
-                                //stop();
+                                stop();
                             });
                     });
             }, 10 * 1000);

--- a/tools/docker/debian/build-state.js
+++ b/tools/docker/debian/build-state.js
@@ -56,7 +56,7 @@ emulator.add_listener("serial0-output-char", function(c)
         booted = true;
 
         // sync and drop caches: Makes it safer to change the filesystem as fewer files are rendered
-        emulator.serial0_send("sync;echo 3 >/proc/sys/vm/drop_caches\n");
+        // emulator.serial0_send("sync;echo 3 >/proc/sys/vm/drop_caches\n");
 
         setTimeout(function ()
             {
@@ -71,7 +71,7 @@ emulator.add_listener("serial0-output-char", function(c)
                             {
                                 if(e) throw e;
                                 console.error("Saved as " + OUTPUT_FILE);
-                                stop();
+                                // stop();
                             });
                     });
             }, 10 * 1000);

--- a/tools/docker/debian/build-state.js
+++ b/tools/docker/debian/build-state.js
@@ -9,9 +9,9 @@ const path = require("path");
 console.log("Don't forget to run `make all` before running this script");
 
 var fs = require("fs");
-var V86 = require("./../../build/libv86.js").V86;
+var V86 = require("./../../../build/libv86.js").V86;
 
-const V86_ROOT = path.join(__dirname, "../..");
+const V86_ROOT = path.join(__dirname, "../../..");
 
 var OUTPUT_FILE = path.join(V86_ROOT, "images/debian-state-base.bin");
 
@@ -56,7 +56,7 @@ emulator.add_listener("serial0-output-char", function(c)
         booted = true;
 
         // sync and drop caches: Makes it safer to change the filesystem as fewer files are rendered
-        emulator.serial0_send("sync;echo 3 >/proc/sys/vm/drop_caches\n");
+        // emulator.serial0_send("sync;echo 3 >/proc/sys/vm/drop_caches\n");
 
         setTimeout(function ()
             {
@@ -71,7 +71,7 @@ emulator.add_listener("serial0-output-char", function(c)
                             {
                                 if(e) throw e;
                                 console.error("Saved as " + OUTPUT_FILE);
-                                stop();
+                                //stop();
                             });
                     });
             }, 10 * 1000);


### PR DESCRIPTION
This PR tries to optimize lazy flags computation. In the current implementation, information about the operation and operands is stored and is in some cases overwritten by subsequent operations. In other cases operations force generation of particular flags since they only do partial lazy computation.

The proposed optimization adds metadata to the analyzer to be able to identify which flags are tested and which are modified by each instruction. Using this information each jitted BB is analyzed for potential otpimizations and instructions which generate flags that are completely overwritten by subsequent instructions and thus never used are being replaced with alternate implementations which do not do flags computation (this includes not storing anything for lazy computation). 

This improves performance significantly in some benchmars like running a tight loop that does mostly register operations.

Since it was not clear to me what the correct metadata is for some instructions, if a particular instruction does not have the metadata it will disable the optimization from that point on until the end of the BB.

Still to do:
- metadata was generated semi-automatically and it could be wrong in some places, it should be double checked
- I am just beginning to learn rust (I know enough to be dangerous) so I am probably using non-idiomatic rust. I probably need to go back and change some code.
- I need to do more testing
- I need to do more profiling
- I need to adjust some tests (generated wasm has been changed)

Challenges:
- duplicating functions to include a "_noflags" version is tedious and error prone. On the other hand dealing with this at runtime (including the check for flag computation in the jitted code) negates some of the perf advantages.
- intruction metadata in the analyzer must be in sync with the actual implementation of the jit and interpreter, also the regular and _noflags jit versions need to be in sync

Initial benchmarks:

```
NEW

TEST                : Iterations/sec.  : Old Index   : New Index
                    :                  : Pentium 90* : AMD K6/233*
--------------------:------------------:-------------:------------
NUMERIC SORT        :          230.87  :       5.92  :       1.94
STRING SORT         :          7.0302  :       3.14  :       0.49
BITFIELD            :      1.0887e+08  :      18.68  :       3.90 <----
FP EMULATION        :          19.962  :       9.58  :       2.21
FOURIER             :          563.87  :       0.64  :       0.36
ASSIGNMENT          :          5.8462  :      22.25  :       5.77 <----
IDEA                :          544.41  :       8.33  :       2.47
HUFFMAN             :          341.86  :       9.48  :       3.03 <----
NEURAL NET          :         0.38348  :       0.62  :       0.26
LU DECOMPOSITION    :          13.835  :       0.72  :       0.52
==========================ORIGINAL BYTEMARK RESULTS==========================
INTEGER INDEX       : 9.261
FLOATING-POINT INDEX: 0.657
Baseline (MSDOS*)   : Pentium* 90, 256 KB L2-cache, Watcom* compiler 10.0
==============================LINUX DATA BELOW===============================
CPU                 : GenuineIntel 0f/06 1000MHz
L2 Cache            : 6144 KB
OS                  : Linux 4.19.0-16-686
C compiler          : gcc version 8.3.0 (Debian 8.3.0-6)
libc                : libc-2.28.so
MEMORY INDEX        : 2.220
INTEGER INDEX       : 2.381
FLOATING-POINT INDEX: 0.364
Baseline (LINUX)    : AMD K6/233*, 512 KB L2-cache, gcc 2.7.2.3, libc-5.4.38

----

OLD

BYTEmark* Native Mode Benchmark ver. 2 (10/95)
Index-split by Andrew D. Balsa (11/97)
Linux/Unix* port by Uwe F. Mayer (12/96,11/97)

TEST                : Iterations/sec.  : Old Index   : New Index
                    :                  : Pentium 90* : AMD K6/233*
--------------------:------------------:-------------:------------
NUMERIC SORT        :          226.04  :       5.80  :       1.90
STRING SORT         :          7.0279  :       3.14  :       0.49
BITFIELD            :      6.4915e+07  :      11.14  :       2.33 <----
FP EMULATION        :           19.46  :       9.34  :       2.15
FOURIER             :          553.47  :       0.63  :       0.35
ASSIGNMENT          :          4.4541  :      16.95  :       4.40 <----
IDEA                :          545.29  :       8.34  :       2.48
HUFFMAN             :          321.95  :       8.93  :       2.85 <----
NEURAL NET          :         0.38921  :       0.63  :       0.26
LU DECOMPOSITION    :          14.207  :       0.74  :       0.53
==========================ORIGINAL BYTEMARK RESULTS==========================
INTEGER INDEX       : 8.150
FLOATING-POINT INDEX: 0.662
Baseline (MSDOS*)   : Pentium* 90, 256 KB L2-cache, Watcom* compiler 10.0
==============================LINUX DATA BELOW===============================
CPU                 : GenuineIntel 0f/06 1000MHz
L2 Cache            : 6144 KB
OS                  : Linux 4.19.0-16-686
C compiler          : gcc version 8.3.0 (Debian 8.3.0-6)
libc                : libc-2.28.so
MEMORY INDEX        : 1.707
INTEGER INDEX       : 2.320
FLOATING-POINT INDEX: 0.367
Baseline (LINUX)    : AMD K6/233*, 512 KB L2-cache, gcc 2.7.2.3, libc-5.4.38

```
