### PR TITLE
Faster `BusConnector.prototype.unregister()`

### DIFF
--- a/src/browser/worker_bus.js
+++ b/src/browser/worker_bus.js
@@ -13,9 +13,8 @@ WorkerBus.Connector = function(pair)
         var data = e.data;
         var listeners = this.listeners[data[0]];
 
-        for(var i = 0; i < listeners.length; i++)
+        for(const listener of listeners)
         {
-            var listener = listeners[i];
             listener.fn.call(listener.this_value, data[1]);
         }
     }.bind(this), false);
@@ -28,10 +27,10 @@ WorkerBus.Connector.prototype.register = function(name, fn, this_value)
 
     if(listeners === undefined)
     {
-        listeners = this.listeners[name] = [];
+        listeners = this.listeners[name] = new Set();
     }
 
-    listeners.push({
+    listeners.add({
         fn: fn,
         this_value: this_value,
     });

--- a/src/bus.js
+++ b/src/bus.js
@@ -20,10 +20,10 @@ BusConnector.prototype.register = function(name, fn, this_value)
 
     if(listeners === undefined)
     {
-        listeners = this.listeners[name] = [];
+        listeners = this.listeners[name] = new Set();
     }
 
-    listeners.push({
+    listeners.add({
         fn: fn,
         this_value: this_value,
     });
@@ -44,10 +44,7 @@ BusConnector.prototype.unregister = function(name, fn)
         return;
     }
 
-    this.listeners[name] = listeners.filter(function(l)
-    {
-        return l.fn !== fn;
-    });
+    listeners.delete(fn);
 };
 
 /**
@@ -71,9 +68,8 @@ BusConnector.prototype.send = function(name, value, unused_transfer)
         return;
     }
 
-    for(var i = 0; i < listeners.length; i++)
+    for(const listener of listeners)
     {
-        var listener = listeners[i];
         listener.fn.call(listener.this_value, value);
     }
 };


### PR DESCRIPTION
By storing the event listeners in a set, it eliminates the need to
iterate over an array to remove each listener. `.unregister()` is now an
O(1) operation (vs. the previous O(n)).