### PR TITLE
fix build on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,18 +170,18 @@ src/rust/gen/analyzer0f.rs: $(ANALYZER_DEPENDENCIES)
 
 build/v86.wasm: $(RUST_FILES) build/softfloat.o build/zstddeclib.o Cargo.toml
 	mkdir -p build/
-	-ls -l --block-size=K build/v86.wasm
+	-BLOCK_SIZE=K ls -l build/v86.wasm
 	cargo rustc --release $(CARGO_FLAGS)
 	mv build/wasm32-unknown-unknown/release/v86.wasm build/v86.wasm
 	-$(WASM_OPT) && wasm-opt -O2 --strip-debug build/v86.wasm -o build/v86.wasm
-	ls -l --block-size=K build/v86.wasm
+	BLOCK_SIZE=K ls -l build/v86.wasm
 
 build/v86-debug.wasm: $(RUST_FILES) build/softfloat.o build/zstddeclib.o Cargo.toml
 	mkdir -p build/
-	-ls -l --block-size=K build/v86-debug.wasm
+	-BLOCK_SIZE=K ls -l build/v86-debug.wasm
 	cargo rustc $(CARGO_FLAGS)
 	mv build/wasm32-unknown-unknown/debug/v86.wasm build/v86-debug.wasm
-	ls -l --block-size=K build/v86-debug.wasm
+	BLOCK_SIZE=K ls -l build/v86-debug.wasm
 
 build/v86-fallback.wasm: $(RUST_FILES) build/softfloat.o build/zstddeclib.o Cargo.toml
 	mkdir -p build/


### PR DESCRIPTION
This attempts to work around #562 by moving the block-size option in ls to an environment variable