### PR TITLE
Text Mode enhancement

### DIFF
--- a/src/browser/dummy_screen.js
+++ b/src/browser/dummy_screen.js
@@ -23,7 +23,7 @@ function DummyScreenAdapter(bus)
         is_graphical = false,
 
         // Index 0: ASCII code
-        // Index 1: Attribute
+        // Index 1: Blinking
         // Index 2: Background color
         // Index 3: Foreground color
         text_mode_data,
@@ -35,7 +35,7 @@ function DummyScreenAdapter(bus)
         text_mode_height;
 
     const CHARACTER_INDEX = 0;
-    const ATTRIBUTE_INDEX = 1;
+    const BLINKING_INDEX = 1;
     const BG_COLOR_INDEX = 2;
     const FG_COLOR_INDEX = 3;
     const TEXT_MODE_COMPONENT_SIZE = 4;
@@ -84,14 +84,14 @@ function DummyScreenAdapter(bus)
         this.set_size_graphical(...data);
     }, this);
 
-    this.put_char = function(row, col, chr, attr, bg_color, fg_color)
+    this.put_char = function(row, col, chr, blinking, bg_color, fg_color)
     {
         if(row < text_mode_height && col < text_mode_width)
         {
             var p = TEXT_MODE_COMPONENT_SIZE * (row * text_mode_width + col);
 
             text_mode_data[p + CHARACTER_INDEX] = chr;
-            text_mode_data[p + ATTRIBUTE_INDEX] = attr;
+            text_mode_data[p + BLINKING_INDEX] = blinking;
             text_mode_data[p + BG_COLOR_INDEX] = bg_color;
             text_mode_data[p + FG_COLOR_INDEX] = fg_color;
         }

--- a/src/browser/dummy_screen.js
+++ b/src/browser/dummy_screen.js
@@ -58,7 +58,7 @@ function DummyScreenAdapter(bus)
     bus.register("screen-put-char", function(data)
     {
         //console.log(data);
-        this.put_char(...data);
+        this.put_char(data[0], data[1], data[2], data[3], data[4], data[5]);
     }, this);
 
     bus.register("screen-text-scroll", function(rows)
@@ -68,20 +68,20 @@ function DummyScreenAdapter(bus)
 
     bus.register("screen-update-cursor", function(data)
     {
-        this.update_cursor(...data);
+        this.update_cursor(data[0], data[1]);
     }, this);
     bus.register("screen-update-cursor-scanline", function(data)
     {
-        this.update_cursor_scanline(...data);
+        this.update_cursor_scanline(data[0], data[1]);
     }, this);
 
     bus.register("screen-set-size-text", function(data)
     {
-        this.set_size_text(...data);
+        this.set_size_text(data[0], data[1]);
     }, this);
     bus.register("screen-set-size-graphical", function(data)
     {
-        this.set_size_graphical(...data);
+        this.set_size_graphical(data[0], data[1]);
     }, this);
 
     this.put_char = function(row, col, chr, blinking, bg_color, fg_color)

--- a/src/browser/dummy_screen.js
+++ b/src/browser/dummy_screen.js
@@ -23,8 +23,9 @@ function DummyScreenAdapter(bus)
         is_graphical = false,
 
         // Index 0: ASCII code
-        // Index 1: Background color
-        // Index 2: Foreground color
+        // Index 1: Attribute
+        // Index 2: Background color
+        // Index 3: Foreground color
         text_mode_data,
 
         // number of columns
@@ -32,6 +33,12 @@ function DummyScreenAdapter(bus)
 
         // number of rows
         text_mode_height;
+
+    const CHARACTER_INDEX = 0;
+    const ATTRIBUTE_INDEX = 1;
+    const BG_COLOR_INDEX = 2;
+    const FG_COLOR_INDEX = 3;
+    const TEXT_MODE_COMPONENT_SIZE = 4;
 
     this.bus = bus;
 
@@ -51,7 +58,7 @@ function DummyScreenAdapter(bus)
     bus.register("screen-put-char", function(data)
     {
         //console.log(data);
-        this.put_char(data[0], data[1], data[2], data[3], data[4]);
+        this.put_char(...data);
     }, this);
 
     bus.register("screen-text-scroll", function(rows)
@@ -61,31 +68,32 @@ function DummyScreenAdapter(bus)
 
     bus.register("screen-update-cursor", function(data)
     {
-        this.update_cursor(data[0], data[1]);
+        this.update_cursor(...data);
     }, this);
     bus.register("screen-update-cursor-scanline", function(data)
     {
-        this.update_cursor_scanline(data[0], data[1]);
+        this.update_cursor_scanline(...data);
     }, this);
 
     bus.register("screen-set-size-text", function(data)
     {
-        this.set_size_text(data[0], data[1]);
+        this.set_size_text(...data);
     }, this);
     bus.register("screen-set-size-graphical", function(data)
     {
-        this.set_size_graphical(data[0], data[1]);
+        this.set_size_graphical(...data);
     }, this);
 
-    this.put_char = function(row, col, chr, bg_color, fg_color)
+    this.put_char = function(row, col, chr, attr, bg_color, fg_color)
     {
         if(row < text_mode_height && col < text_mode_width)
         {
-            var p = 3 * (row * text_mode_width + col);
+            var p = TEXT_MODE_COMPONENT_SIZE * (row * text_mode_width + col);
 
-            text_mode_data[p] = chr;
-            text_mode_data[p + 1] = bg_color;
-            text_mode_data[p + 2] = fg_color;
+            text_mode_data[p + CHARACTER_INDEX] = chr;
+            text_mode_data[p + ATTRIBUTE_INDEX] = attr;
+            text_mode_data[p + BG_COLOR_INDEX] = bg_color;
+            text_mode_data[p + FG_COLOR_INDEX] = fg_color;
         }
     };
 
@@ -113,7 +121,7 @@ function DummyScreenAdapter(bus)
             return;
         }
 
-        text_mode_data = new Int32Array(cols * rows * 3);
+        text_mode_data = new Int32Array(cols * rows * TEXT_MODE_COMPONENT_SIZE);
 
         text_mode_width = cols;
         text_mode_height = rows;
@@ -168,11 +176,11 @@ function DummyScreenAdapter(bus)
     this.get_text_row = function(i)
     {
         var row = "";
-        var offset = 3 * i * text_mode_width;
+        var offset = TEXT_MODE_COMPONENT_SIZE * i * text_mode_width;
 
         for(var j = 0; j < text_mode_width; j++)
         {
-            row += String.fromCharCode(text_mode_data[offset + 3 * j]);
+            row += String.fromCharCode(text_mode_data[offset + CHARACTER_INDEX + TEXT_MODE_COMPONENT_SIZE * j]);
         }
 
         return row;

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -38,7 +38,7 @@ function ScreenAdapter(screen_container, bus)
         is_graphical = false,
 
         // Index 0: ASCII code
-        // Index 1: Attribute
+        // Index 1: Blinking
         // Index 2: Background color
         // Index 3: Foreground color
         text_mode_data,
@@ -50,7 +50,7 @@ function ScreenAdapter(screen_container, bus)
         text_mode_height;
 
     const CHARACTER_INDEX = 0;
-    const ATTRIBUTE_INDEX = 1;
+    const BLINKING_INDEX = 1;
     const BG_COLOR_INDEX = 2;
     const FG_COLOR_INDEX = 3;
     const TEXT_MODE_COMPONENT_SIZE = 4;
@@ -235,7 +235,7 @@ function ScreenAdapter(screen_container, bus)
         return image;
     };
 
-    this.put_char = function(row, col, chr, attr, bg_color, fg_color)
+    this.put_char = function(row, col, chr, blinking, bg_color, fg_color)
     {
         if(row < text_mode_height && col < text_mode_width)
         {
@@ -243,7 +243,7 @@ function ScreenAdapter(screen_container, bus)
 
             dbg_assert(chr >= 0 && chr < 0x100);
             text_mode_data[p + CHARACTER_INDEX] = chr;
-            text_mode_data[p + ATTRIBUTE_INDEX] = attr;
+            text_mode_data[p + BLINKING_INDEX] = blinking;
             text_mode_data[p + BG_COLOR_INDEX] = bg_color;
             text_mode_data[p + FG_COLOR_INDEX] = fg_color;
 
@@ -481,7 +481,7 @@ function ScreenAdapter(screen_container, bus)
             color_element,
             fragment;
 
-        var attribute,
+        var blinking,
             bg_color,
             fg_color,
             text;
@@ -493,11 +493,11 @@ function ScreenAdapter(screen_container, bus)
         {
             color_element = document.createElement("span");
 
-            attribute = text_mode_data[offset + ATTRIBUTE_INDEX];
+            blinking = text_mode_data[offset + BLINKING_INDEX];
             bg_color = text_mode_data[offset + BG_COLOR_INDEX];
             fg_color = text_mode_data[offset + FG_COLOR_INDEX];
 
-            if (attribute & (1<<7)) {
+            if (blinking) {
                 color_element.classList.add('blink');
             }
 
@@ -508,7 +508,9 @@ function ScreenAdapter(screen_container, bus)
 
             // put characters of the same color in one element
             while(i < text_mode_width &&
-                text_mode_data[offset + ATTRIBUTE_INDEX] === attribute)
+                text_mode_data[offset + BLINKING_INDEX] === blinking &&
+                text_mode_data[offset + BG_COLOR_INDEX] === bg_color &&
+                text_mode_data[offset + FG_COLOR_INDEX] === fg_color)
             {
                 var ascii = text_mode_data[offset + CHARACTER_INDEX];
 

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -122,7 +122,7 @@ function ScreenAdapter(screen_container, bus)
 
     graphic_context.imageSmoothingEnabled = false;
 
-    cursor_element.classList.add("cursor")
+    cursor_element.classList.add("cursor");
     cursor_element.style.position = "absolute";
     cursor_element.style.backgroundColor = "#ccc";
     cursor_element.style.width = "7px";
@@ -210,7 +210,7 @@ function ScreenAdapter(screen_container, bus)
                     const index = (y * text_mode_width + x) * TEXT_MODE_COMPONENT_SIZE;
                     const character = text_mode_data[index + CHARACTER_INDEX];
                     const bg_color = text_mode_data[index + BG_COLOR_INDEX];
-                    const fg_color = text_mode_data[index + FG_COLOR_INDEX]
+                    const fg_color = text_mode_data[index + FG_COLOR_INDEX];
 
                     context.fillStyle = number_as_color(bg_color);
                     context.fillRect(x * char_size[0], y * char_size[1], char_size[0], char_size[1]);

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -497,8 +497,9 @@ function ScreenAdapter(screen_container, bus)
             bg_color = text_mode_data[offset + BG_COLOR_INDEX];
             fg_color = text_mode_data[offset + FG_COLOR_INDEX];
 
-            if (blinking) {
-                color_element.classList.add('blink');
+            if(blinking)
+            {
+                color_element.classList.add("blink");
             }
 
             color_element.style.backgroundColor = number_as_color(bg_color);

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -146,16 +146,16 @@ function ScreenAdapter(screen_container, bus)
     bus.register("screen-put-char", function(data)
     {
         //console.log(data);
-        this.put_char(...data);
+        this.put_char(data[0], data[1], data[2], data[3], data[4], data[5]);
     }, this);
 
     bus.register("screen-update-cursor", function(data)
     {
-        this.update_cursor(...data);
+        this.update_cursor(data[0], data[1]);
     }, this);
     bus.register("screen-update-cursor-scanline", function(data)
     {
-        this.update_cursor_scanline(...data);
+        this.update_cursor_scanline(data[0], data[1]);
     }, this);
 
     bus.register("screen-clear", function()
@@ -165,11 +165,11 @@ function ScreenAdapter(screen_container, bus)
 
     bus.register("screen-set-size-text", function(data)
     {
-        this.set_size_text(...data);
+        this.set_size_text(data[0], data[1]);
     }, this);
     bus.register("screen-set-size-graphical", function(data)
     {
-        this.set_size_graphical(...data);
+        this.set_size_graphical(data[0], data[1], data[2], data[3]);
     }, this);
 
 

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -38,8 +38,9 @@ function ScreenAdapter(screen_container, bus)
         is_graphical = false,
 
         // Index 0: ASCII code
-        // Index 1: Background color
-        // Index 2: Foreground color
+        // Index 1: Attribute
+        // Index 2: Background color
+        // Index 3: Foreground color
         text_mode_data,
 
         // number of columns
@@ -47,6 +48,12 @@ function ScreenAdapter(screen_container, bus)
 
         // number of rows
         text_mode_height;
+
+    const CHARACTER_INDEX = 0;
+    const ATTRIBUTE_INDEX = 1;
+    const BG_COLOR_INDEX = 2;
+    const FG_COLOR_INDEX = 3;
+    const TEXT_MODE_COMPONENT_SIZE = 4;
 
     var stopped = false;
 
@@ -115,6 +122,7 @@ function ScreenAdapter(screen_container, bus)
 
     graphic_context.imageSmoothingEnabled = false;
 
+    cursor_element.classList.add("blink")
     cursor_element.style.position = "absolute";
     cursor_element.style.backgroundColor = "#ccc";
     cursor_element.style.width = "7px";
@@ -138,16 +146,16 @@ function ScreenAdapter(screen_container, bus)
     bus.register("screen-put-char", function(data)
     {
         //console.log(data);
-        this.put_char(data[0], data[1], data[2], data[3], data[4]);
+        this.put_char(...data);
     }, this);
 
     bus.register("screen-update-cursor", function(data)
     {
-        this.update_cursor(data[0], data[1]);
+        this.update_cursor(...data);
     }, this);
     bus.register("screen-update-cursor-scanline", function(data)
     {
-        this.update_cursor_scanline(data[0], data[1]);
+        this.update_cursor_scanline(...data);
     }, this);
 
     bus.register("screen-clear", function()
@@ -157,11 +165,11 @@ function ScreenAdapter(screen_container, bus)
 
     bus.register("screen-set-size-text", function(data)
     {
-        this.set_size_text(data[0], data[1]);
+        this.set_size_text(...data);
     }, this);
     bus.register("screen-set-size-graphical", function(data)
     {
-        this.set_size_graphical(data[0], data[1], data[2], data[3]);
+        this.set_size_graphical(...data);
     }, this);
 
 
@@ -199,11 +207,15 @@ function ScreenAdapter(screen_container, bus)
             {
                 for(let y = 0; y < text_mode_height; y++)
                 {
-                    const index = (y * text_mode_width + x) * 3;
-                    context.fillStyle = number_as_color(text_mode_data[index + 1]);
+                    const index = (y * text_mode_width + x) * TEXT_MODE_COMPONENT_SIZE;
+                    const character = text_mode_data[index + CHARACTER_INDEX];
+                    const bg_color = text_mode_data[index + BG_COLOR_INDEX];
+                    const fg_color = text_mode_data[index + FG_COLOR_INDEX]
+
+                    context.fillStyle = number_as_color(bg_color);
                     context.fillRect(x * char_size[0], y * char_size[1], char_size[0], char_size[1]);
-                    context.fillStyle = number_as_color(text_mode_data[index + 2]);
-                    context.fillText(charmap[text_mode_data[index]], x * char_size[0], y * char_size[1]);
+                    context.fillStyle = number_as_color(fg_color);
+                    context.fillText(charmap[character], x * char_size[0], y * char_size[1]);
                 }
             }
 
@@ -223,16 +235,17 @@ function ScreenAdapter(screen_container, bus)
         return image;
     };
 
-    this.put_char = function(row, col, chr, bg_color, fg_color)
+    this.put_char = function(row, col, chr, attr, bg_color, fg_color)
     {
         if(row < text_mode_height && col < text_mode_width)
         {
-            var p = 3 * (row * text_mode_width + col);
+            var p = TEXT_MODE_COMPONENT_SIZE * (row * text_mode_width + col);
 
             dbg_assert(chr >= 0 && chr < 0x100);
-            text_mode_data[p] = chr;
-            text_mode_data[p + 1] = bg_color;
-            text_mode_data[p + 2] = fg_color;
+            text_mode_data[p + CHARACTER_INDEX] = chr;
+            text_mode_data[p + ATTRIBUTE_INDEX] = attr;
+            text_mode_data[p + BG_COLOR_INDEX] = bg_color;
+            text_mode_data[p + FG_COLOR_INDEX] = fg_color;
 
             changed_rows[row] = 1;
         }
@@ -305,7 +318,7 @@ function ScreenAdapter(screen_container, bus)
         }
 
         changed_rows = new Int8Array(rows);
-        text_mode_data = new Int32Array(cols * rows * 3);
+        text_mode_data = new Int32Array(cols * rows * TEXT_MODE_COMPONENT_SIZE);
 
         text_mode_width = cols;
         text_mode_height = rows;
@@ -463,12 +476,13 @@ function ScreenAdapter(screen_container, bus)
 
     this.text_update_row = function(row)
     {
-        var offset = 3 * row * text_mode_width,
+        var offset = TEXT_MODE_COMPONENT_SIZE * row * text_mode_width,
             row_element,
             color_element,
             fragment;
 
-        var bg_color,
+        var attribute,
+            bg_color,
             fg_color,
             text;
 
@@ -479,8 +493,13 @@ function ScreenAdapter(screen_container, bus)
         {
             color_element = document.createElement("span");
 
-            bg_color = text_mode_data[offset + 1];
-            fg_color = text_mode_data[offset + 2];
+            attribute = text_mode_data[offset + ATTRIBUTE_INDEX];
+            bg_color = text_mode_data[offset + BG_COLOR_INDEX];
+            fg_color = text_mode_data[offset + FG_COLOR_INDEX];
+
+            if (attribute & (1<<7)) {
+                color_element.classList.add('blink');
+            }
 
             color_element.style.backgroundColor = number_as_color(bg_color);
             color_element.style.color = number_as_color(fg_color);
@@ -489,16 +508,15 @@ function ScreenAdapter(screen_container, bus)
 
             // put characters of the same color in one element
             while(i < text_mode_width &&
-                text_mode_data[offset + 1] === bg_color &&
-                text_mode_data[offset + 2] === fg_color)
+                text_mode_data[offset + ATTRIBUTE_INDEX] === attribute)
             {
-                var ascii = text_mode_data[offset];
+                var ascii = text_mode_data[offset + CHARACTER_INDEX];
 
                 text += charmap[ascii];
                 dbg_assert(charmap[ascii]);
 
                 i++;
-                offset += 3;
+                offset += TEXT_MODE_COMPONENT_SIZE;
 
                 if(row === cursor_row)
                 {

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -122,7 +122,7 @@ function ScreenAdapter(screen_container, bus)
 
     graphic_context.imageSmoothingEnabled = false;
 
-    cursor_element.classList.add("blink")
+    cursor_element.classList.add("cursor")
     cursor_element.style.position = "absolute";
     cursor_element.style.backgroundColor = "#ccc";
     cursor_element.style.width = "7px";
@@ -529,6 +529,7 @@ function ScreenAdapter(screen_container, bus)
                     else if(i === cursor_col + 1)
                     {
                         // found the cursor
+                        cursor_element.style.backgroundColor = color_element.style.color;
                         fragment.appendChild(cursor_element);
                         break;
                     }

--- a/src/vga.js
+++ b/src/vga.js
@@ -851,7 +851,7 @@ VGAScreen.prototype.text_mode_redraw = function()
 
     const split_screen_row = this.scan_line_to_screen_row(this.line_compare);
     const row_offset = Math.max(0, (this.offset_register * 2 - this.max_cols) * 2);
-    const blink_flag = this.attribute_mode & (1<<3);
+    const blink_flag = this.attribute_mode & 1 << 3;
     const bg_color_mask = blink_flag ? 7 : 0xF;
 
     for(var row = 0; row < this.max_rows; row++)
@@ -865,7 +865,7 @@ VGAScreen.prototype.text_mode_redraw = function()
         {
             chr = this.vga_memory[addr];
             color = this.vga_memory[addr | 1];
-            blinking = blink_flag && (color & (1<<7));
+            blinking = blink_flag && (color & 1 << 7);
 
             this.bus.send("screen-put-char", [row, col, chr, blinking,
                 this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & bg_color_mask]],
@@ -920,8 +920,8 @@ VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
         chr = value;
         color = this.vga_memory[addr | 1];
     }
-    const blink_flag = this.attribute_mode & (1<<3);
-    const blinking = blink_flag && (color & (1<<7));
+    const blink_flag = this.attribute_mode & 1 << 3;
+    const blinking = blink_flag && (color & 1 << 7);
     const bg_color_mask = blink_flag ? 7 : 0xF;
 
     this.bus.send("screen-put-char", [row, col, chr, blinking,

--- a/src/vga.js
+++ b/src/vga.js
@@ -865,7 +865,7 @@ VGAScreen.prototype.text_mode_redraw = function()
         {
             chr = this.vga_memory[addr];
             color = this.vga_memory[addr | 1];
-            blinking = blink_flag && (color & (1<<7))
+            blinking = blink_flag && (color & (1<<7));
 
             this.bus.send("screen-put-char", [row, col, chr, blinking,
                 this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & bg_color_mask]],

--- a/src/vga.js
+++ b/src/vga.js
@@ -846,10 +846,13 @@ VGAScreen.prototype.text_mode_redraw = function()
 {
     var addr = this.start_address << 1,
         chr,
+        blinking,
         color;
 
     const split_screen_row = this.scan_line_to_screen_row(this.line_compare);
     const row_offset = Math.max(0, (this.offset_register * 2 - this.max_cols) * 2);
+    const blink_flag = this.attribute_mode & (1<<3);
+    const bg_color_mask = blink_flag ? 7 : 0xF;
 
     for(var row = 0; row < this.max_rows; row++)
     {
@@ -862,9 +865,10 @@ VGAScreen.prototype.text_mode_redraw = function()
         {
             chr = this.vga_memory[addr];
             color = this.vga_memory[addr | 1];
+            blinking = blink_flag && (color & (1<<7))
 
-            this.bus.send("screen-put-char", [row, col, chr, color,
-                this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 7]],
+            this.bus.send("screen-put-char", [row, col, chr, blinking,
+                this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & bg_color_mask]],
                 this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
 
             addr += 2;
@@ -916,9 +920,12 @@ VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
         chr = value;
         color = this.vga_memory[addr | 1];
     }
+    const blink_flag = this.attribute_mode & (1<<3);
+    const blinking = blink_flag && (color & (1<<7));
+    const bg_color_mask = blink_flag ? 7 : 0xF;
 
-    this.bus.send("screen-put-char", [row, col, chr, color,
-        this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 7]],
+    this.bus.send("screen-put-char", [row, col, chr, blinking,
+        this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & bg_color_mask]],
         this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
 };
 

--- a/src/vga.js
+++ b/src/vga.js
@@ -863,8 +863,8 @@ VGAScreen.prototype.text_mode_redraw = function()
             chr = this.vga_memory[addr];
             color = this.vga_memory[addr | 1];
 
-            this.bus.send("screen-put-char", [row, col, chr,
-                this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 0xF]],
+            this.bus.send("screen-put-char", [row, col, chr, color,
+                this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 7]],
                 this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
 
             addr += 2;
@@ -917,8 +917,8 @@ VGAScreen.prototype.vga_memory_write_text_mode = function(addr, value)
         color = this.vga_memory[addr | 1];
     }
 
-    this.bus.send("screen-put-char", [row, col, chr,
-        this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 0xF]],
+    this.bus.send("screen-put-char", [row, col, chr, color,
+        this.vga256_palette[this.dac_mask & this.dac_map[color >> 4 & 7]],
         this.vga256_palette[this.dac_mask & this.dac_map[color & 0xF]]]);
 };
 

--- a/v86.css
+++ b/v86.css
@@ -307,5 +307,22 @@ h4 {
 }
 
 .blink {
-    animation: blink calc(1s / 4.380) step-start infinite;
+    animation: blink 0.6s step-start infinite;
 }
+
+.cursor {
+    animation: cursor 0.2s step-start infinite;
+}
+
+@keyframes blink {
+    50% {
+        color: transparent;
+    }
+}
+
+@keyframes cursor {
+    50% {
+        background-color: transparent;
+    }
+}
+

--- a/v86.css
+++ b/v86.css
@@ -130,6 +130,22 @@ h4 {
 #terminal {
     max-width: 1024px;
 }
+.blink {
+    animation: blink 0.6s step-start infinite;
+}
+@keyframes blink {
+    50% {
+        color: transparent;
+    }
+}
+.cursor {
+    animation: cursor 0.6s step-start infinite;
+}
+@keyframes cursor {
+    50% {
+        background-color: transparent;
+    }
+}
 
 /* the code below was copied from xterm.css */
 
@@ -305,24 +321,3 @@ h4 {
     z-index: 2;
     position: relative;
 }
-
-.blink {
-    animation: blink 0.6s step-start infinite;
-}
-
-.cursor {
-    animation: cursor 0.2s step-start infinite;
-}
-
-@keyframes blink {
-    50% {
-        color: transparent;
-    }
-}
-
-@keyframes cursor {
-    50% {
-        background-color: transparent;
-    }
-}
-

--- a/v86.css
+++ b/v86.css
@@ -305,3 +305,7 @@ h4 {
     z-index: 2;
     position: relative;
 }
+
+.blink {
+    animation: blink calc(1s / 4.380) step-start infinite;
+}


### PR DESCRIPTION
1. Add BLINK flag support (3rd bit in VGA Attribute Mode Control Register).

> When this bit is set to 0, the most significant bit of the attribute selects the background intensity (allows 16 colors for background). When set to 1, this bit enables blinking.

![blink](https://github.com/copy/v86/assets/5357560/8e90d681-8765-473e-9364-ce5e6d34f374)

A test program which writes a blinking text to the text buffer

```
org 100h

mov ax, 0xB800 ; text buffer address
mov es, ax     ; segment register points to the text buffer
xor di, di     ; text buffer offset

mov ah, 0x92   ; XRGBIRGB, X-blink, RGB-bg, I-intensity, RGB-fg
xor bx, bx     ; text buffer index
mov cx, len    ; message length
mov bp, msg    ; message address

print:
mov al, [bp]            ; put next char from msg to al
mov word [es:di+bx], ax ; direct write to the text buffer
add bx, 2               ; video memory cell is 2-bytes long
inc bp                  ; move to the next char from msg
loop print

mov ah, 94h             ; red on blue (blink)
mov al, 3               ; heart char
mov word [es:di+bx], ax ; direct write to the text buffer

xor ah, ah     ; press any key to continue
int 16h

mov ah, 4Ch    ; exit
int 21h

msg db 'Hello + World = '
len equ $ - msg

```

A test program to clear/set BLINK flag
```
org 100h

mov dx, 3DAh
in al, dx

mov dx, 3C0h
mov al, 30h
out dx, al

inc dx
in al, dx
and al, 11110111b ; clear BLINK flag
;or al, 00001000b ; set BLINK flag
dec dx
out dx, al

mov ah, 4Ch    ; exit
int 21h
```

SuperCalc 4 clears BLINK on start to use high intensity yellow for background:

![sc](https://github.com/copy/v86/assets/5357560/d4cd05c3-6dff-4ca6-aa96-1d08aecd4a2c)

on exit, it sets the flag back.

2. fill the cursor with the foreground color of the character at the cursor's current location:
![cursor1](https://github.com/copy/v86/assets/5357560/6b5dc03a-ffb8-471d-b940-8b9904735438)
![cursor2](https://github.com/copy/v86/assets/5357560/efc5924a-e485-43bd-9b49-4fee4ea7b30d)
![cursor3](https://github.com/copy/v86/assets/5357560/af147ecc-5733-4c0d-aa8b-fe0edc5a3a09)
