### PR TITLE
Target keyboard events to screencontainer instead of window

### DIFF
--- a/src/browser/keyboard.js
+++ b/src/browser/keyboard.js
@@ -11,8 +11,13 @@ var SCAN_CODE_RELEASE = 0x80;
  *
  * @param {BusConnector} bus
  */
-function KeyboardAdapter(bus)
+function KeyboardAdapter(bus, screen_container)
 {
+    // Make screen container focusable
+    if(screen_container.tabIndex === undefined)
+    {
+        screen_container.tabIndex = 0;
+    }
     var
         /**
          * @type {!Object.<boolean>}
@@ -234,25 +239,25 @@ function KeyboardAdapter(bus)
 
     this.destroy = function()
     {
-        if(typeof window !== "undefined")
+        if(typeof screen_container !== "undefined")
         {
-            window.removeEventListener("keyup", keyup_handler, false);
-            window.removeEventListener("keydown", keydown_handler, false);
-            window.removeEventListener("blur", blur_handler, false);
+            screen_container.removeEventListener("keyup", keyup_handler, false);
+            screen_container.removeEventListener("keydown", keydown_handler, false);
+            screen_container.removeEventListener("blur", blur_handler, false);
         }
     };
 
     this.init = function()
     {
-        if(typeof window === "undefined")
+        if(typeof screen_container === "undefined")
         {
             return;
         }
         this.destroy();
 
-        window.addEventListener("keyup", keyup_handler, false);
-        window.addEventListener("keydown", keydown_handler, false);
-        window.addEventListener("blur", blur_handler, false);
+        screen_container.addEventListener("keyup", keyup_handler, false);
+        screen_container.addEventListener("keydown", keydown_handler, false);
+        screen_container.addEventListener("blur", blur_handler, false);
     };
     this.init();
 

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -294,7 +294,7 @@ V86Starter.prototype.continue_init = async function(emulator, options)
 
     if(!options["disable_keyboard"])
     {
-        this.keyboard_adapter = new KeyboardAdapter(this.bus);
+        this.keyboard_adapter = new KeyboardAdapter(this.bus, options["screen_container"]);
     }
     if(!options["disable_mouse"])
     {


### PR DESCRIPTION
This is in reference to #916; I think it's reasonable for keyboard events to go to the screen container, in case you don't want v86 consuming all keyboard actions anywhere on the page.  For cases where you have multiple v86 instances or want keyboard navigation outside of the emulator this is helpful.  (Mouse events already filter based on mouse position so those are fine.)

I decided just to change the keyboard event registration instead of making it configurable because the current behavior feels wrong to me personally, but if @copy or others feel strongly one can always add another config option or alter the "disable keyboard" option to be something like a `keyboard_target` HTMLElement (and if null, act as if the keyboard is disabled).