### PR TITLE
Add support for fixed_chunk_size to async Range downloads.

### DIFF
--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -441,7 +441,7 @@ V86Starter.prototype.continue_init = async function(emulator, options)
                 }
                 else
                 {
-                    buffer = new v86util.AsyncXHRBuffer(file.url, file.size);
+                    buffer = new v86util.AsyncXHRBuffer(file.url, file.size, file.fixed_chunk_size);
                 }
 
                 files_to_load.push({

--- a/src/buffer.js
+++ b/src/buffer.js
@@ -203,7 +203,7 @@
         if(this.fixed_chunk_size)
         {
             requested_start = offset - (offset % this.fixed_chunk_size);
-            requested_length = (Math.floor((offset + len - 1) / this.fixed_chunk_size) + 1 - Math.floor(requested_start / this.fixed_chunk_size)) * this.fixed_chunk_size;
+            requested_length = Math.ceil((offset - requested_start + len) / this.fixed_chunk_size) * this.fixed_chunk_size;
         }
 
         v86util.load_file(this.filename, {


### PR DESCRIPTION
This allows reducing the number of separate HTTP requests, which considerably improves load times at the cost of increased bandwidth use. Tested locally, to a limited extent.