### PR TITLE
Add dac_mask to fix text mode color

### DIFF
--- a/src/vga.js
+++ b/src/vga.js
@@ -308,8 +308,8 @@ function VGAScreen(cpu, bus, vga_memory_size)
     io.register_read(0x3CE, this, this.port3CE_read);
     io.register_read(0x3CF, this, this.port3CF_read);
 
-	io.register_read(0x3C6, this, this.port3C6_read);
-	io.register_write(0x3C6, this, this.port3C6_write);
+    io.register_read(0x3C6, this, this.port3C6_read);
+    io.register_write(0x3C6, this, this.port3C6_write);
     io.register_write(0x3C7, this, this.port3C7_write);
     io.register_read(0x3C7, this, this.port3C7_read);
     io.register_write(0x3C8, this, this.port3C8_write);

--- a/src/vga.js
+++ b/src/vga.js
@@ -253,6 +253,8 @@ function VGAScreen(cpu, bus, vga_memory_size)
     this.dac_color_index_write = 0;
     this.dac_color_index_read = 0;
     this.dac_state = 0;
+	
+	this.dac_mask = 0;
 
     this.dac_map = new Uint8Array(0x10);
 
@@ -306,6 +308,8 @@ function VGAScreen(cpu, bus, vga_memory_size)
     io.register_read(0x3CE, this, this.port3CE_read);
     io.register_read(0x3CF, this, this.port3CF_read);
 
+	io.register_read(0x3C6, this, this.port3C6_read);
+	io.register_write(0x3C6, this, this.port3C6_write);
     io.register_write(0x3C7, this, this.port3C7_write);
     io.register_read(0x3C7, this, this.port3C7_read);
     io.register_write(0x3C8, this, this.port3C8_write);
@@ -832,7 +836,8 @@ VGAScreen.prototype.text_mode_redraw = function()
             color = this.vga_memory[addr | 1];
 
             this.bus.send("screen-put-char", [row, col, chr,
-                this.vga256_palette[color >> 4 & 0xF], this.vga256_palette[color & 0xF]]);
+                this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 0xF]],
+				this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
 
             addr += 2;
         }
@@ -860,7 +865,8 @@ VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
     }
 
     this.bus.send("screen-put-char", [row, col, chr,
-            this.vga256_palette[color >> 4 & 0xF], this.vga256_palette[color & 0xF]]);
+            this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 0xF]],
+			this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
 
     this.vga_memory[addr] = value;
 };
@@ -1488,6 +1494,16 @@ VGAScreen.prototype.port3C5_read = function()
         default:
     }
     return 0;
+};
+
+VGAScreen.prototype.port3C6_write = function(data)
+{
+    this.dac_mask = data;
+};
+
+VGAScreen.prototype.port3C6_read = function()
+{
+    return this.dac_mask;
 };
 
 VGAScreen.prototype.port3C7_write = function(index)

--- a/src/vga.js
+++ b/src/vga.js
@@ -521,7 +521,7 @@ VGAScreen.prototype.set_state = function(state)
     this.clocking_mode = state[59];
     this.line_compare = state[60];
     state[61] && this.pixel_buffer.set(state[61]);
-    this.dac_mask = state[62];
+    this.dac_mask = state[62] === undefined ? 0xFF : state[62];
 
     this.bus.send("screen-set-mode", this.graphical_mode);
 

--- a/src/vga.js
+++ b/src/vga.js
@@ -253,8 +253,8 @@ function VGAScreen(cpu, bus, vga_memory_size)
     this.dac_color_index_write = 0;
     this.dac_color_index_read = 0;
     this.dac_state = 0;
-	
-	this.dac_mask = 0;
+
+    this.dac_mask = 0xFF;
 
     this.dac_map = new Uint8Array(0x10);
 
@@ -452,6 +452,7 @@ VGAScreen.prototype.get_state = function()
     state[59] = this.clocking_mode;
     state[60] = this.line_compare;
     state[61] = this.pixel_buffer;
+    state[62] = this.dac_mask;
 
     return state;
 };
@@ -520,6 +521,7 @@ VGAScreen.prototype.set_state = function(state)
     this.clocking_mode = state[59];
     this.line_compare = state[60];
     state[61] && this.pixel_buffer.set(state[61]);
+    this.dac_mask = state[62];
 
     this.bus.send("screen-set-mode", this.graphical_mode);
 
@@ -837,7 +839,7 @@ VGAScreen.prototype.text_mode_redraw = function()
 
             this.bus.send("screen-put-char", [row, col, chr,
                 this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 0xF]],
-				this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
+                this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
 
             addr += 2;
         }
@@ -865,8 +867,8 @@ VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
     }
 
     this.bus.send("screen-put-char", [row, col, chr,
-            this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 0xF]],
-			this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
+        this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 0xF]],
+        this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
 
     this.vga_memory[addr] = value;
 };


### PR DESCRIPTION
Before:
![before1](https://user-images.githubusercontent.com/68371847/168707418-6045f8e8-feb0-4773-8a76-8168bdc68973.png)
![before2](https://user-images.githubusercontent.com/68371847/168707430-9c889cb4-9757-456f-bd4d-9f173767ca4a.png)
![before3](https://user-images.githubusercontent.com/68371847/168707443-aa02d164-0f19-4762-97ff-e8e8c4152526.png)
After:
![after1](https://user-images.githubusercontent.com/68371847/168707456-3acd903e-829a-4a32-8825-460dd8c4a281.png)
![after2](https://user-images.githubusercontent.com/68371847/168707466-99be2d85-27ad-46df-bc10-61970bef2993.png)
![after3](https://user-images.githubusercontent.com/68371847/168707506-d3844aa3-55f0-44a3-8d03-daff427dae9c.png)