### PR TITLE
Export as a module first

### DIFF
--- a/src/browser/filestorage.js
+++ b/src/browser/filestorage.js
@@ -148,15 +148,15 @@ ServerFileStorageWrapper.prototype.uncache = function(sha256sum)
 };
 
 // Closure Compiler's way of exporting
-if(typeof window !== "undefined")
-{
-    window["MemoryFileStorage"] = MemoryFileStorage;
-    window["ServerFileStorageWrapper"] = ServerFileStorageWrapper;
-}
-else if(typeof module !== "undefined" && typeof module.exports !== "undefined")
+if(typeof module !== "undefined" && typeof module.exports !== "undefined")
 {
     module.exports["MemoryFileStorage"] = MemoryFileStorage;
     module.exports["ServerFileStorageWrapper"] = ServerFileStorageWrapper;
+}
+else if(typeof window !== "undefined")
+{
+    window["MemoryFileStorage"] = MemoryFileStorage;
+    window["ServerFileStorageWrapper"] = ServerFileStorageWrapper;
 }
 else if(typeof importScripts === "function")
 {

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -1403,15 +1403,15 @@ function FileNotFoundError(message)
 FileNotFoundError.prototype = Error.prototype;
 
 // Closure Compiler's way of exporting
-if(typeof window !== "undefined")
-{
-    window["V86Starter"] = V86;
-    window["V86"] = V86;
-}
-else if(typeof module !== "undefined" && typeof module.exports !== "undefined")
+if(typeof module !== "undefined" && typeof module.exports !== "undefined")
 {
     module.exports["V86Starter"] = V86;
     module.exports["V86"] = V86;
+}
+else if(typeof window !== "undefined")
+{
+    window["V86Starter"] = V86;
+    window["V86"] = V86;
 }
 else if(typeof importScripts === "function")
 {

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -1676,13 +1676,13 @@ CPU.prototype.device_lower_irq = function(i)
 };
 
 // Closure Compiler's way of exporting
-if(typeof window !== "undefined")
-{
-    window["CPU"] = CPU;
-}
-else if(typeof module !== "undefined" && typeof module.exports !== "undefined")
+if(typeof module !== "undefined" && typeof module.exports !== "undefined")
 {
     module.exports["CPU"] = CPU;
+}
+else if(typeof window !== "undefined")
+{
+    window["CPU"] = CPU;
 }
 else if(typeof importScripts === "function")
 {


### PR DESCRIPTION
This fixes using v86 in bundlers like vite.