### PR TITLE
More graceful HTTP content negotiation

### DIFF
--- a/src/buffer.js
+++ b/src/buffer.js
@@ -742,6 +742,7 @@
                 },
                 headers: {
                     Range: "bytes=0-0",
+                    "X-Accept-Encoding": "identity"
                 }
             });
         };

--- a/src/lib.js
+++ b/src/lib.js
@@ -578,6 +578,7 @@ function load_file(filename, options, n_tries)
         let start = options.range.start;
         let end = start + options.range.length - 1;
         http.setRequestHeader("Range", "bytes=" + start + "-" + end);
+        http.setRequestHeader("X-Accept-Encoding", "identity");
 
         // Abort if server responds with complete file in response to range
         // request, to prevent downloading large files from broken http servers
@@ -604,6 +605,14 @@ function load_file(filename, options, n_tries)
             }
             else if(http.response)
             {
+                if(options.range)
+                {
+                    let enc = http.getResponseHeader("Content-Encoding");
+                    if(enc && enc !== "identity")
+                    {
+                        console.error("Server sent Content-Encoding in response to ranged request", {filename, enc});
+                    }
+                }
                 options.done && options.done(http.response, http);
             }
         }


### PR DESCRIPTION
When v86 needs to load a chunk of a file, it can silently download garbage if the server is using gzip encoding (it gets a range, but of the wrong data).  This patch does two things:

1. Error out instead of proceeding if the content-encoding of a download after a range request exists and is not "identity".
2. Send the nonstandard "X-Accept-Encoding: identity" header when making range requests.

We can't use `Accept-Encoding` because it's on the forbidden header list, but some web servers respect `X-Accept-Encoding`.