### PR TITLE
Only scale display when window big enough (#622)

### DIFF
--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -330,7 +330,9 @@ function ScreenAdapter(screen_container, bus)
         graphical_mode_height = height;
 
         // add some scaling to tiny resolutions
-        if(graphical_mode_width <= 640)
+        if(graphical_mode_width <= 640 &&
+           graphical_mode_width * 2 < window.innerWidth &&
+           graphical_mode_height * 2 < window.innerHeight)
         {
             base_scale = 2;
         }


### PR DESCRIPTION
2x Scale graphic display only when 
- Guest system running in low resolution (width <= 640) graphic mode
- Host browser has enough window size to show 2x scale.