### PR TITLE
PageFault error code now reports page presence correctly

### DIFF
--- a/src/rust/cpu/cpu.rs
+++ b/src/rust/cpu/cpu.rs
@@ -1999,7 +1999,7 @@ pub unsafe fn do_page_walk(
             }
 
             allow_user &= page_table_entry & PAGE_TABLE_USER_MASK != 0;
-            if user && !allow_user{
+            if user && !allow_user {
                 if side_effects {
                     trigger_pagefault(addr, true, for_writing, user, jit);
                 }


### PR DESCRIPTION
If page directory was present and ring3 access or write protection violation caused page fault on page directory level, page presence was not checked and it was assumed to be present.

This PR adds this check to correctly report present bit in page fault error codes.

I found this bug as my OS uses the present bit in error code of page fault as the initial requirement for demand paging.

This is my first time writing rust, so please tell me if something should be done differently.