### PR TITLE
Update Debian build info

### DIFF
--- a/examples/debian.html
+++ b/examples/debian.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<title>Debian</title>
+
+<script src="../build/libv86.js"></script>
+<script>
+"use strict";
+
+window.onload = function()
+{
+    var emulator = new V86Starter({
+        wasm_path: "../build/v86.wasm",
+        memory_size: 512 * 1024 * 1024,
+        vga_memory_size: 8 * 1024 * 1024,
+        screen_container: document.getElementById("screen_container"),
+        bios: { url: "../bios/seabios.bin" },
+        vga_bios: { url: "../bios/vgabios.bin" },
+        initial_state: { url: "../images/debian-state-base.bin" },
+        filesystem: {
+            baseurl: "../images/debian-9p-rootfs-flat/",
+            basefs: { url: "../images/debian-base-fs.json" }
+        },
+        autostart: true,
+    });
+};
+</script>
+
+<!-- A minimal structure for the ScreenAdapter defined in browser/screen.js -->
+<div id="screen_container">
+    <div style="white-space: pre; font: 14px monospace; line-height: 14px"></div>
+    <canvas style="display: none"></canvas>
+</div>

--- a/examples/debian.html
+++ b/examples/debian.html
@@ -12,13 +12,8 @@ window.onload = function()
         memory_size: 512 * 1024 * 1024,
         vga_memory_size: 8 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
-        bios: { url: "../bios/seabios.bin" },
-        vga_bios: { url: "../bios/vgabios.bin" },
         initial_state: { url: "../images/debian-state-base.bin" },
-        filesystem: {
-            baseurl: "../images/debian-9p-rootfs-flat/",
-            basefs: { url: "../images/debian-base-fs.json" }
-        },
+        filesystem: { baseurl: "../images/debian-9p-rootfs-flat/" },
         autostart: true,
     });
 };

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -179,17 +179,6 @@
         // Abandonware OS images are from https://winworldpc.com/library/operating-systems
         var oses = [
             {
-                id: "debian",
-                name: "Debian",
-                memory_size: 512 * 1024 * 1024,
-                vga_memory_size: 8 * 1024 * 1024,
-                state: { url: host + "debian-state-base.bin" },
-                filesystem: {
-                    "baseurl": host + "debian-9p-rootfs-flat/",
-                    "basefs": { url: host + "debian-base-fs.json" }
-                }
-            },
-            {
                 id: "archlinux",
                 name: "Arch Linux",
                 memory_size: 512 * 1024 * 1024,

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -179,6 +179,17 @@
         // Abandonware OS images are from https://winworldpc.com/library/operating-systems
         var oses = [
             {
+                id: "debian",
+                name: "Debian",
+                memory_size: 512 * 1024 * 1024,
+                vga_memory_size: 8 * 1024 * 1024,
+                state: { url: host + "debian-state-base.bin" },
+                filesystem: {
+                    "baseurl": host + "debian-9p-rootfs-flat/",
+                    "basefs": { url: host + "debian-base-fs.json" }
+                }
+            },
+            {
                 id: "archlinux",
                 name: "Arch Linux",
                 memory_size: 512 * 1024 * 1024,

--- a/tools/docker/debian/Readme.md
+++ b/tools/docker/debian/Readme.md
@@ -2,7 +2,8 @@ You can build a Linux image for use with v86:
 
 1. Run `./build-container.sh` to build the Docker container and v86 images (requires dockerd)
 2. Run `./build-state.js` to build a state image in order to skip the boot process
-3. Run a webserver serving repo root and go to `/examples/debian.html` in a browser
+3. Optionally, compress the `debian-state-base.bin` file using zstd (v86 automatically detects the zstd magic and decompresses on the fly)
+4. Run a webserver serving repo root and go to `examples/debian.html` in a browser
 
 If you want to see more info you can run it in a debug mode, to do so add a new profile in the `src/browser/main.js` file to the `oses` variable like so:
 
@@ -14,10 +15,7 @@ var oses = [
         memory_size: 512 * 1024 * 1024,
         vga_memory_size: 8 * 1024 * 1024,
         state: { url: host + "debian-state-base.bin" },
-        filesystem: {
-            "baseurl": host + "debian-9p-rootfs-flat/",
-            "basefs": { url: host + "debian-base-fs.json" }
-        }
+        filesystem: { "baseurl": host + "debian-9p-rootfs-flat/" }
     },
     ...
 ```

--- a/tools/docker/debian/Readme.md
+++ b/tools/docker/debian/Readme.md
@@ -2,7 +2,26 @@ You can build a Linux image for use with v86:
 
 1. Run `./build-container.sh` to build the Docker container and v86 images (requires dockerd)
 2. Run `./build-state.js` to build a state image in order to skip the boot process
+3. Run a webserver serving repo root and go to `/examples/debian.html` in a browser
 
-Go to `debug.html?profile=debian` to start the generated container.
+If you want to see more info you can run it in a debug mode, to do so add a new profile in the `src/browser/main.js` file to the `oses` variable like so:
+
+```js
+var oses = [
+    {
+        id: "debian",
+        name: "Debian",
+        memory_size: 512 * 1024 * 1024,
+        vga_memory_size: 8 * 1024 * 1024,
+        state: { url: host + "debian-state-base.bin" },
+        filesystem: {
+            "baseurl": host + "debian-9p-rootfs-flat/",
+            "basefs": { url: host + "debian-base-fs.json" }
+        }
+    },
+    ...
+```
+
+Save it and go to `debug.html?profile=debian` to start the generated container.
 
 You can modify the `Dockerfile` to customize the generated Linux image.

--- a/tools/docker/debian/build-container.sh
+++ b/tools/docker/debian/build-container.sh
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
 set -veu
 
-OUT_ROOTFS_TAR=$(dirname "$0")/../../../images/debian-9p-rootfs.tar
-OUT_ROOTFS_FLAT=$(dirname "$0")/../../../images/debian-9p-rootfs-flat
-OUT_FSJSON=$(dirname "$0")/../../../images/debian-base-fs.json
+IMAGES="$(dirname "$0")"/../../../images
+OUT_ROOTFS_TAR="$IMAGES"/debian-9p-rootfs.tar
+OUT_ROOTFS_FLAT="$IMAGES"/debian-9p-rootfs-flat
+OUT_FSJSON="$IMAGES"/debian-base-fs.json
 CONTAINER_NAME=debian-full
 IMAGE_NAME=i386/debian-full
 
+mkdir -p "$IMAGES"
 docker build . --platform linux/386 --rm --tag "$IMAGE_NAME"
 docker rm "$CONTAINER_NAME" || true
 docker create --platform linux/386 -t -i --name "$CONTAINER_NAME" "$IMAGE_NAME" bash
 
 docker export "$CONTAINER_NAME" > "$OUT_ROOTFS_TAR"
 
-$(dirname "$0")/../../../tools/fs2json.py --out "$OUT_FSJSON" "$OUT_ROOTFS_TAR"
+"$(dirname "$0")"/../../../tools/fs2json.py --out "$OUT_FSJSON" "$OUT_ROOTFS_TAR"
 
 # Note: Not deleting old files here
 mkdir -p "$OUT_ROOTFS_FLAT"
-$(dirname "$0")/../../../tools/copy-to-sha256.py "$OUT_ROOTFS_TAR" "$OUT_ROOTFS_FLAT"
+"$(dirname "$0")"/../../../tools/copy-to-sha256.py "$OUT_ROOTFS_TAR" "$OUT_ROOTFS_FLAT"
 
 echo "$OUT_ROOTFS_TAR", "$OUT_ROOTFS_FLAT" and "$OUT_FSJSON" created.

--- a/tools/docker/debian/build-container.sh
+++ b/tools/docker/debian/build-container.sh
@@ -7,9 +7,9 @@ OUT_FSJSON=$(dirname "$0")/../../../images/debian-base-fs.json
 CONTAINER_NAME=debian-full
 IMAGE_NAME=i386/debian-full
 
-docker build . --rm --tag "$IMAGE_NAME"
+docker build . --platform linux/386 --rm --tag "$IMAGE_NAME"
 docker rm "$CONTAINER_NAME" || true
-docker create -t -i --name "$CONTAINER_NAME" "$IMAGE_NAME" bash
+docker create --platform linux/386 -t -i --name "$CONTAINER_NAME" "$IMAGE_NAME" bash
 
 docker export "$CONTAINER_NAME" > "$OUT_ROOTFS_TAR"
 


### PR DESCRIPTION
This MR addresses 2 issues:
## In the README about building Debian image 1 step is missing.
You need to add a new profile into main.js file in order for http://localhost/debug?profile=debian to load something, otherwise it just loads default debug page instead of actual image.

## There is an error while building Debian image
Error looks like this: 
> WARNING: The requested image’s platform (linux/386) does not match the detected host platform (linux/amd64) and no specific platform was requested

Adding platform in the build script explicitly fixes the issue.

ps: I guess I should have opened separate merge requests for each issue...?