### PR TITLE
change multiboot to boot as an option rom, add initrd, cmdline

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -115,7 +115,9 @@ var
      */
     MMAP_BLOCK_BITS = 17,
     /** @const */
-    MMAP_BLOCK_SIZE = 1 << MMAP_BLOCK_BITS;
+    MMAP_BLOCK_SIZE = 1 << MMAP_BLOCK_BITS,
+    /** @const */
+    MMAP_MAX = 0x100000000;
 
 /** @const */
 var CR0_PG = 1 << 31;

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -743,11 +743,11 @@ CPU.prototype.init = function(settings, device_bus)
 
     if(settings.bzimage)
     {
-        const { option_rom } = load_kernel(this.mem8, settings.bzimage, settings.initrd, settings.cmdline || "");
+        const option_rom = load_kernel(this.mem8, settings.bzimage, settings.initrd, settings.cmdline || "");
 
         if(option_rom)
         {
-            this.option_roms.push(option_rom);
+            this.option_roms.push(option_rom.option_rom);
         }
     }
 
@@ -976,13 +976,13 @@ CPU.prototype.init = function(settings, device_bus)
     if(settings.multiboot)
     {
         dbg_log("loading multiboot", LOG_CPU);
-        const { option_rom } = this.load_multiboot_option_rom(settings.multiboot, settings.initrd, settings.cmdline);
+        const option_rom = this.load_multiboot_option_rom(settings.multiboot, settings.initrd, settings.cmdline);
 
         if(option_rom)
         {
             if (this.bios.main) {
                 dbg_log("adding option rom for multiboot", LOG_CPU);
-                this.option_roms.push(option_rom);
+                this.option_roms.push(option_rom.option_rom);
             } else {
                 dbg_log("loaded multiboot", LOG_CPU);
                 this.reg32[REG_EAX] = this.io.port_read32(0xF4);
@@ -1002,7 +1002,7 @@ CPU.prototype.load_multiboot = function (buffer)
         dbg_assert(false, "load_multiboot not supported with BIOS");
     }
 
-    const { option_rom } = this.load_multiboot_option_rom(buffer, false, null);
+    const option_rom = this.load_multiboot_option_rom(buffer, false, null);
     if(option_rom)
     {
         dbg_log("loaded multiboot", LOG_CPU);
@@ -1340,6 +1340,7 @@ CPU.prototype.load_multiboot_option_rom = function(buffer, initrd, cmdline)
         };
         break;
     }
+    dbg_log("Multiboot header not found", LOG_CPU);
 };
 
 CPU.prototype.fill_cmos = function(rtc, settings)

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -975,7 +975,14 @@ CPU.prototype.init = function(settings, device_bus)
 
     if(settings.multiboot)
     {
-        this.load_multiboot(settings.multiboot);
+        dbg_log("loading multiboot", LOG_CPU);
+        const { option_rom } = this.load_multiboot_option_rom(settings.multiboot, settings.initrd, settings.cmdline || "");
+
+        if(option_rom)
+        {
+            dbg_log("adding option rom for multiboot", LOG_CPU);
+            this.option_roms.push(option_rom);
+        }
     }
 
     if(DEBUG)
@@ -984,7 +991,25 @@ CPU.prototype.init = function(settings, device_bus)
     }
 };
 
-CPU.prototype.load_multiboot = function(buffer)
+CPU.prototype.load_multiboot = function (buffer)
+{
+    if (this.bios.main) {
+        dbg_assert(false, "load_multiboot not supported with BIOS");
+    }
+
+    const { option_rom } = this.load_multiboot_option_rom(buffer, false, "");
+    if(option_rom)
+    {
+        dbg_log("loaded multiboot", LOG_CPU);
+        this.write_blob(new Uint8Array(option_rom.data), 0);
+        // set CS segment to 0
+        this.segment_offsets[1] = 0;
+        this.sreg[1] = 0;
+        this.instruction_pointer[0] = this.get_seg_cs() + 0x3 | 0;
+    }
+};
+
+CPU.prototype.load_multiboot_option_rom = function(buffer, initrd, cmdline)
 {
     // https://www.gnu.org/software/grub/manual/multiboot/multiboot.html
 
@@ -1025,123 +1050,186 @@ CPU.prototype.load_multiboot = function(buffer)
         }
 
         dbg_log("Multiboot magic found, flags: " + h(flags >>> 0, 8), LOG_CPU);
-        dbg_assert((flags & ~MULTIBOOT_HEADER_ADDRESS) === 0, "TODO");
+        // bit 0 : load modules on page boundaries (may as well, if we load modules)
+        // bit 1 : provide a memory map (which we always will)
+        dbg_assert((flags & ~MULTIBOOT_HEADER_ADDRESS & ~3) === 0, "TODO");
 
-        this.reg32[REG_EAX] = 0x2BADB002;
 
         let multiboot_info_addr = 0x7C00;
-        this.reg32[REG_EBX] = multiboot_info_addr;
-        this.write32(multiboot_info_addr, 0);
+        // actually do the load and return the entrypoint address
+        // do this in a io register hook, so it can happen after BIOS does its work
+        var cpu = this;
 
-        this.cr[0] = 1;
-        this.protected_mode[0] = +true;
-        this.flags[0] = FLAGS_DEFAULT;
-        this.is_32[0] = +true;
-        this.stack_size_32[0] = +true;
+        this.io.register_read(0xF4, this, function () {return 0;} , function () { return 0;}, function () {
+            let multiboot_data = multiboot_info_addr + 116;
+            cpu.write32(multiboot_info_addr, ((1 << 2) |  // cmdline set
+                                               (1 << 6) )); // mmap set
 
-        for(var i = 0; i < 6; i++)
-        {
-            this.segment_is_null[i] = 0;
-            this.segment_offsets[i] = 0;
-            this.segment_limits[i] = 0xFFFFFFFF;
+            // command line
+            cpu.write32(multiboot_info_addr + 16, multiboot_data);
 
-            // Value doesn't matter, OS isn't allowed to reload without setting
-            // up a proper GDT
-            this.sreg[i] = 0xB002;
-        }
+            cmdline += "\x00";
+            const encoder = new TextEncoder();
+            const cmdline_utf8 = encoder.encode(cmdline);
+            cpu.write_blob(cmdline_utf8, multiboot_data);
+            multiboot_data += cmdline_utf8.length;
 
-        if(flags & MULTIBOOT_HEADER_ADDRESS)
-        {
-            dbg_log("Multiboot specifies its own address table", LOG_CPU);
+            // memory map
+            let multiboot_mmap_count = 0;
+            cpu.write32(multiboot_info_addr + 44, 0);
+            cpu.write32(multiboot_info_addr + 48, multiboot_data);
 
-            var header_addr = buf32[offset + 12 >> 2];
-            var load_addr = buf32[offset + 16 >> 2];
-            var load_end_addr = buf32[offset + 20 >> 2];
-            var bss_end_addr = buf32[offset + 24 >> 2];
-            var entry_addr = buf32[offset + 28 >> 2];
-
-            dbg_log("header=" + h(header_addr, 8) +
-                    " load=" + h(load_addr, 8) +
-                    " load_end=" + h(load_end_addr, 8) +
-                    " bss_end=" + h(bss_end_addr, 8) +
-                    " entry=" + h(entry_addr, 8));
-
-            dbg_assert(load_addr <= header_addr);
-
-            var file_start = offset - (header_addr - load_addr);
-
-            if(load_end_addr === 0)
-            {
-                var length = undefined;
-            }
-            else
-            {
-                dbg_assert(load_end_addr >= load_addr);
-                var length = load_end_addr - load_addr;
-            }
-
-            let blob = new Uint8Array(buffer, file_start, length);
-            this.write_blob(blob, load_addr);
-
-            this.instruction_pointer[0] = this.get_seg_cs() + entry_addr | 0;
-        }
-        else if(buf32[0] === ELF_MAGIC)
-        {
-            dbg_log("Multiboot image is in elf format", LOG_CPU);
-
-            let elf = read_elf(buffer);
-
-            this.instruction_pointer[0] = this.get_seg_cs() + elf.header.entry | 0;
-
-            for(let program of elf.program_headers)
-            {
-                if(program.type === 0)
-                {
-                    // null
+            // Create a memory map for the multiboot kernel
+            // does not exclude traditional bios exclusions
+            let start = 0;
+            let was_memory = false;
+            for (let addr = 0; addr < MMAP_MAX; addr += MMAP_BLOCK_SIZE) {
+                if (was_memory && cpu.memory_map_read8[addr >>> MMAP_BLOCK_BITS] !== undefined) {
+                    cpu.write32(multiboot_data, 20); // size
+                    cpu.write32(multiboot_data + 4, start); //addr (64-bit)
+                    cpu.write32(multiboot_data + 8, 0);
+                    cpu.write32(multiboot_data + 12, addr - start); // len (64-bit)
+                    cpu.write32(multiboot_data + 16, 0);
+                    cpu.write32(multiboot_data + 20, 1); // type (MULTIBOOT_MEMORY_AVAILABLE)
+                    multiboot_data += 24;
+                    multiboot_mmap_count += 24;
+                    was_memory = false;
+                } else if (!was_memory && cpu.memory_map_read8[addr >>> MMAP_BLOCK_BITS] === undefined) {
+                    start = addr;
+                    was_memory = true;
                 }
-                else if(program.type === 1)
-                {
-                    // load
+            }
+            dbg_assert (!was_memory, "top of 4GB shouldn't have memory");
 
-                    // Since multiboot specifies that paging is disabled,
-                    // virtual and physical address must be equal
-                    dbg_assert(program.paddr === program.vaddr);
-                    dbg_assert(program.filesz <= program.memsz);
+            cpu.write32(multiboot_info_addr + 44, multiboot_mmap_count);
 
-                    if(program.paddr + program.memsz < this.memory_size[0])
-                    {
-                        if(program.filesz) // offset might be outside of buffer if filesz is 0
-                        {
-                            let blob = new Uint8Array(buffer, program.offset, program.filesz);
-                            this.write_blob(blob, program.paddr);
-                        }
-                    }
-                    else
-                    {
-                        dbg_log("Warning: Skipped loading section, paddr=" + h(program.paddr) + " memsz=" + program.memsz, LOG_CPU);
-                    }
-                }
-                else if(
-                    program.type === 2 ||
-                    program.type === 3 ||
-                    program.type === 4 ||
-                    program.type === 6 ||
-                    program.type === 0x6474e550 ||
-                    program.type === 0x6474e551 ||
-                    program.type === 0x6474e553)
+            let entrypoint = 0;
+            let top_of_load = 0;
+
+            if(flags & MULTIBOOT_HEADER_ADDRESS)
+            {
+                dbg_log("Multiboot specifies its own address table", LOG_CPU);
+
+                var header_addr = buf32[offset + 12 >> 2];
+                var load_addr = buf32[offset + 16 >> 2];
+                var load_end_addr = buf32[offset + 20 >> 2];
+                var bss_end_addr = buf32[offset + 24 >> 2];
+                var entry_addr = buf32[offset + 28 >> 2];
+
+                dbg_log("header=" + h(header_addr, 8) +
+                        " load=" + h(load_addr, 8) +
+                        " load_end=" + h(load_end_addr, 8) +
+                        " bss_end=" + h(bss_end_addr, 8) +
+                        " entry=" + h(entry_addr, 8));
+
+                dbg_assert(load_addr <= header_addr);
+
+                var file_start = offset - (header_addr - load_addr);
+
+                if(load_end_addr === 0)
                 {
-                    // ignore for now
+                    var length = undefined;
                 }
                 else
                 {
-                    dbg_assert(false, "unimplemented elf section type: " + h(program.type));
+                    dbg_assert(load_end_addr >= load_addr);
+                    var length = load_end_addr - load_addr;
+                }
+
+                let blob = new Uint8Array(buffer, file_start, length);
+                cpu.write_blob(blob, load_addr);
+
+                entrypoint = entry_addr | 0;
+                top_of_load = Math.max(load_end_addr, bss_end_addr);
+            }
+            else if(buf32[0] === ELF_MAGIC)
+            {
+                dbg_log("Multiboot image is in elf format", LOG_CPU);
+
+                let elf = read_elf(buffer);
+
+                entrypoint = elf.header.entry | 0;
+
+                for(let program of elf.program_headers)
+                {
+                    if(program.type === 0)
+                    {
+                        // null
+                    }
+                    else if(program.type === 1)
+                    {
+                        // load
+
+                        // Since multiboot specifies that paging is disabled,
+                        // virtual and physical address must be equal
+                        dbg_assert(program.paddr === program.vaddr);
+                        dbg_assert(program.filesz <= program.memsz);
+
+                        if(program.paddr + program.memsz < cpu.memory_size[0])
+                        {
+                            if(program.filesz) // offset might be outside of buffer if filesz is 0
+                            {
+                                let blob = new Uint8Array(buffer, program.offset, program.filesz);
+                                cpu.write_blob(blob, program.paddr);
+                            }
+                            top_of_load = Math.max(top_of_load, program.paddr + program.memsz);
+                            dbg_log("prg load " + program.paddr + " to " + (program.paddr + program.memsz), LOG_CPU);
+                        }
+                        else
+                        {
+                            dbg_log("Warning: Skipped loading section, paddr=" + h(program.paddr) + " memsz=" + program.memsz, LOG_CPU);
+                        }
+                    }
+                    else if(
+                        program.type === 2 || // dynamic
+                        program.type === 3 || // interp
+                        program.type === 4 || // note
+                        program.type === 6 || // phdr
+                        program.type === 7 || // tls
+                        program.type === 0x6474e550 || // gnu_eh_frame
+                        program.type === 0x6474e551 || // gnu_stack
+                        program.type === 0x6474e552 || // gnu_relro
+                        program.type === 0x6474e553)   // gnu_property
+                    {
+                        dbg_log("skip load type " + program.type + " " + program.paddr + " to " + (program.paddr + program.memsz), LOG_CPU);
+                        // ignore for now
+                    }
+                    else
+                    {
+                        dbg_assert(false, "unimplemented elf section type: " + h(program.type));
+                    }
                 }
             }
-        }
-        else
-        {
-            dbg_assert(false, "Not a bootable multiboot format");
-        }
+            else
+            {
+                dbg_assert(false, "Not a bootable multiboot format");
+            }
+
+            if (initrd)
+            {
+                cpu.write32(multiboot_info_addr + 20, 1); // mods_count
+                cpu.write32(multiboot_info_addr + 24, multiboot_data); // mods_addr;
+
+                var ramdisk_address = top_of_load;
+                dbg_log("ramdisk address " + ramdisk_address);
+                if ((ramdisk_address & 4095) != 0) {
+                    ramdisk_address = (ramdisk_address & ~4095) + 4096;
+                }
+                dbg_log("ramdisk address " + ramdisk_address);
+                var ramdisk_top = ramdisk_address + initrd.byteLength;
+
+                cpu.write32(multiboot_data, ramdisk_address); // mod_start
+                cpu.write32(multiboot_data + 4, ramdisk_top); // mod_end
+                cpu.write32(multiboot_data + 8, 0); // string
+                cpu.write32(multiboot_data + 12, 0); // reserved
+                multiboot_data += 16;
+
+                dbg_assert(ramdisk_top < cpu.memory_size[0]);
+
+                cpu.write_blob(new Uint8Array(initrd), ramdisk_address);
+            }
+            return entrypoint;
+        });
 
         // only for kvm-unit-test
         this.io.register_write_consecutive(0xF4, this,
@@ -1173,12 +1261,165 @@ CPU.prototype.load_multiboot = function(buffer)
             this.io.register_write(0x2000 + i, this, handle_write, handle_write, handle_write);
         }
 
-        this.update_state_flags();
+        // This rom will be executed by seabios after its initialisation
+        // It sets up the multiboot environment.
+        const SIZE = 0x200;
 
-        dbg_log("Starting multiboot kernel at:", LOG_CPU);
-        this.debug.dump_state();
-        this.debug.dump_regs();
+        const data8 = new Uint8Array(0x100);
+        const data16 = new Uint16Array(data8.buffer);
 
+        data16[0] = 0xAA55;
+        data8[2] = SIZE / 0x200;
+
+        let i = 3;
+
+        // adjust these if the code below changes
+        const TRAMPOFFSET = 0x2F;
+        const GDTOFFSET = 0x35;
+        const GDTSIZE = 0x18;
+
+        // disable interrupts
+        data8[i++] = 0xFA; // cli
+
+        // A20 enabled (do nothing, because v86 doesn't have an A20 gate)
+        // find address of GDT
+        data8[i++] = 0x66; // mov eax, cs
+        data8[i++] = 0x8C;
+        data8[i++] = 0xC8;
+        data8[i++] = 0x66; // shl eax, 0x4
+        data8[i++] = 0xC1;
+        data8[i++] = 0xE0;
+        data8[i++] = 0x04;
+        data8[i++] = 0x66; // add eax, GDTOFFSET
+        data8[i++] = 0x83;
+        data8[i++] = 0xC0;
+        data8[i++] = GDTOFFSET;
+        data8[i++] = 0xBF; // mov di, GDTOFFSET + 2
+        data8[i++] = GDTOFFSET + 2;
+        data8[i++] = 0x00;
+        // store GDT address in GDT[0], used as GDT Descriptor
+        data8[i++] = 0x2E; // mov DWORD PTR cs:[di],eax
+        data8[i++] = 0x66;
+        data8[i++] = 0x89;
+        data8[i++] = 0x05;
+        // load GDT
+        data8[i++] = 0x67; // lgdtw [eax]
+        data8[i++] = 0x0F;
+        data8[i++] = 0x01;
+        data8[i++] = 0x10;
+        // calculate address to jump to protected mode
+        data8[i++] = 0x66; // add eax, GDTSIZE
+        data8[i++] = 0x83;
+        data8[i++] = 0xc0;
+        data8[i++] = GDTSIZE;
+        data8[i++] = 0xBF; // mov di, TRAMPOFFSET
+        data8[i++] = TRAMPOFFSET;
+        data8[i++] = 0x00;
+        // store destination address in far jump
+        data8[i++] = 0x2E; // mov DWORD PTR cs:[di],eax
+        data8[i++] = 0x66;
+        data8[i++] = 0x89;
+        data8[i++] = 0x05;
+        // enable protected mode
+        data8[i++] = 0x0F; // mov eax, cr0
+        data8[i++] = 0x20;
+        data8[i++] = 0xC0;
+        data8[i++] = 0x0C; // or al, 0x1
+        data8[i++] = 0x01;
+        data8[i++] = 0x0F; // mov cr0, eax
+        data8[i++] = 0x22;
+        data8[i++] = 0xC0;
+        data8[i++] = 0x66; // jmp 0x8:0xFFFFFFFF (placeholder to be replaced by physical address of trampoline)
+        data8[i++] = 0xEA;
+        dbg_assert(i == TRAMPOFFSET, "trampoline offset is not correct");
+        data8[i++] = 0xFF;
+        data8[i++] = 0xFF;
+        data8[i++] = 0xFF;
+        data8[i++] = 0xFF;
+        data8[i++] = 0x08;
+        data8[i++] = 0x00;
+        dbg_assert(i == GDTOFFSET, "GDTOFFSET is not correct");
+        // GDT
+        data8[i++] = GDTSIZE - 1; // GDT[0] is inaccesible, use it to store the GDT Descriptor
+        data8[i++] = 0;
+        data8[i++] = 0; data8[i++] = 0;
+        data8[i++] = 0; data8[i++] = 0; data8[i++] = 0; data8[i++] = 0;
+        // segment 0x08, Ring 0 code, base 0, limit 0xFFFF FFFF
+        data8[i++] = 0xFF;
+        data8[i++] = 0xFF;
+        data8[i++] = 0;
+        data8[i++] = 0;
+        data8[i++] = 0;
+        data8[i++] = 0x9A;
+        data8[i++] = 0xCF;
+        data8[i++] = 0;
+        // segment 0x10, Ring 0 data, base 0, limit 0xFFFF FFFF
+        data8[i++] = 0xFF;
+        data8[i++] = 0xFF;
+        data8[i++] = 0;
+        data8[i++] = 0;
+        data8[i++] = 0;
+        data8[i++] = 0x92;
+        data8[i++] = 0xCF;
+        data8[i++] = 0;
+        dbg_assert(i - GDTOFFSET == GDTSIZE, "GDTSIZE is not correct");
+        // now in protected mode, set the rest of the segments
+        data8[i++] = 0xB8; // mov ax, 0x10
+        data8[i++] = 0x10;
+        data8[i++] = 0x00;
+        data8[i++] = 0x8e; // mov ds, eax
+        data8[i++] = 0xd8;
+        data8[i++] = 0x8e; // mov es, eax
+        data8[i++] = 0xc0;
+        data8[i++] = 0x8e; // mov fs, eax
+        data8[i++] = 0xe0;
+        data8[i++] = 0x8e; // mov gs, eax
+        data8[i++] = 0xe8;
+        data8[i++] = 0x8e; // mov ss, eax
+        data8[i++] = 0xd0;
+        // trigger load and input entrypoint into eax
+        data8[i++] = 0xe5; // in 0xF4
+        data8[i++] = 0xF4;
+        // copy entrypoint address to ecx
+        data8[i++] = 0x89; // mv ecx, eax
+        data8[i++] = 0xc1;
+        // place magic value in eax
+        data8[i++] = 0xb8; // mov eax, 0x2badb002
+        data8[i++] = 0x02;
+        data8[i++] = 0xb0;
+        data8[i++] = 0xad;
+        data8[i++] = 0x2b;
+        // place multiboot header location in ebx
+        data8[i++] = 0xbb; // mov ebx, multiboot_info_addr
+        data8[i++] = multiboot_info_addr;
+        data8[i++] = multiboot_info_addr >> 8;
+        data8[i++] = multiboot_info_addr >> 16;
+        data8[i++] = multiboot_info_addr >> 24;
+        // jump to multiboot entrypoint
+        data8[i++] = 0xFF; // jmp rcx
+        data8[i++] = 0xE1;
+
+        dbg_assert(i < SIZE);
+
+        const checksum_index = i;
+        data8[checksum_index] = 0;
+
+        let rom_checksum = 0;
+
+        for(let i = 0; i < data8.length; i++)
+        {
+            rom_checksum += data8[i];
+        }
+
+        data8[checksum_index] = -rom_checksum;
+
+        return {
+            option_rom:
+            {
+                name: "genroms/multiboot.bin",
+                data: data8
+            }
+        };
         break;
     }
 };

--- a/src/elf.js
+++ b/src/elf.js
@@ -155,7 +155,7 @@ function read_elf(buffer)
             );
         }
 
-        console.log("%d program headers:", sections_headers.length);
+        console.log("%d section headers:", sections_headers.length);
         for(let section of sections_headers)
         {
             console.log(

--- a/src/io.js
+++ b/src/io.js
@@ -29,7 +29,7 @@ function IO(cpu)
         cpu.memory_map_read32[i] = cpu.memory_map_write32[i] = undefined;
     }
 
-    this.mmap_register(memory_size, 0x100000000 - memory_size,
+    this.mmap_register(memory_size, MMAP_MAX - memory_size,
         function(addr) {
             // read outside of the memory size
             dbg_log("Read from unmapped memory space, addr=" + h(addr >>> 0, 8), LOG_IO);

--- a/src/kernel.js
+++ b/src/kernel.js
@@ -186,7 +186,7 @@ function make_linux_boot_rom(real_mode_segment, heap_end)
 
     const SIZE = 0x200;
 
-    const data8 = new Uint8Array(0x100);
+    const data8 = new Uint8Array(SIZE);
     const data16 = new Uint16Array(data8.buffer);
 
     data16[0] = 0xAA55;

--- a/src/kernel.js
+++ b/src/kernel.js
@@ -171,11 +171,8 @@ function load_kernel(mem8, bzimage, initrd, cmdline)
     mem8.set(protected_mode_kernel, KERNEL_HIGH_ADDRESS);
 
     return {
-        option_rom:
-        {
-            name: "genroms/kernel.bin",
-            data: make_linux_boot_rom(real_mode_segment, heap_end),
-        }
+        name: "genroms/kernel.bin",
+        data: make_linux_boot_rom(real_mode_segment, heap_end),
     };
 }
 


### PR DESCRIPTION
This fleshes out the multiboot support a bit more. My hobby os relies on multiboot, but also needs some ACPI tables set. Using the existing multiboot support means seabios doesn't run at all, and the tables are missing.

The multiboot content is loaded in an i/o write hook rather than before booting, because otherwise seabios may overwrite the loaded data (happens with the kvm-test).

load_multiboot still works, although the mechanism changed, because nasmtests uses it directly and doesn't load seabios anyway. Now it generates the option rom, loads it at address 0 (seemed like a convenient place) and adjusts execution to start at address 3 (where an option rom is jumped to in a BIOS context).

There's a not entirely related log fix in elf section header debug info (log said program headers, but was reporting about section headers); happy to put that separate, but it came up while I was working on this.