### PR TITLE
DAC Fix for Win9x bootlogo progressbar

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@
  * @define {boolean}
  * Overridden for production by closure compiler
  */
-var DEBUG = true;
+var DEBUG = false;
 
 /** @const */
 var LOG_TO_FILE = false;

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@
  * @define {boolean}
  * Overridden for production by closure compiler
  */
-var DEBUG = false;
+var DEBUG = true;
 
 /** @const */
 var LOG_TO_FILE = false;

--- a/src/vga.js
+++ b/src/vga.js
@@ -1544,11 +1544,11 @@ VGAScreen.prototype.port3C9_write = function(color_byte)
     var index = this.dac_color_index_write / 3 | 0,
         offset = this.dac_color_index_write % 3,
         color = this.vga256_palette[index];
-	
-	var b = color_byte & 1;
+
 	color_byte &= 0x3F;
     if (!(this.dispi_enable_value & 0x20))
 	{
+		var b = color_byte & 1;
 		color_byte = color_byte << 2 | b << 1 | b;
 	}
 

--- a/src/vga.js
+++ b/src/vga.js
@@ -1578,7 +1578,7 @@ VGAScreen.prototype.port3C9_read = function()
     var color = this.vga256_palette[index];
 
     this.dac_color_index_read++;
-    return (color >> (2 - offset) * 8 & 0xFF) / 255 * 63 | 0;
+    return (color >> (2 - offset) * 8 & 0xFF) / 256 * 64 | 0;
 };
 
 VGAScreen.prototype.port3CC_read = function()

--- a/src/vga.js
+++ b/src/vga.js
@@ -1581,14 +1581,14 @@ VGAScreen.prototype.port3C9_read = function()
     var index = this.dac_color_index_read / 3 | 0;
     var offset = this.dac_color_index_read % 3;
     var color = this.vga256_palette[index];
-	var color6 = color >> (2 - offset) * 8 & 0xFF;
+	var color8 = color >> (2 - offset) * 8 & 0xFF;
 
     this.dac_color_index_read++;
 
 	if (this.dispi_enable_value & 0x20)
-		return color6;
-	var b = color6 & 1;
-    return color6 >> 2 | b >> 1 | b;
+		return color8;
+	var b = color8 & 1;
+    return color8 >> 2 | b >> 1 | b;
 };
 
 VGAScreen.prototype.port3CC_read = function()

--- a/src/vga.js
+++ b/src/vga.js
@@ -1581,9 +1581,14 @@ VGAScreen.prototype.port3C9_read = function()
     var index = this.dac_color_index_read / 3 | 0;
     var offset = this.dac_color_index_read % 3;
     var color = this.vga256_palette[index];
+	var color6 = color >> (2 - offset) * 8 & 0xFF;
 
     this.dac_color_index_read++;
-    return (color >> (2 - offset) * 8 & 0xFF) / 255 * 63 | 0;
+
+	if (this.dispi_enable_value & 0x20)
+		return color6;
+	var b = color6 & 1;
+    return color6 >> 2 | b >> 1 | b;
 };
 
 VGAScreen.prototype.port3CC_read = function()

--- a/src/vga.js
+++ b/src/vga.js
@@ -1545,12 +1545,12 @@ VGAScreen.prototype.port3C9_write = function(color_byte)
         offset = this.dac_color_index_write % 3,
         color = this.vga256_palette[index];
 
-	color_byte &= 0x3F;
-    if (!(this.dispi_enable_value & 0x20))
-	{
-		var b = color_byte & 1;
-		color_byte = color_byte << 2 | b << 1 | b;
-	}
+    if((this.dispi_enable_value & 0x20) === 0)
+    {
+        color_byte &= 0x3F;
+        const b = color_byte & 1;
+        color_byte = color_byte << 2 | b << 1 | b;
+    }
 
     if(offset === 0)
     {
@@ -1581,14 +1581,18 @@ VGAScreen.prototype.port3C9_read = function()
     var index = this.dac_color_index_read / 3 | 0;
     var offset = this.dac_color_index_read % 3;
     var color = this.vga256_palette[index];
-	var color8 = color >> (2 - offset) * 8 & 0xFF;
+    var color8 = color >> (2 - offset) * 8 & 0xFF;
 
     this.dac_color_index_read++;
 
-	if (this.dispi_enable_value & 0x20)
-		return color8;
-	var b = color8 & 1;
-    return color8 >> 2 | b >> 1 | b;
+    if(this.dispi_enable_value & 0x20)
+    {
+        return color8;
+    }
+    else
+    {
+        return color8 >> 2;
+    }
 };
 
 VGAScreen.prototype.port3CC_read = function()

--- a/src/vga.js
+++ b/src/vga.js
@@ -1544,8 +1544,13 @@ VGAScreen.prototype.port3C9_write = function(color_byte)
     var index = this.dac_color_index_write / 3 | 0,
         offset = this.dac_color_index_write % 3,
         color = this.vga256_palette[index];
-
-    color_byte = (color_byte & 0x3F) * 255 / 63 | 0;
+	
+	var b = color_byte & 1;
+	color_byte &= 0x3F;
+    if (!(this.dispi_enable_value & 0x20))
+	{
+		color_byte = color_byte << 2 | b << 1 | b;
+	}
 
     if(offset === 0)
     {
@@ -1578,7 +1583,7 @@ VGAScreen.prototype.port3C9_read = function()
     var color = this.vga256_palette[index];
 
     this.dac_color_index_read++;
-    return (color >> (2 - offset) * 8 & 0xFF) / 256 * 64 | 0;
+    return (color >> (2 - offset) * 8 & 0xFF) / 255 * 63 | 0;
 };
 
 VGAScreen.prototype.port3CC_read = function()


### PR DESCRIPTION
I don't know how, but I've randomly fixed it.
Before:
![before](https://user-images.githubusercontent.com/68371847/174467168-d7aa05e2-2d08-405d-a75d-e4aca8c1d925.png)
After:
![after](https://user-images.githubusercontent.com/68371847/174467172-93d02c04-158d-4397-aeae-c9aafeb7b94f.png)

