### PR TITLE
Virtio console: Send bytes to the right queues

### DIFF
--- a/src/virtio_console.js
+++ b/src/virtio_console.js
@@ -204,12 +204,12 @@ function VirtioConsole(cpu, bus)
     });
 
     for (let port = 0; port < this.ports; ++port) {
-        let queue = port == 0 ? 0 : port * 2 + 2;
+        let queue_id = port == 0 ? 0 : port * 2 + 2;
         this.bus.register("virtio-console" + port + "-input-bytes", function(data) {
-            let queue = this.virtio.queues[0];
+            let queue = this.virtio.queues[queue_id];
             if (queue.has_request()) {
                 const bufchain = queue.pop_request();
-                this.Send(0, bufchain, new Uint8Array(data));
+                this.Send(queue_id, bufchain, new Uint8Array(data));
             } else {
                 //TODO: Buffer
             }


### PR DESCRIPTION
I discovered that all virtio console data was getting sent to the same port (`/dev/hvc0`) when doing something like this:

```js
const encoder = new TextEncoder()
emulator.bus.send('virtio-console1-input-bytes', encoder.encode('hello world 1\n'))
emulator.bus.send('virtio-console2-input-bytes', encoder.encode('hello world 2\n'))
emulator.bus.send('virtio-console3-input-bytes', encoder.encode('hello world 3\n'))
```

When looking at the code, I noticed that the variable `queue` (the first one) is unused. I renamed it to `queue_id` (because there's another `queue` variable inside the event listener), plugged it into where it looked like it should go, and it worked :)