### PR TITLE
vga: clear memory if VBE_DISPI_NOCLEARMEM is not set

### DIFF
--- a/src/vga.js
+++ b/src/vga.js
@@ -2113,6 +2113,10 @@ VGAScreen.prototype.port1CF_write = function(value)
         case 4:
             // enable, options
             this.svga_enabled = (value & 1) === 1;
+            if(this.svga_enabled & ((value & 0x80) === 0))
+            {
+                this.svga_memory.fill(0);
+            }
             this.dispi_enable_value = value;
             break;
         case 5:

--- a/src/vga.js
+++ b/src/vga.js
@@ -2113,7 +2113,7 @@ VGAScreen.prototype.port1CF_write = function(value)
         case 4:
             // enable, options
             this.svga_enabled = (value & 1) === 1;
-            if(this.svga_enabled & ((value & 0x80) === 0))
+            if(this.svga_enabled && (value & 0x80) === 0)
             {
                 this.svga_memory.fill(0);
             }


### PR DESCRIPTION
Fixes #641, tested on https://old-releases.ubuntu.com/releases/4.10/warty-release-live-i386.iso and https://cdimage.debian.org/debian-cd/current/i386/iso-cd/debian-12.6.0-i386-netinst.iso