### PR TITLE
Remove spurious ControlLeft-key when AltRight is pressed under Windows

### DIFF
--- a/src/browser/keyboard.js
+++ b/src/browser/keyboard.js
@@ -433,7 +433,7 @@ function KeyboardAdapter(bus)
                     handle_event(deferred_event, deferred_keydown);
                     deferred_event = null;
                 }, 10);
-                return;
+                return false;
             }
         }
 

--- a/src/browser/keyboard.js
+++ b/src/browser/keyboard.js
@@ -468,7 +468,7 @@ function KeyboardAdapter(bus)
         if(deferred_code)
         {
             clearTimeout(deferred_timeout_id);
-            if(!altgr_key || (deferred_code === 0x1D && code !== 0xE038) || (deferred_code === 0x9D && code !== 0xE0B8))
+            if(!(altgr_key && ((deferred_code === 0x1D && code === 0xE038) || (deferred_code === 0x9D && code === 0xE0B8))))
             {
                 send_to_controller(deferred_code);
             }


### PR DESCRIPTION
Remove ControlLeft from keyboard input sequence `ControlLeft + AltRight` if platform is Windows and `AltRight` is pressed.

See issue #1127 for more details.