### PR TITLE
Fullscreen centering

### DIFF
--- a/v86.css
+++ b/v86.css
@@ -11,6 +11,10 @@
       align-items: center;
       justify-content: center;
     }
+#screen_container:fullscreen #vga {
+    width: auto !important;
+    height: 100% !important;
+}
 #runtime_infos, #filesystem_panel {
     float: left;
     width: 250px;

--- a/v86.css
+++ b/v86.css
@@ -6,6 +6,11 @@
     padding: 4px;
     color: #fff;
 }
+#screen_container:fullscreen {
+      display: flex !important;
+      align-items: center;
+      justify-content: center;
+    }
 #runtime_infos, #filesystem_panel {
     float: left;
     width: 250px;


### PR DESCRIPTION
Works in both Google Chrome and Mozilla Firefox.
### Screenshots
![image](https://github.com/copy/v86/assets/69303239/a90d0bf5-e49d-4f42-b35e-899c47e2b29c)
Text mode (Buildroot Linux)
![image](https://github.com/copy/v86/assets/69303239/20b9d00d-b3a4-4490-a80b-36f6911a9b32)
VGA mode (Windows 1.0)