### PR TITLE
Add support for PAE (#97)

### DIFF
--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1762,7 +1762,7 @@
         $("dump_gdt").onclick = debug.dump_gdt_ldt.bind(debug);
         $("dump_idt").onclick = debug.dump_idt.bind(debug);
         $("dump_regs").onclick = debug.dump_regs.bind(debug);
-        $("dump_pt").onclick = debug.dump_page_directory.bind(debug);
+        $("dump_pt").onclick = debug.dump_page_structures.bind(debug);
 
         $("dump_log").onclick = function()
         {

--- a/src/const.js
+++ b/src/const.js
@@ -120,6 +120,7 @@ var
 
 /** @const */
 var CR0_PG = 1 << 31;
+var CR4_PAE = 1 << 5;
 
 
 // https://github.com/qemu/seabios/blob/14221cd86eadba82255fdc55ed174d401c7a0a04/src/fw/paravirt.c#L205-L219

--- a/src/rust/cpu/instructions_0f.rs
+++ b/src/rust/cpu/instructions_0f.rs
@@ -798,13 +798,10 @@ pub unsafe fn instr_0F22(r: i32, creg: i32) {
                 return;
             }
             else {
-                if 0 != (*cr.offset(4) ^ data) & (CR4_PGE | CR4_PSE) {
+                if 0 != (*cr.offset(4) ^ data) & (CR4_PGE | CR4_PSE | CR4_PAE) {
                     full_clear_tlb();
                 }
                 *cr.offset(4) = data;
-                if 0 != *cr.offset(4) & CR4_PAE {
-                    dbg_assert!(false, "PAE is not supported");
-                }
             }
         },
         _ => {
@@ -3177,7 +3174,7 @@ pub unsafe fn instr_0FA2() {
                 ecx |= 1 << 31
             }; // hypervisor
             edx = (if true /* have fpu */ { 1 } else {  0 }) |      // fpu
-                    vme | 1 << 3 | 1 << 4 | 1 << 5 |   // vme, pse, tsc, msr
+                    vme | 1 << 3 | 1 << 4 | 1 << 5 | 1 << 6 |  // vme, pse, tsc, msr, pae
                     1 << 8 | 1 << 11 | 1 << 13 | 1 << 15 | // cx8, sep, pge, cmov
                     1 << 23 | 1 << 24 | 1 << 25 | 1 << 26; // mmx, fxsr, sse1, sse2
 

--- a/src/rust/cpu/memory.rs
+++ b/src/rust/cpu/memory.rs
@@ -97,6 +97,19 @@ pub unsafe fn read_aligned32(addr: u32) -> i32 {
     };
 }
 
+pub unsafe fn read_aligned64(addr: u32) -> i64 {
+    dbg_assert!(addr < 0x40000000 as u32);
+    dbg_assert!(addr & 1 == 0);
+    if in_mapped_range(addr << 2) {
+        let lo = mmap_read32(addr << 2);
+        let hi = mmap_read32(addr + 1 << 2);
+        return lo as i64 | (hi as i64) << 32;
+    }
+    else {
+        return *(mem8 as *mut i64).offset((addr >> 1) as isize);
+    }
+}
+
 pub unsafe fn read128(addr: u32) -> reg128 {
     let mut value: reg128 = reg128 {
         i8_0: [0 as i8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/tests/kvm-unit-tests/README.md
+++ b/tests/kvm-unit-tests/README.md
@@ -12,6 +12,7 @@ make -C ../../build/libv86.js
 ./run.js x86/sieve.flat
 ./run.js x86/ioapic.flat
 ./run.js x86/apic.flat
+./run.js x86/pae.flat
 ```
 
 Tests can also be run in browser by going to `?profile=test-$name` (for

--- a/tests/kvm-unit-tests/x86/Makefile.common
+++ b/tests/kvm-unit-tests/x86/Makefile.common
@@ -51,6 +51,7 @@ tests-common = $(TEST_DIR)/vmexit.flat $(TEST_DIR)/tsc.flat \
                $(TEST_DIR)/init.flat $(TEST_DIR)/smap.flat \
                $(TEST_DIR)/hyperv_synic.flat $(TEST_DIR)/hyperv_stimer.flat \
                $(TEST_DIR)/hyperv_connections.flat \
+               $(TEST_DIR)/pae.flat \
 
 ifdef API
 tests-api = api/api-sample api/dirty-log api/dirty-log-perf

--- a/tests/kvm-unit-tests/x86/pae.c
+++ b/tests/kvm-unit-tests/x86/pae.c
@@ -1,0 +1,101 @@
+/* Simple PAE paging test. See lib/x86/vm.c for similar code which sets up
+ * non-PAE paging. */
+
+#include "fwcfg.h"
+#include "asm/page.h"
+#include "processor.h"
+
+#ifdef __x86_64__
+#error This test is 32-bit only.
+#endif
+
+#define HUGE_PAGE_SIZE (1UL << 21)
+
+uint64_t pdpt[4] __attribute__((aligned(0x20)));
+uint64_t page_dirs[4 * 512] __attribute__((aligned(0x1000)));
+uint64_t page_tables[512 * 512] __attribute__((aligned(0x1000)));
+
+static bool is_pae_supported(void) {
+    struct cpuid c = cpuid(1);
+    return c.d & (1 << 6);
+}
+
+/* Fill page directory at `pd` with huge page entries. */
+static void setup_pd_huge_pages(uint64_t *pd, uint64_t start, uint64_t end) {
+    uint64_t phys = start;
+    for (unsigned int i = 0; i < 512; i++) {
+        *pd++ = phys | PT_PRESENT_MASK | PT_WRITABLE_MASK | PT_USER_MASK |
+            PT_PAGE_SIZE_MASK;
+
+        phys += HUGE_PAGE_SIZE;
+        if (phys >= end)
+            return;
+    }
+}
+
+/* Fill page directory at `pd` with page table entries, and use memory at `pt`
+ * to create page tables. */
+static void setup_pd(uint64_t *pd, uint64_t *pt, uint64_t start, uint64_t end) {
+    uint64_t phys = start;
+    for (unsigned int i = 0; i < 512; i++) {
+        *pd++ = (uint32_t)pt | PT_PRESENT_MASK | PT_WRITABLE_MASK | PT_USER_MASK;
+        for (unsigned int j = 0; j < 512; j++) {
+            *pt++ = phys | PT_PRESENT_MASK | PT_WRITABLE_MASK | PT_USER_MASK;
+            phys += PAGE_SIZE;
+            if (phys >= end)
+                return;
+        }
+    }
+}
+
+static void setup_mmu(void) {
+    uint64_t mem_size = fwcfg_get_u64(FW_CFG_RAM_SIZE);
+    if (mem_size > (1ULL << 32))
+        mem_size = 1ULL << 32;
+
+    /* Map physical memory at 0000_0000 using huge pages */
+    pdpt[0] = (uint32_t)&page_dirs[0 * 512] | PT_PRESENT_MASK;
+    setup_pd_huge_pages(&page_dirs[0 * 512], 0, mem_size);
+
+    /* Map physical memory at 4000_0000 using huge pages */
+    pdpt[1] = (uint32_t)&page_dirs[1 * 512] | PT_PRESENT_MASK;
+    setup_pd_huge_pages(&page_dirs[1 * 512], 0, mem_size);
+
+    /* Map physical memory at 8000_0000 using huge pages */
+    pdpt[2] = (uint32_t)&page_dirs[2 * 512] | PT_PRESENT_MASK;
+    setup_pd_huge_pages(&page_dirs[2 * 512], 0, mem_size);
+
+    /* Map physical memory at C000_0000 using normal tables */
+    pdpt[3] = (uint32_t)&page_dirs[3 * 512] | PT_PRESENT_MASK;
+    setup_pd(&page_dirs[3 * 512], &page_tables[0], 0, mem_size);
+
+    write_cr0(0);
+    write_cr4(read_cr4() | X86_CR4_PAE);
+    write_cr3((uint32_t)pdpt);
+    write_cr0(X86_CR0_PG | X86_CR0_PE | X86_CR0_WP);
+
+    printf("paging enabled\n");
+}
+
+int main(void)
+{
+    if (!is_pae_supported()) {
+        printf("PAE not supported\n");
+        return 1;
+    }
+    printf("PAE supported\n");
+    setup_mmu();
+
+    volatile unsigned int test;
+    for (int i = 1; i < 4; i++) {
+        volatile unsigned int *ptr = (unsigned int*)((uint32_t)&test + (i << 30));
+        printf("writing %u to %p, and reading from %p\n", i, ptr, &test);
+        *ptr = i;
+        if (test != i) {
+            printf("error, got %u\n", i);
+            return 1;
+        }
+    }
+    printf("everything OK\n");
+    return 0;
+}


### PR DESCRIPTION
Physical memory is still limited to 32-bit addresses, but systems that enable PAE should work now.

## Ubuntu 12

I managed to boot the Ubuntu 12 ISO. However, it takes a lot of time to start and is too slow to do anything...

![ubuntu12c](https://user-images.githubusercontent.com/468495/149311528-4df044f6-4256-4489-b25d-76f154e80566.png)

(During the boot, it complains about `soft lockup - CPU #0 stuck for 23s!`. Apparently it happens during the inintrd decompression `unlzma`, because it's pretty slow. However, if you just wait, it should go through).

## Serenity OS (#299)

PAE also should unlock Serenity OS. I tried it, but there are still some issues. After applying some workarounds, I managed to boot it and it looks like it initializes network, mouse, and starts various processes. However, graphics fail to display. I'll post an update later.