### PR TITLE
Advertise latest SerenityOS version as working

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,7 +81,7 @@ Here's an overview of the operating systems supported in v86:
 - OpenBSD works with a specific boot configuration. At the `boot>` prompt type
   `boot -c`, then at the `UKC>` prompt `disable mpbios` and `exit`.
 - NetBSD works only with a custom kernel, see [#350](https://github.com/copy/v86/issues/350).
-- Older versions of SerenityOS work (1.0.gc460f4a is a known working version).
+- SerenityOS works.
 
 You can get some infos on the disk images here: https://github.com/copy/images.
 


### PR DESCRIPTION
After #299 was resolved (thanks for your awesome work!), we can simply advertise SerenityOS target as working in the README.md file.