### PR TITLE
Allow receiving wasm as a function via wasm_fn

### DIFF
--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -200,13 +200,13 @@ function V86Starter(options)
                 }
             });
         });
-    }
+    };
     
     const loadWASM = async () =>
     {
-        const exports = options["wasm_fn"]
-            ? await options["wasm_fn"]({ "env": wasm_shared_funcs })
-            : await loadWASMFromUrl(v86_bin);
+        const exports = options["wasm_fn"] ?
+            await options["wasm_fn"]({ "env": wasm_shared_funcs }) :
+            await loadWASMFromUrl(v86_bin);
 
         wasm_memory = exports.memory;
         exports["rust_init"]();
@@ -215,7 +215,7 @@ function V86Starter(options)
         cpu = emulator.cpu;
 
         this.continue_init(emulator, options);
-    }
+    };
 
     loadWASM();
 }

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -188,14 +188,14 @@ function V86Starter(options)
                         WebAssembly
                             .instantiate(bytes, env)
                             .then(({ instance }) => {
-                                resolve(instance);
+                                resolve(instance.exports);
                             }, err => {
                                 v86util.load_file(v86_bin_fallback, {
                                     done: bytes => {
                                         WebAssembly
                                             .instantiate(bytes, env)
                                             .then(({ instance }) => {
-                                                resolve(instance);
+                                                resolve(instance.exports);
                                             });
                                     },
                                 });
@@ -219,7 +219,7 @@ function V86Starter(options)
     }
 
     wasm_fn({ "env": wasm_shared_funcs })
-        .then(({ exports }) => {
+        .then((exports) => {
             wasm_memory = exports.memory;
             exports["rust_init"]();
 

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -175,7 +175,7 @@ function V86Starter(options)
         v86_bin_fallback = "build/" + v86_bin_fallback;
     }
 
-    async function loadWASMFromUrl(url)
+    const loadWASMFromUrl = async (url) =>
     {
         return new Promise((resolve) =>
         {
@@ -202,7 +202,7 @@ function V86Starter(options)
         });
     }
     
-    async function loadWASM()
+    const loadWASM = async () =>
     {
         const exports = options["wasm_fn"]
             ? await options["wasm_fn"]({ "env": wasm_shared_funcs })

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -175,68 +175,49 @@ function V86Starter(options)
         v86_bin_fallback = "build/" + v86_bin_fallback;
     }
 
-    if (options["wasm_fn"]) {
-        options["wasm_fn"]({ "env": wasm_shared_funcs })
-            .then((exports) => {
-                const imports = wasm_shared_funcs;
-                wasm_memory = exports.memory;
-                exports["rust_init"]();
-
-                const emulator = this.v86 = new v86(this.emulator_bus, { exports, wasm_table });
-                cpu = emulator.cpu;
-
-                this.continue_init(emulator, options);
-            });
-    } else {
-        v86util.load_file(v86_bin, {
-            done: bytes =>
-            {
-                WebAssembly
-                    .instantiate(bytes, { "env": wasm_shared_funcs })
-                    .then(({ instance }) => {
-                        const imports = wasm_shared_funcs;
-                        const exports = instance["exports"];
-                        wasm_memory = exports.memory;
-                        exports["rust_init"]();
-
-                        const emulator = this.v86 = new v86(this.emulator_bus, { exports, wasm_table });
-                        cpu = emulator.cpu;
-
-                        this.continue_init(emulator, options);
-                    }, err => {
-                        v86util.load_file(v86_bin_fallback, {
-                            done: bytes => {
-                                WebAssembly
-                                    .instantiate(bytes, { "env": wasm_shared_funcs })
-                                    .then(({ instance }) => {
-                                        const imports = wasm_shared_funcs;
-                                        const exports = instance["exports"];
-                                        wasm_memory = exports.memory;
-                                        exports["rust_init"]();
-
-                                        const emulator = this.v86 = new v86(this.emulator_bus, { exports, wasm_table });
-                                        cpu = emulator.cpu;
-
-                                        this.continue_init(emulator, options);
-                                    });
-                            },
-                        });
+    async function loadWASMFromUrl(url)
+    {
+        return new Promise((resolve) =>
+        {
+            v86util.load_file(url, {
+                done: bytes =>
+                {
+                    WebAssembly.instantiate(bytes, { "env": wasm_shared_funcs })
+                        .then(({ instance }) => resolve(instance.exports),
+                            err => loadWASMFromUrl(v86_bin_fallback).then(resolve));
+                },
+                progress: e =>
+                {
+                    this.emulator_bus.send("download-progress", {
+                        file_index: 0,
+                        file_count: 1,
+                        file_name: v86_bin,
+        
+                        lengthComputable: e.lengthComputable,
+                        total: e.total,
+                        loaded: e.loaded,
                     });
-            },
-            progress: e =>
-            {
-                this.emulator_bus.send("download-progress", {
-                    file_index: 0,
-                    file_count: 1,
-                    file_name: v86_bin,
-
-                    lengthComputable: e.lengthComputable,
-                    total: e.total,
-                    loaded: e.loaded,
-                });
-            }
+                }
+            });
         });
     }
+    
+    async function loadWASM()
+    {
+        const exports = options["wasm_fn"]
+            ? await options["wasm_fn"]({ "env": wasm_shared_funcs })
+            : await loadWASMFromUrl(v86_bin);
+
+        wasm_memory = exports.memory;
+        exports["rust_init"]();
+
+        const emulator = this.v86 = new v86(this.emulator_bus, { exports, wasm_table });
+        cpu = emulator.cpu;
+
+        this.continue_init(emulator, options);
+    }
+
+    loadWASM();
 }
 
 V86Starter.prototype.continue_init = async function(emulator, options)


### PR DESCRIPTION
Some bundlers allow directly importing a .wasm file ([https://vitejs.dev/guide/features.html#webassembly](https://vitejs.dev/guide/features.html#webassembly)).

This modification to the starter would allow receiving the wasm file via an import:
```js
import v86Wasm from "../build/v86.wasm";
const emu = new V86Starter({
    wasm_fn: v86Wasm,
});
```