### PR TITLE
Using and splitting images without server-side

### DIFF
--- a/src/browser/lib.js
+++ b/src/browser/lib.js
@@ -460,7 +460,7 @@ var ASYNC_SAFE = false;
      * @param {string} filename Name of the file to download
      * @param {number|undefined} size
      */
-    function AsyncXHRPartfileBuffer(filename, size)
+    function AsyncXHRPartfileBuffer(filename, size, step)
     {
         const parts = filename.match(/(.*)(\..*)/);
 
@@ -478,6 +478,8 @@ var ASYNC_SAFE = false;
         /** @const */
         this.block_size = 256;
         this.byteLength = size;
+        this.use_step_ = typeof step == 'number'
+        this.step_ = step
 
         this.loaded_blocks = Object.create(null);
 
@@ -522,18 +524,44 @@ var ASYNC_SAFE = false;
             }
             return;
         }
+		
+		if(this.use_step_) {
+			const fake_offset = parseInt(offset / this.step_) * this.step_;
+			const m_offset = offset - fake_offset;
+			const total_count = parseInt(len / this.step_) + 2;
+			var blocks_ = new Uint8Array(m_offset + (total_count * this.step_));
+			var finished = 0;
+			
+			for (var i = 0; i < total_count; i++) {
+				const cur = i * this.step_;
+				const part_filename = this.basename + "-" + (cur + fake_offset) + this.extension;
+				
+				v86util.load_file(part_filename, {
+					done: function done(buffer) {
+						const block = new Uint8Array(buffer);
+						blocks_.set(block, cur);
+						const tmp_blocks = blocks_.slice(m_offset, m_offset + len);
+						finished++;
+						if (finished == total_count) {
+							fn(tmp_blocks);
+						}
+					}.bind(this),
+				});
+			}		
+		}
+		else {
+			const part_filename = this.basename + "-" + offset + "-" + (offset + len) + this.extension;
 
-        const part_filename = this.basename + "-" + offset + "-" + (offset + len) + this.extension;
-
-        v86util.load_file(part_filename, {
-            done: function done(buffer)
-            {
-                dbg_assert(buffer.byteLength === len);
-                var block = new Uint8Array(buffer);
-                this.handle_read(offset, len, block);
-                fn(block);
-            }.bind(this),
-        });
+			v86util.load_file(part_filename, {
+				done: function done(buffer)
+				{
+					dbg_assert(buffer.byteLength === len);
+					var block = new Uint8Array(buffer);
+					this.handle_read(offset, len, block);
+					fn(block);
+				}.bind(this),
+			});
+		}
     };
 
     AsyncXHRPartfileBuffer.prototype.set = AsyncXHRBuffer.prototype.set;

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -380,6 +380,7 @@ V86Starter.prototype.continue_init = async function(emulator, options)
             async: file["async"],
             url: file["url"],
             size: file["size"],
+            step: file["step"],
             use_parts: file.use_parts,
         };
 
@@ -439,7 +440,7 @@ V86Starter.prototype.continue_init = async function(emulator, options)
 
                 if(file.use_parts)
                 {
-                    buffer = new v86util.AsyncXHRPartfileBuffer(file.url, file.size);
+                    buffer = new v86util.AsyncXHRPartfileBuffer(file.url, file.size, file.step);
                 }
                 else
                 {

--- a/tools/imgsplit.py
+++ b/tools/imgsplit.py
@@ -1,0 +1,74 @@
+import os
+from sys import argv
+from sys import exit as exit_
+
+
+argc = len(argv)
+filename = None
+step = 4096
+args = argv[1:]
+argc -= 1
+
+
+for i in range(argc):
+    lowered = args[i].lower()
+    is_last = i == argc - 1
+    if lowered == '--help' or lowered == '-h':
+        print('--help - Display information.')
+        print('--step {int} - Set step')
+        print('--filename {path} - Set file path')
+        exit_(0)
+    elif lowered == '--step' or lowered == '-s':
+        if is_last:
+            print('Argument required!')
+            exit_(1)
+        else:
+            step = int(args[i + 1])
+    elif lowered == '--filename' or lowered == '-f':
+        if is_last:
+            print('Argument required!')
+            exit_(1)
+        else:
+            filename = args[i + 1]
+
+if argc <= 1 or not filename:
+    print('Use --help for more information')
+    exit_(1)
+
+if not os.access(filename, os.F_OK):
+    print('Could not open file!')
+    exit_(1)
+
+ext = filename.split('.')[-1]
+no_ext = filename[:-len(ext) - 1].replace('\\', '/').split('/')[-1]
+    
+out_dir = os.path.join(os.path.dirname(filename), no_ext + '_out')
+
+
+if os.path.isdir(out_dir):
+    if os.listdir(out_dir):
+        print('Out dir is not empty!')
+        exit_(1)
+else:
+    os.mkdir(out_dir)
+
+opened = open(filename, 'rb')
+
+readf = opened.read()
+
+file_length = len(readf)
+
+i = 0
+
+while i < file_length - step:
+    temp_file = open(os.path.join(out_dir, f'{no_ext}-{i}.{ext}'), 'wb')
+    temp_file.write(readf[i:i + step])
+    temp_file.close()
+    i += step
+
+
+temp_file = open(os.path.join(out_dir, f'{no_ext}-{i}.{ext}'), 'wb')
+temp_file.write(readf[i:file_length])
+temp_file.close()
+
+opened.close()


### PR DESCRIPTION
Slower than default part file buffer, but can run without server-side, for example - on github pages, where file size limit is 100mb

## How to use
Example on Windows 3.1 image:
```sh
python3 tools/imgsplit.py -f win31.img -s 4096
```
src/browser/main.js
```js
{
	id: "windows31",
	memory_size: 64 * 1024 * 1024,
	hda: {
		"url": "/win31_out/win31.img",
		"async": true,
		"size": 34463744,
		"step": 4096, // just add this to use without server-side
		use_parts: true
	},
	name: "Windows 3.1",
}
```
When {step} is smaller, it will be faster, but have more part files.
I don't recommending to use {step} smaller than 512