### PR TITLE
Allow sharing files with guest using UI, even with custom profile

### DIFF
--- a/lib/9p.js
+++ b/lib/9p.js
@@ -733,6 +733,7 @@ Virtio9p.prototype.ReceiveRequest = async function (bufchain) {
             marshall.Marshall(["Q"], [inode.qid], this.replybuffer, 7);
             this.BuildReply(id, tag, 13);
             this.SendReply(bufchain);
+            this.bus.send("9p-attach");
             break;
 
         case 108: // tflush

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1263,12 +1263,15 @@
         $("runtime_options").style.display = "block";
         $("runtime_infos").style.display = "block";
         $("screen_container").style.display = "block";
-
-        if(settings.filesystem)
-        {
-            init_filesystem_panel(emulator);
+        init_filesystem_panel(emulator);
+        if(!(settings.filesystem)) {
+            // Hide the filesystem panel for now
+            $("filesystem_panel").style.display="none";
+            // Show the filesystem panel if it's ever used
+            emulator.add_listener("9p-read-start", function(args) {
+                $("filesystem_panel").style.display="block";
+            });
         }
-
         $("run").onclick = function()
         {
             if(emulator.is_running())

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1263,15 +1263,19 @@
         $("runtime_options").style.display = "block";
         $("runtime_infos").style.display = "block";
         $("screen_container").style.display = "block";
-        init_filesystem_panel(emulator);
-        if(!(settings.filesystem)) {
-            // Hide the filesystem panel for now
-            $("filesystem_panel").style.display="none";
-            // Show the filesystem panel if the 9p file share is mounted at some point (May break with saved state)
-            emulator.add_listener("9p-attach", function() {
-                $("filesystem_panel").style.display="block";
+
+        if(settings.filesystem)
+        {
+            init_filesystem_panel(emulator);
+        }
+        else
+        {
+            emulator.add_listener("9p-attach", function()
+            {
+                init_filesystem_panel(emulator);
             });
         }
+
         $("run").onclick = function()
         {
             if(emulator.is_running())

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1267,8 +1267,8 @@
         if(!(settings.filesystem)) {
             // Hide the filesystem panel for now
             $("filesystem_panel").style.display="none";
-            // Show the filesystem panel if it's ever used
-            emulator.add_listener("9p-read-start", function(args) {
+            // Show the filesystem panel if the 9p file share is mounted at some point (May break with saved state)
+            emulator.add_listener("9p-attach", function() {
                 $("filesystem_panel").style.display="block";
             });
         }


### PR DESCRIPTION
The 9p filesystem is always accessible by the guest, even if the UI is hidden. This will make the file picker UI be shown when needed; all the user has to do is run `ls` on the 9p mount.