### PR TITLE
Floppy image switched with bzimage (sugar for user)

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
             </tr>
 
             <tr>
-                <td><label for="floppy_image">Floppy disk image</label></td>
+                <td><label for="floppy_image">Floppy image / bzImage / vmlinuz.bin</label></td>
                 <td> <input type="file" id="floppy_image"><br></td>
             </tr>
 

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -137,8 +137,18 @@
             var floppy_file = $("floppy_image").files[0];
             if(floppy_file)
             {
-                last_file = floppy_file;
-                settings.fda = { buffer: floppy_file };
+                let name = floppy_file.name;
+                
+                if (name.endsWith("vmlinux") || name.endsWith(".elf") || name.endsWith('.bin') || name.startsWith("bzImage") || name.startsWith("vmlinuz")) {
+                    settings.filesystem = {};
+                    settings.bzimage = { buffer: floppy_file };
+                    last_file = floppy_file;
+                    floppy_file.value = "";
+                    floppy_file = undefined;
+                } else {
+                    last_file = floppy_file;
+                    settings.fda = { buffer: floppy_file };
+                }
             }
 
             var cd_file = $("cd_image").files[0];
@@ -177,7 +187,7 @@
                 set_title(last_file.name);
             }
 
-            start_emulation(settings);
+            start_emulation(settings); ///
         };
 
         if(DEBUG)
@@ -1089,11 +1099,12 @@
             }
         }
 
-        if(!settings.fda)
+        if(!settings.fda && !settings.bzimage)
         {
             var floppy_file = $("floppy_image").files[0];
             if(floppy_file)
             {
+                
                 settings.fda = { buffer: floppy_file };
             }
         }

--- a/src/floppy.js
+++ b/src/floppy.js
@@ -93,8 +93,18 @@ function FloppyController(cpu, fda_image, fdb_image)
         }
         else
         {
-            throw "Unknown floppy size: " + h(fda_image.byteLength);
+            console.error("Unknown floppy size: " + h(this.floppy_size));
+            floppy_type = ((this.floppy_size >> 10) > 1440) ?  floppy_types[2880] : floppy_types[1440];
+            console.log("Floppy type rounded: " + (Object.keys(floppy_types)[Object.values(floppy_types).indexOf(floppy_type)]));
+
+            cpu.devices.rtc.cmos_write(CMOS_FLOPPY_DRIVE_TYPE, floppy_type.type << 4);
+
+            sectors_per_track = floppy_type.sectors;
+            number_of_heads = floppy_type.heads;
+            number_of_cylinders = floppy_type.tracks;
+
         }
+        console.log("Floppy details: ", floppy_type); 
 
         this.sectors_per_track = sectors_per_track;
         this.number_of_heads = number_of_heads;


### PR DESCRIPTION
User can select bzImage/vmlinuz instead floopy disk image, difference detected by name (you can use other detection).
These commits adapted from my fork https://github.com/proxy-m/jx86