### PR TITLE
Make screenshot function return an Image

### DIFF
--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1932,7 +1932,12 @@
 
         $("take_screenshot").onclick = function()
         {
-            emulator.screen_make_screenshot();
+            const image = emulator.screen_make_screenshot();
+            try {
+                const w = window.open("");
+                w.document.write(image.outerHTML);
+            }
+            catch(e) {}
             $("take_screenshot").blur();
         };
 

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -16,7 +16,7 @@ function ScreenAdapter(screen_container, bus)
 
         text_screen = screen_container.getElementsByTagName("div")[0],
         cursor_element = document.createElement("div");
-  
+
     var
         /** @type {number} */
         cursor_row,

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -16,7 +16,7 @@ function ScreenAdapter(screen_container, bus)
 
         text_screen = screen_container.getElementsByTagName("div")[0],
         cursor_element = document.createElement("div");
-
+  
     var
         /** @type {number} */
         cursor_row,
@@ -220,12 +220,7 @@ function ScreenAdapter(screen_container, bus)
 
             image.src = canvas.toDataURL("image/png");
         }
-
-        try {
-            const w = window.open("");
-            w.document.write(image.outerHTML);
-        }
-        catch(e) {}
+        return image;
     };
 
     this.put_char = function(row, col, chr, bg_color, fg_color)

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -963,8 +963,9 @@ V86Starter.prototype.screen_make_screenshot = function()
 {
     if(this.screen_adapter)
     {
-        this.screen_adapter.make_screenshot();
+        return this.screen_adapter.make_screenshot();
     }
+    return null;
 };
 
 /**


### PR DESCRIPTION
Returning an image rather than always opening a new window slightly expands the utility of embedding v86---we may want to take a screenshot and use just its data without asking the user to download it.