### PR TITLE
Fix V86.destroy() with xterm.js

### DIFF
--- a/src/browser/serial.js
+++ b/src/browser/serial.js
@@ -240,8 +240,8 @@ function SerialAdapterXtermJS(element, bus)
     }, this);
 
     this.destroy = function() {
-        on_data_disposable["dispose"]()
-        term["dispose"]()
+        on_data_disposable["dispose"]();
+        term["dispose"]();
     };
 }
 

--- a/src/browser/serial.js
+++ b/src/browser/serial.js
@@ -234,21 +234,15 @@ function SerialAdapterXtermJS(element, bus)
         }
     });
 
-    bus.register("serial0-output-char", serial_char_handler, this);
-
-    this.destroy = function()
-    {
-        on_data_disposable["dispose"]();
-        term["dispose"]();
-    }
-
-    /**
-     * @param {string} chr 
-     */
-    function serial_char_handler(chr)
+    bus.register("serial0-output-char", function(chr)
     {
         term.write(chr);
-    }
+    }, this);
+
+    this.destroy = function() {
+        on_data_disposable["dispose"]()
+        term["dispose"]()
+    };
 }
 
 SerialAdapterXtermJS.prototype.show = function()

--- a/src/browser/serial.js
+++ b/src/browser/serial.js
@@ -227,22 +227,29 @@ function SerialAdapterXtermJS(element, bus)
     term["setOption"]("logLevel", "off");
     term.write("This is the serial console. Whatever you type or paste here will be sent to COM1");
 
-    term["onData"](function(data) {
+    const on_data_disposable = term["onData"](function(data) {
         for(let i = 0; i < data.length; i++)
         {
             bus.send("serial0-input", data.charCodeAt(i));
         }
     });
 
-    bus.register("serial0-output-char", function(chr)
+    bus.register("serial0-output-char", serial_char_handler, this);
+
+    this.destroy = function()
+    {
+        bus.unregister("serial0-output-char", serial_char_handler);
+        on_data_disposable["dispose"]();
+        term["dispose"]();
+    }
+
+    /**
+     * @param {string} chr 
+     */
+    function serial_char_handler(chr)
     {
         term.write(chr);
-    }, this);
-}
-
-SerialAdapterXtermJS.prototype.destroy = function()
-{
-    this.term && this.term.dispose();
+    }
 }
 
 SerialAdapterXtermJS.prototype.show = function()

--- a/src/browser/serial.js
+++ b/src/browser/serial.js
@@ -240,6 +240,11 @@ function SerialAdapterXtermJS(element, bus)
     }, this);
 }
 
+SerialAdapterXtermJS.prototype.destroy = function()
+{
+    this.term && this.term.dispose();
+}
+
 SerialAdapterXtermJS.prototype.show = function()
 {
     this.term && this.term.open(this.element);

--- a/src/browser/serial.js
+++ b/src/browser/serial.js
@@ -238,7 +238,6 @@ function SerialAdapterXtermJS(element, bus)
 
     this.destroy = function()
     {
-        bus.unregister("serial0-output-char", serial_char_handler);
         on_data_disposable["dispose"]();
         term["dispose"]();
     }

--- a/src/bus.js
+++ b/src/bus.js
@@ -33,7 +33,7 @@ BusConnector.prototype.register = function(name, fn, this_value)
  * Unregister one message with the given name and callback
  *
  * @param {string} name
- * @param {function()} fn
+ * @param {function(?)} fn
  */
 BusConnector.prototype.unregister = function(name, fn)
 {


### PR DESCRIPTION
`V86.destroy()` was throwing an error due to `SerialAdapterXtermJS`
having no `destroy()` method.