### PR TITLE
Wait for emulation to stop when destroying

### DIFF
--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -708,9 +708,8 @@ V86Starter.prototype.stop = async function()
             resolve();
         };
         this.add_listener("emulator-stopped", listener);
+        this.bus.send("cpu-stop");
     });
-
-    this.bus.send("cpu-stop");
 
     await stopped;
 };

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -698,22 +698,21 @@ V86Starter.prototype.run = async function()
  */
 V86Starter.prototype.stop = async function()
 {
-    // Emulation is not guaranteed to stop immediately in the same event loop
-    // cycle.
-    // If the emulator is running, this promise will resolve when the emulator
-    // has finished stopping.
-    // Else, this promise will resolve immediately.
-    const promise = new Promise(resolve => {
-        if (!this.cpu_is_running) return resolve();
+    if (!this.cpu_is_running) {
+        return;
+    }
+
+    const stopped = new Promise((resolve) => {
         const listener = () => {
             this.remove_listener("emulator-stopped", listener);
             resolve();
         };
         this.add_listener("emulator-stopped", listener);
-        this.bus.send("cpu-stop");
-    })
+    });
 
-    await promise;
+    this.bus.send("cpu-stop");
+
+    await stopped;
 };
 
 /**

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -698,11 +698,12 @@ V86Starter.prototype.run = async function()
  */
 V86Starter.prototype.stop = async function()
 {
-    if (!this.cpu_is_running) {
+    if(!this.cpu_is_running)
+    {
         return;
     }
 
-    const stopped = new Promise((resolve) => {
+    await new Promise(resolve => {
         const listener = () => {
             this.remove_listener("emulator-stopped", listener);
             resolve();
@@ -710,8 +711,6 @@ V86Starter.prototype.stop = async function()
         this.add_listener("emulator-stopped", listener);
         this.bus.send("cpu-stop");
     });
-
-    await stopped;
 };
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ function v86(bus, wasm)
     this.running = false;
 
     /** @type {boolean} */
-    this.stopped = false;
+    this.stopping = false;
 
     this.tick_counter = 0;
     this.worker = null;
@@ -29,7 +29,7 @@ function v86(bus, wasm)
 
 v86.prototype.run = function()
 {
-    this.stopped = false;
+    this.stopping = false;
 
     if(!this.running)
     {
@@ -42,9 +42,9 @@ v86.prototype.run = function()
 
 v86.prototype.do_tick = function()
 {
-    if(this.stopped || !this.running)
+    if(this.stopping || !this.running)
     {
-        this.stopped = this.running = false;
+        this.stopping = this.running = false;
         this.bus.send("emulator-stopped");
         return;
     }
@@ -74,7 +74,7 @@ v86.prototype.stop = function()
 {
     if(this.running)
     {
-        this.stopped = true;
+        this.stopping = true;
     }
 };
 


### PR DESCRIPTION
In some environments, the "emulator-stopped" event did not always fire when calling the `destroy()` method. This waits for emulation to finish stopping before continuing with the rest of the destructor.

My use case, for more context:
I'm running v86 in a React app, and the page does not reload between destroying one emulator instance and starting another. Setting event listeners for the "emulator-stopped" event seemed to prevent garbage collection, so it quickly consumed lots of memory and would crash the browser tab.