### PR TITLE
fix `docker run` command in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -111,7 +111,7 @@ See `tools/docker/test-image/Dockerfile` for a full setup on Debian.
 - If you have docker installed, you can run the whole system inside a container.
 - See `tools/docker/exec` to find Dockerfile required for this.
 - You can run `docker build -f tools/docker/exec/Dockerfile -t v86:alpine-3.14 .` from the root directory to generate docker image.
-- Then you can simply run `docker run -it v86:alpine-3.14 -p 8000:800` to start the server.
+- Then you can simply run `docker run -it -p 8000:8000 v86:alpine-3.14` to start the server.
 - Check `localhost:8000` for hosted server.
 
 ## Testing


### PR DESCRIPTION
Hi again,

Building inside Docker is super great! I fixed a simple typo of `docker run`.

## before PR
<img width="980" alt="image" src="https://user-images.githubusercontent.com/10933561/126896336-8410439e-25d7-4115-9987-3806dd473a7d.png">

## after PR

<img width="492" alt="image" src="https://user-images.githubusercontent.com/10933561/126896348-8ffee4e8-c7de-435e-ba4b-8ae34d25405b.png">

