### PR TITLE
vga: support line_compare and offset_register in text mode

### DIFF
--- a/src/vga.js
+++ b/src/vga.js
@@ -847,11 +847,14 @@ VGAScreen.prototype.text_mode_redraw = function()
     var addr = this.start_address << 1,
         chr,
         color;
-    var split_screen_row = this.scan_line_to_screen_row(this.line_compare);
+
+    const split_screen_row = this.scan_line_to_screen_row(this.line_compare);
+    const row_offset = Math.max(0, (this.offset_register * 2 - this.max_cols) * 2);
 
     for(var row = 0; row < this.max_rows; row++)
     {
-        if (row == split_screen_row) {
+        if(row === split_screen_row)
+        {
             addr = 0;
         }
 
@@ -866,26 +869,39 @@ VGAScreen.prototype.text_mode_redraw = function()
 
             addr += 2;
         }
-        if ((this.offset_register * 2) > this.max_cols) {
-            addr += ((this.offset_register * 2) - this.max_cols) * 2;
-        }
+
+        addr += row_offset;
     }
 };
 
 VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
 {
-    let max_cols = Math.max(this.max_cols, this.offset_register * 2);
+    const max_cols = Math.max(this.max_cols, this.offset_register * 2);
+    let row;
+    let col;
 
-    var memory_start = (addr >> 1) - this.start_address,
-        row = memory_start / max_cols | 0,
-        col = memory_start % max_cols,
-        chr,
-        color;
-    if (memory_start < 0) {
-        memory_start = addr >> 1;
+    if((addr >> 1) >= this.start_address)
+    {
+        const memory_start = (addr >> 1) - this.start_address;
+        row = memory_start / max_cols | 0;
+        col = memory_start % max_cols;
+    }
+    else
+    {
+        const memory_start = addr >> 1;
         row = (memory_start / max_cols | 0) + this.scan_line_to_screen_row(this.line_compare);
         col = memory_start % max_cols;
     }
+
+    dbg_assert(row >= 0 && col >= 0);
+
+    if(col >= this.max_cols || row >= this.max_rows)
+    {
+        return;
+    }
+
+    let chr;
+    let color;
 
     // XXX: Should handle 16 bit write if possible
     if(addr & 1)
@@ -908,17 +924,25 @@ VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
 
 VGAScreen.prototype.update_cursor = function()
 {
-    let max_cols = Math.max(this.max_cols, this.offset_register * 2);
+    const max_cols = Math.max(this.max_cols, this.offset_register * 2);
+    let row;
+    let col;
 
-    var row = (this.cursor_address - this.start_address) / max_cols | 0,
+    if(this.cursor_address >= this.start_address)
+    {
+        row = (this.cursor_address - this.start_address) / max_cols | 0,
         col = (this.cursor_address - this.start_address) % max_cols;
-
-    if (this.cursor_address < this.start_address) {
+    }
+    else
+    {
         row = (this.cursor_address / max_cols | 0) + this.scan_line_to_screen_row(this.line_compare);
         col = this.cursor_address % max_cols;
     }
 
+    dbg_assert(row >= 0 && col >= 0);
+
     row = Math.min(this.max_rows - 1, row);
+    col = Math.min(this.max_cols - 1, col);
 
     this.bus.send("screen-update-cursor", [row, col]);
 };

--- a/src/vga.js
+++ b/src/vga.js
@@ -847,9 +847,14 @@ VGAScreen.prototype.text_mode_redraw = function()
     var addr = this.start_address << 1,
         chr,
         color;
+    var split_screen_row = this.scan_line_to_screen_row(this.line_compare);
 
     for(var row = 0; row < this.max_rows; row++)
     {
+        if (row == split_screen_row) {
+            addr = 0;
+        }
+
         for(var col = 0; col < this.max_cols; col++)
         {
             chr = this.vga_memory[addr];
@@ -861,16 +866,26 @@ VGAScreen.prototype.text_mode_redraw = function()
 
             addr += 2;
         }
+        if ((this.offset_register * 2) > this.max_cols) {
+            addr += ((this.offset_register * 2) - this.max_cols) * 2;
+        }
     }
 };
 
 VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
 {
+    let max_cols = Math.max(this.max_cols, this.offset_register * 2);
+
     var memory_start = (addr >> 1) - this.start_address,
-        row = memory_start / this.max_cols | 0,
-        col = memory_start % this.max_cols,
+        row = memory_start / max_cols | 0,
+        col = memory_start % max_cols,
         chr,
         color;
+    if (memory_start < 0) {
+        memory_start = addr >> 1;
+        row = (memory_start / max_cols | 0) + this.scan_line_to_screen_row(this.line_compare);
+        col = memory_start % max_cols;
+    }
 
     // XXX: Should handle 16 bit write if possible
     if(addr & 1)
@@ -893,8 +908,15 @@ VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
 
 VGAScreen.prototype.update_cursor = function()
 {
-    var row = (this.cursor_address - this.start_address) / this.max_cols | 0,
-        col = (this.cursor_address - this.start_address) % this.max_cols;
+    let max_cols = Math.max(this.max_cols, this.offset_register * 2);
+
+    var row = (this.cursor_address - this.start_address) / max_cols | 0,
+        col = (this.cursor_address - this.start_address) % max_cols;
+
+    if (this.cursor_address < this.start_address) {
+        row = (this.cursor_address / max_cols | 0) + this.scan_line_to_screen_row(this.line_compare);
+        col = this.cursor_address % max_cols;
+    }
 
     row = Math.min(this.max_rows - 1, row);
 


### PR DESCRIPTION
There's not a whole lot of use of these registers in text mode in the wild, but crazierl uses it, so I'm motivated. :)

Math.max(this.max_cols, this.offset_register * 2) is a bit of a cop-out, I think VGA user should likely be properly setting the offset register, but I didn't want things to fail in case they don't.