### PR TITLE
readme: add SkiffOS (Buildroot) config link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,6 +59,7 @@ Here's an overview of the operating systems supported in v86:
   - [Buildroot](https://buildroot.uclibc.org) can be used to build a minimal image.
     [humphd/browser-vm](https://github.com/humphd/browser-vm) and
     [darin755/browser-buildroot](https://github.com/Darin755/browser-buildroot) have some useful scripts for building one.
+  - [SkiffOS](https://github.com/skiffos/SkiffOS/tree/master/configs/browser/v86) (based on Buildroot) can cross-compile a custom image.
   - Archlinux works. See [archlinux.md](docs/archlinux.md) for building an image.
   - Debian works. An image can be built from a Dockerfile, see [tools/docker/debian/](tools/docker/debian/).
   - Ubuntu up to 16.04 works.


### PR DESCRIPTION
SkiffOS is a configuration layering system for Buildroot.

It supports re-targeting system image configs to different hardware.

The linked configuration can be combined with other layers to deploy Docker and other Linux distributions to the v86 emulator.

The configuration fragments slim down the Buildroot and Kernel systems & switch off any unnecessary features.

https://github.com/skiffos/SkiffOS/tree/master/configs/browser/v86

Demo ISO: https://drive.google.com/file/d/1UFoUEt1CQrD8B4800ii9yehff68h9IPG/view

V86 is really awesome & I was really floored to see that everything could run in it with minimal adjustments.