### PR TITLE
Report current PS/2 scan code set as 1

### DIFF
--- a/src/ps2.js
+++ b/src/ps2.js
@@ -567,7 +567,7 @@ PS2.prototype.port60_write = function(write_byte)
         }
         else
         {
-            this.kbd_buffer.push(2);
+            this.kbd_buffer.push(1);
         }
     }
     else if(this.next_read_rate)


### PR DESCRIPTION
PS/2 keyboard reported current scan code set as 2 while only scan code set 1 was emulated.