### PR TITLE
Implement HADDPS instruction

### DIFF
--- a/gen/x86_table.js
+++ b/gen/x86_table.js
@@ -699,6 +699,7 @@ const encodings = [
     { sse: 1, opcode: 0x660F59, e: 1, custom: 1 },
     { sse: 1, opcode: 0xF20F59, e: 1, custom: 1 },
     { sse: 1, opcode: 0xF30F59, e: 1, custom: 1 },
+    { sse: 1, opcode: 0xF20F7C, e: 1, custom: 1 },
 
     { sse: 1, opcode: 0x0F5A, e: 1, custom: 1 },
     { sse: 1, opcode: 0x660F5A, e: 1, custom: 1 },

--- a/src/rust/cpu/instructions_0f.rs
+++ b/src/rust/cpu/instructions_0f.rs
@@ -1821,6 +1821,24 @@ pub unsafe fn instr_F30F59_reg(r1: i32, r2: i32) { instr_F30F59(read_xmm_f32(r1)
 pub unsafe fn instr_F30F59_mem(addr: i32, r: i32) {
     instr_F30F59(return_on_pagefault!(safe_read_f32(addr)), r);
 }
+#[no_mangle]
+pub unsafe fn instr_F20F7C(source: reg128, r: i32) {
+    // haddps xmm, xmm/mem128
+    let destination = read_xmm128s(r);
+    let result = reg128 {
+        f32: [
+            destination.f32[0] + destination.f32[1],
+            destination.f32[2] + destination.f32[3],
+            source.f32[0] + source.f32[1],
+            source.f32[2] + source.f32[3],
+        ],
+    };
+    write_xmm_reg128(r, result);
+}
+pub unsafe fn instr_F20F7C_reg(r1: i32, r2: i32) { instr_F20F7C(read_xmm128s(r1), r2); }
+pub unsafe fn instr_F20F7C_mem(addr: i32, r: i32) {
+    instr_F20F7C(return_on_pagefault!(safe_read128s(addr)), r);
+}
 
 #[no_mangle]
 pub unsafe fn instr_0F5A(source: u64, r: i32) {

--- a/src/rust/jit_instructions.rs
+++ b/src/rust/jit_instructions.rs
@@ -6128,6 +6128,12 @@ pub fn instr_F30F59_mem_jit(ctx: &mut JitContext, modrm_byte: ModrmByte, r: u32)
 pub fn instr_F30F59_reg_jit(ctx: &mut JitContext, r1: u32, r2: u32) {
     sse_read_f32_xmm_xmm(ctx, "instr_F30F59", r1, r2);
 }
+pub fn instr_F20F7C_mem_jit(ctx: &mut JitContext, modrm_byte: ModrmByte, r: u32) {
+    sse_read128_xmm_mem(ctx, "instr_F20F7C", modrm_byte, r);
+}
+pub fn instr_F20F7C_reg_jit(ctx: &mut JitContext, r1: u32, r2: u32) {
+    sse_read128_xmm_xmm(ctx, "instr_F20F7C", r1, r2);
+}
 
 pub fn instr_0F5A_mem_jit(ctx: &mut JitContext, modrm_byte: ModrmByte, r: u32) {
     sse_read64_xmm_mem(ctx, "instr_0F5A", modrm_byte, r);


### PR DESCRIPTION
This PR adds the HADDPS instruction, which fixes [this issue](https://github.com/copy/v86/issues/835). This allows the KolibriOS Raytracing demo to run. Numeric exceptions aren't implemented.

Documentation:
- https://c9x.me/x86/html/file_module_x86_id_133.html
- https://www.felixcloutier.com/x86/haddps