### PR TITLE
Floppy eject/insert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,7 @@ api-tests: all-debug
 	./tests/api/clean-shutdown.js
 	./tests/api/state.js
 	./tests/api/reset.js
+	./tests/api/floppy-insert-eject.js
 
 all-tests: jshint kvm-unit-test qemutests qemutests-release jitpagingtests api-tests nasmtests nasmtests-force-jit tests expect-tests
 	# Skipping:

--- a/debug.html
+++ b/debug.html
@@ -226,6 +226,7 @@ function load_next()
                 <td><label for="boot_order">Boot order</label></td>
                 <td>
                     <select id="boot_order">
+                        <option value="0">Auto</option>
                         <option value="213">CD / Floppy / Hard Disk</option>
                         <option value="123">CD / Hard Disk / Floppy</option>
                         <option value="231">Floppy / CD / Hard Disk</option>

--- a/debug.html
+++ b/debug.html
@@ -262,6 +262,7 @@ function load_next()
         <input type="button" value="Get hard disk image" id="get_hda_image">
         <input type="button" value="Get second hard disk image" id="get_hdb_image">
         <input type="button" value="Get cdrom image" id="get_cdrom_image">
+        <input type="button" value="Insert floppy image" id="change_fda_image">
         <input type="button" value="Save State" id="save_state">
         <input type="button" value="Load State" id="load_state"> <input type="file" style="display: none" id="load_state_input">
         <input type="button" value="Memory Dump" id="memory_dump">
@@ -278,16 +279,6 @@ function load_next()
         </label>
 
         <br>
-        <label id="change_fda" style="display: none">
-            Change floppy:
-            <input type="file">
-        </label>
-
-        <label id="change_cdrom" style="display: none">
-            Change CD:
-            <input type="file">
-        </label>
-
     </div>
 
     <pre style="margin: 0" id="log_levels"></pre>

--- a/index.html
+++ b/index.html
@@ -158,6 +158,7 @@
                 <td><label for="boot_order">Boot order</label></td>
                 <td>
                     <select id="boot_order">
+                        <option value="0">Auto</option>
                         <option value="213">CD / Floppy / Hard Disk</option>
                         <option value="123">CD / Hard Disk / Floppy</option>
                         <option value="231">Floppy / CD / Hard Disk</option>

--- a/index.html
+++ b/index.html
@@ -185,6 +185,7 @@
         <input type="button" value="Get hard disk image" id="get_hda_image">
         <input type="button" value="Get second hard disk image" id="get_hdb_image">
         <input type="button" value="Get cdrom image" id="get_cdrom_image">
+        <input type="button" value="Insert floppy image" id="change_fda_image">
         <input type="button" value="Save State" id="save_state">
         <input type="button" value="Load State" id="load_state"> <input type="file" style="display: none" id="load_state_input">
         <input type="button" value="Memory Dump" id="memory_dump">
@@ -201,18 +202,6 @@
         </label>
 
         <br>
-        <label id="change_fda" style="display: none">
-            Change floppy:
-            <input type="file">
-        </label>
-
-        <label id="change_cdrom" style="display: none">
-            Change CD:
-            <input type="file">
-        </label>
-
-        <br>
-
     </div>
     <pre style="display: none" id="loading"></pre>
 </div>

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -343,7 +343,6 @@
                     size: 8 * 1024 * 1024,
                     async: false,
                 },
-                boot_order: 0x132,
                 name: "MS-DOS",
             },
             {
@@ -605,7 +604,6 @@
                     fixed_chunk_size: 256 * 1024,
                     use_parts: !ON_LOCALHOST,
                 },
-                boot_order: 0x132,
                 name: "Windows 2000",
             },
             {

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1704,6 +1704,32 @@
             };
         }
 
+        $("change_fda_image").value = settings.fda ? "Eject floppy image" : "Insert floppy image";
+        $("change_fda_image").onclick = function()
+        {
+            if(emulator.v86.cpu.devices.fdc.fda_image)
+            {
+                emulator.eject_fda();
+                $("change_fda_image").value = "Insert floppy image";
+            }
+            else
+            {
+                const file_input = document.createElement("input");
+                file_input.type = "file";
+                file_input.onchange = async function(e)
+                {
+                    const file = file_input.files[0];
+                    if(file)
+                    {
+                        await emulator.set_fda({ buffer: file });
+                        $("change_fda_image").value = "Eject floppy image";
+                    }
+                };
+                file_input.click();
+            }
+            $("change_fda_image").blur();
+        };
+
         $("memory_dump").onclick = function()
         {
             const mem8 = emulator.v86.cpu.mem8;

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -994,7 +994,7 @@ V86Starter.prototype.set_fda = async function(file)
         {
             this.v86.cpu.devices.fdc.set_fda(image);
         };
-        image.load();
+        await image.load();
     }
 };
 

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -256,12 +256,17 @@ V86Starter.prototype.continue_init = async function(emulator, options)
         "cdrom": undefined,
     };
 
+    const boot_order =
+        options["boot_order"] ? options["boot_order"] :
+        options["fda"] ? BOOT_ORDER_FD_FIRST :
+        options["hda"] ? BOOT_ORDER_HD_FIRST : BOOT_ORDER_CD_FIRST;
+
     settings.acpi = options["acpi"];
     settings.load_devices = true;
     settings.log_level = options["log_level"];
     settings.memory_size = options["memory_size"] || 64 * 1024 * 1024;
     settings.vga_memory_size = options["vga_memory_size"] || 8 * 1024 * 1024;
-    settings.boot_order = options["boot_order"] || 0x213;
+    settings.boot_order = boot_order;
     settings.fastboot = options["fastboot"] || false;
     settings.fda = undefined;
     settings.fdb = undefined;

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -1111,7 +1111,7 @@ CPU.prototype.load_multiboot = function(buffer)
 
 CPU.prototype.fill_cmos = function(rtc, settings)
 {
-    var boot_order = settings.boot_order || 0x213;
+    var boot_order = settings.boot_order || BOOT_ORDER_CD_FIRST;
 
     // Used by seabios to determine the boot order
     //   Nibble

--- a/src/rtc.js
+++ b/src/rtc.js
@@ -40,6 +40,10 @@
 /** @const */ var CMOS_MEM_HIGHMEM_HIGH = 0x5d;
 /** @const */ var CMOS_BIOS_SMP_COUNT = 0x5f;
 
+// see CPU.prototype.fill_cmos
+const BOOT_ORDER_CD_FIRST = 0x123;
+const BOOT_ORDER_HD_FIRST = 0x312;
+const BOOT_ORDER_FD_FIRST = 0x321;
 
 /**
  * RTC (real time clock) and CMOS

--- a/tests/api/floppy-insert-eject.js
+++ b/tests/api/floppy-insert-eject.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+"use strict";
+
+const TEST_RELEASE_BUILD = +process.env.TEST_RELEASE_BUILD;
+
+const fs = require("fs");
+var V86 = require(`../../build/${TEST_RELEASE_BUILD ? "libv86" : "libv86-debug"}.js`).V86;
+
+process.on("unhandledRejection", exn => { throw exn; });
+
+const emulator = new V86({
+    bios: { url: __dirname + "/../../bios/seabios.bin" },
+    vga_bios: { url: __dirname + "/../../bios/vgabios.bin" },
+    hda: { url: __dirname + "/../../images/msdos.img" },
+    network_relay_url: "<UNUSED>",
+    autostart: true,
+    memory_size: 32 * 1024 * 1024,
+    filesystem: {},
+    log_level: 0,
+    screen_dummy: true,
+});
+
+emulator.automatically([
+    { sleep: 1 },
+    { vga_text: "C:\\> " },
+    { keyboard_send: "dir A:\n" },
+    { vga_text: "Abort, Retry, Fail?" },
+    { keyboard_send: "F" },
+    { call: () => {
+            emulator.set_fda({ url: __dirname + "/../../images/freedos722.img" });
+        },
+    },
+    { keyboard_send: "dir A:\n" },
+    { sleep: 1 },
+    { vga_text: "FDOS         <DIR>" },
+    { call: () => {
+            console.log("Passed");
+            emulator.stop();
+        }
+    },
+]);


### PR DESCRIPTION
This patch implements two new methods on FloppyController, `eject_fda` and `insert_fda`.  These are not exposed to the UI yet, but from the browser console in debug mode they work for removing and inserting floppies in MS-DOS at least.

Caveats:
1. FloppyController does not implement the format track command, so you need to give it a pre-formatted disk image.
2. FloppyController does not seem to emulate all the relevant internal controller state, so I made a best-effort patch here (references: [this website](https://www.isdaman.com/alsos/hardware/fdc/floppy.htm) , [osdev](https://wiki.osdev.org/Floppy_Disk_Controller) ).  I did what I could around reset behavior, extending existing commands, and reporting errors on seeks and reads, but this is pretty far outside my wheelhouse.

So, please see this PR as a request for testing and review towards part of #54 .