### PR TITLE
Fix debian build

### DIFF
--- a/tools/docker/debian/Dockerfile
+++ b/tools/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM i386/debian
+FROM i386/debian:buster
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/tools/docker/debian/build-container.sh
+++ b/tools/docker/debian/build-container.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -veu
 
-OUT_ROOTFS_TAR=$(dirname "$0")/../../images/debian-9p-rootfs.tar
-OUT_ROOTFS_FLAT=$(dirname "$0")/../../images/debian-9p-rootfs-flat
-OUT_FSJSON=$(dirname "$0")/../../images/debian-base-fs.json
+OUT_ROOTFS_TAR=$(dirname "$0")/../../../images/debian-9p-rootfs.tar
+OUT_ROOTFS_FLAT=$(dirname "$0")/../../../images/debian-9p-rootfs-flat
+OUT_FSJSON=$(dirname "$0")/../../../images/debian-base-fs.json
 CONTAINER_NAME=debian-full
 IMAGE_NAME=i386/debian-full
 
@@ -13,10 +13,10 @@ docker create -t -i --name "$CONTAINER_NAME" "$IMAGE_NAME" bash
 
 docker export "$CONTAINER_NAME" > "$OUT_ROOTFS_TAR"
 
-$(dirname "$0")/../../tools/fs2json.py --out "$OUT_FSJSON" "$OUT_ROOTFS_TAR"
+$(dirname "$0")/../../../tools/fs2json.py --out "$OUT_FSJSON" "$OUT_ROOTFS_TAR"
 
 # Note: Not deleting old files here
 mkdir -p "$OUT_ROOTFS_FLAT"
-$(dirname "$0")/../../tools/copy-to-sha256.py "$OUT_ROOTFS_TAR" "$OUT_ROOTFS_FLAT"
+$(dirname "$0")/../../../tools/copy-to-sha256.py "$OUT_ROOTFS_TAR" "$OUT_ROOTFS_FLAT"
 
 echo "$OUT_ROOTFS_TAR", "$OUT_ROOTFS_FLAT" and "$OUT_FSJSON" created.

--- a/tools/docker/debian/build-state.js
+++ b/tools/docker/debian/build-state.js
@@ -9,9 +9,9 @@ const path = require("path");
 console.log("Don't forget to run `make all` before running this script");
 
 var fs = require("fs");
-var V86 = require("./../../build/libv86.js").V86;
+var V86 = require("./../../../build/libv86.js").V86;
 
-const V86_ROOT = path.join(__dirname, "../..");
+const V86_ROOT = path.join(__dirname, "../../..");
 
 var OUTPUT_FILE = path.join(V86_ROOT, "images/debian-state-base.bin");
 


### PR DESCRIPTION
Hi,

I fixed `tools/docker/debian` to build debian image. `FROM i386/debian` causes errors, "... bullseye-security InRelease' is not signed.", so I specified `:buster`. I added `../` to `build-container.sh` and `build-state.js`.


One thing I'm not sure is the following statement in tools/docker/debian/Readme.md.

> Go to debug.html?profile=debian to start the generated container.

I don't know how to start the built debian. I confirmed I could run the built debian, modifying examples/arch.html instead.

<img width="552" alt="image" src="https://user-images.githubusercontent.com/10933561/133951383-bbd1dcdd-c9a2-4cf1-8669-fd1af62a7db9.png">

But anyway, this PR fixed building of debian.
