### PR TITLE
Use localstorage to save options

### DIFF
--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -101,6 +101,29 @@
 
     function onload()
     {
+        // Load previously entered options via the local storage
+        const elementsToRestore = ['memory_size', 'video_memory_size', 'networking_proxy', 'disable_audio', 'enable_acpi', 'boot_order'];
+        for (const elementId of elementsToRestore)
+        {
+            const savedValue = window.localStorage.getItem(elementId);
+          
+            if (savedValue !== null)
+            {
+                const element = document.getElementById(elementId);
+                if (element)
+                {
+                    if(element.type === 'checkbox')
+                    {
+                        element.checked = savedValue === 'true' ? true : false;
+                    }
+                    else
+                    {
+                        element.value = savedValue;
+                    }
+                }
+            }
+        }
+
         if(!window.WebAssembly)
         {
             alert("Your browser is not supported because it doesn't support WebAssembly");
@@ -116,6 +139,22 @@
 
         $("start_emulation").onclick = function()
         {
+            // Save entered options into the local storage
+            for (const elementId of elementsToRestore)
+            {
+                const element = document.getElementById(elementId);
+                if(element){
+                    if(element.tagName === 'SELECT' || element.type !== 'checkbox')
+                    {
+                        window.localStorage.setItem(elementId, element.value);
+                    }
+                    else
+                    {
+                        window.localStorage.setItem(elementId, element.checked);
+                    }
+                }
+            }
+
             $("boot_options").style.display = "none";
             set_profile("custom");
 


### PR DESCRIPTION
This small change just incorporates the usage of the browser's local storage to remember and restore a handful of options for a minor increase to the overall quality of life.
Namely it saves and restores:
1. System memory size 
2. Video memory size
3. The networking proxy that's configured (saving this will be rather nice if testing a local one)
4. The boot order
5. If audio is enabled
6. If ACPI is enabled

Worst case, this doesn't save info in a way that someone finds helpful and they have to change the value as they would have normally. Best case, people re-use the config for a bunch of different testing and this change saves them a bit of clicks / keystrokes.