### PR TITLE
Cursor Fixed in SuperCalc 1.0

### DIFF
--- a/src/browser/dummy_screen.js
+++ b/src/browser/dummy_screen.js
@@ -65,7 +65,7 @@ function DummyScreenAdapter(bus)
     }, this);
     bus.register("screen-update-cursor-scanline", function(data)
     {
-        this.update_cursor_scanline(data[0], data[1]);
+        this.update_cursor_scanline(...data);
     }, this);
 
     bus.register("screen-set-size-text", function(data)
@@ -129,7 +129,7 @@ function DummyScreenAdapter(bus)
     {
     };
 
-    this.update_cursor_scanline = function(start, end)
+    this.update_cursor_scanline = function(start, end, max)
     {
     };
 

--- a/src/browser/dummy_screen.js
+++ b/src/browser/dummy_screen.js
@@ -65,7 +65,7 @@ function DummyScreenAdapter(bus)
     }, this);
     bus.register("screen-update-cursor-scanline", function(data)
     {
-        this.update_cursor_scanline(...data);
+        this.update_cursor_scanline(data[0], data[1], data[2]);
     }, this);
 
     bus.register("screen-set-size-text", function(data)

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -147,7 +147,7 @@ function ScreenAdapter(screen_container, bus)
     }, this);
     bus.register("screen-update-cursor-scanline", function(data)
     {
-        this.update_cursor_scanline(data[0], data[1]);
+        this.update_cursor_scanline(...data);
     }, this);
 
     bus.register("screen-clear", function()
@@ -434,7 +434,7 @@ function ScreenAdapter(screen_container, bus)
         }
     }
 
-    this.update_cursor_scanline = function(start, end)
+    this.update_cursor_scanline = function(start, end, max)
     {
         if(start & 0x20)
         {
@@ -442,10 +442,17 @@ function ScreenAdapter(screen_container, bus)
         }
         else
         {
-            cursor_element.style.display = "inline";
-
-            cursor_element.style.height = Math.min(15, end - start) + "px";
-            cursor_element.style.marginTop = Math.min(15, start) + "px";
+            start = Math.min(max, start & 0x1F)
+            end = Math.min(max, end & 0x1F)
+            if (end <= start)
+            {
+                cursor_element.style.display = "none";
+            } else
+            {
+                cursor_element.style.display = "inline";
+                cursor_element.style.height = (end - start) + "px";
+                cursor_element.style.marginTop = start + "px";
+            }
         }
     };
 
@@ -453,7 +460,9 @@ function ScreenAdapter(screen_container, bus)
     {
         if(row !== cursor_row || col !== cursor_col)
         {
-            changed_rows[row] = 1;
+            if (row < text_mode_height) {
+                changed_rows[row] = 1;
+            }
             changed_rows[cursor_row] = 1;
 
             cursor_row = row;

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -442,8 +442,8 @@ function ScreenAdapter(screen_container, bus)
         }
         else
         {
-            start = Math.min(max, start & 0x1F)
-            end = Math.min(max, end & 0x1F)
+            start = Math.min(max, start & 0x1F);
+            end = Math.min(max, end & 0x1F);
             if (end <= start)
             {
                 cursor_element.style.display = "none";

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -147,7 +147,7 @@ function ScreenAdapter(screen_container, bus)
     }, this);
     bus.register("screen-update-cursor-scanline", function(data)
     {
-        this.update_cursor_scanline(...data);
+        this.update_cursor_scanline(data[0], data[1], data[2]);
     }, this);
 
     bus.register("screen-clear", function()
@@ -207,12 +207,12 @@ function ScreenAdapter(screen_container, bus)
                 }
             }
 
-            if(cursor_element.style.display !== "none")
+            if(cursor_element.style.display !== "none" && cursor_row < text_mode_height && cursor_col < text_mode_width)
             {
                 context.fillStyle = cursor_element.style.backgroundColor;
                 context.fillRect(
                     cursor_col * char_size[0],
-                    cursor_row * char_size[1] + parseInt(cursor_element.style.marginTop, 10) - 1,
+                    cursor_row * char_size[1] + parseInt(cursor_element.style.marginTop, 10),
                     parseInt(cursor_element.style.width, 10),
                     parseInt(cursor_element.style.height, 10)
                 );
@@ -434,25 +434,17 @@ function ScreenAdapter(screen_container, bus)
         }
     }
 
-    this.update_cursor_scanline = function(start, end, max)
+    this.update_cursor_scanline = function(start, end, visible)
     {
-        if(start & 0x20)
+        if(visible)
         {
-            cursor_element.style.display = "none";
+            cursor_element.style.display = "inline";
+            cursor_element.style.height = (end - start) + "px";
+            cursor_element.style.marginTop = start + "px";
         }
         else
         {
-            start = Math.min(max, start & 0x1F);
-            end = Math.min(max, end & 0x1F);
-            if (end <= start)
-            {
-                cursor_element.style.display = "none";
-            } else
-            {
-                cursor_element.style.display = "inline";
-                cursor_element.style.height = (end - start) + "px";
-                cursor_element.style.marginTop = start + "px";
-            }
+            cursor_element.style.display = "none";
         }
     };
 

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -452,10 +452,14 @@ function ScreenAdapter(screen_container, bus)
     {
         if(row !== cursor_row || col !== cursor_col)
         {
-            if (row < text_mode_height) {
+            if(row < text_mode_height)
+            {
                 changed_rows[row] = 1;
             }
-            changed_rows[cursor_row] = 1;
+            if(cursor_row < text_mode_height)
+            {
+                changed_rows[cursor_row] = 1;
+            }
 
             cursor_row = row;
             cursor_col = col;

--- a/src/io.js
+++ b/src/io.js
@@ -241,8 +241,11 @@ IO.prototype.register_write_consecutive = function(port_addr, device, w8_1, w8_2
     }
     else
     {
+        function w16_w8_2(data) {
+            w8_2.call(this, data & 0xFF);
+        }
         this.register_write(port_addr,     device, w8_1, w16_1);
-        this.register_write(port_addr + 1, device, w8_2);
+        this.register_write(port_addr + 1, device, w8_2, w16_w8_2);
     }
 };
 

--- a/src/io.js
+++ b/src/io.js
@@ -241,11 +241,8 @@ IO.prototype.register_write_consecutive = function(port_addr, device, w8_1, w8_2
     }
     else
     {
-        function w16_w8_2(data) {
-            w8_2.call(this, data & 0xFF);
-        }
         this.register_write(port_addr,     device, w8_1, w16_1);
-        this.register_write(port_addr + 1, device, w8_2, w16_w8_2);
+        this.register_write(port_addr + 1, device, w8_2);
     }
 };
 

--- a/src/vga.js
+++ b/src/vga.js
@@ -941,9 +941,6 @@ VGAScreen.prototype.update_cursor = function()
 
     dbg_assert(row >= 0 && col >= 0);
 
-    row = Math.min(this.max_rows - 1, row);
-    col = Math.min(this.max_cols - 1, col);
-
     this.bus.send("screen-update-cursor", [row, col]);
 };
 
@@ -1352,7 +1349,7 @@ VGAScreen.prototype.update_vertical_retrace = function()
 
 VGAScreen.prototype.update_cursor_scanline = function()
 {
-    this.bus.send("screen-update-cursor-scanline", [this.cursor_scanline_start, this.cursor_scanline_end]);
+    this.bus.send("screen-update-cursor-scanline", [this.cursor_scanline_start, this.cursor_scanline_end, this.max_scan_line]);
 };
 
 /**


### PR DESCRIPTION
The following issues are fixed:

1.
If a DOS program sets the cursor out of the screen then it should be hidden, but v86 shows it.

You can reproduce it by running VC.com (Volkov Commander) and "View" (F3) any file.
The cursor will be at position (0,24), but VC sets it to (0,127) to hide

The following program can reproduce a bug:

```
org 100h

mov dl, 0  ; cursor column
mov dh, 25 ; cursor row (out of the screen)
mov ah, 2  ; move cursor function
mov bh, 0  ; display page
int 10h

xor ah, ah ; press any key to continue
int 16h

int 20h    ; exit
```
v86 shows cursor at 0,24
expected: cursor is hidden

Solution: Remove range checks in VGAScreen.update_cursor in vga.js

2.
If a DOS program sets the "Cursor Scan Line End" less than "Cursor Scan Line Start" then cursor also should be hidden.

v86 is trying to set a negative height:
```
cursor_element.style.height = Math.min(15, end - start) + "px";
```

Solution: Hide cursor if end <= start, see "update_cursor_scanline" function in screen.js

3.
SuperCalc 1.0 is writing a word to I/O Port 3D5h.
v86 doesn't have a w16 handler and ignores such writes (and throws an assert error in debug.html).
As as result, cursor position is invalid or hidden.

Writing a word to the second consecutive register is allowed, so we can use w8 handler and treat the data (a word) as a byte, see io.js

The following program reproduces the bug:

```
org 100h

mov bx, 79   ; cursor column (X)
mov ax, 24   ; cursor row (Y)
mov dl, 80   ; number of columns (width)
mul dl       ; ax = ax * dl = rows * width
add bx, ax   ; bx = ax * dl + bx = rows * width + cols = cursor location

mov dx, 3D4h ; crtc index
mov al, 0x0F ; cursor location low
out dx, al
inc dl       ; crtc data
mov ax, bx   ; al = cursor location low
out dx, ax   ; <- assert error in v86 but works in dosbox-x
;out dx, al  ; v86 supports a byte write only

dec dl       ; crtc inex
mov al, 0x0E ; cursor location high
out dx, al
inc dl       ; crtc data
mov al, bh   ; al = cursor location high
out dx, ax   ; <- assert error in v86 but works in dosbox-x
;out dx, al  ; v86 supports a byte write only

xor ah, ah   ; press any key to continue
int 16h

int 20h      ; exit
```

After the fix, the cursor location is correct:

![image](https://github.com/copy/v86/assets/5357560/d68ae937-3dcc-49cd-8323-d1f6a3c46c77)

The cursor color and blinking is fixed in another PR.