### PR TITLE
ci: set 1 hour timeout for "Build and test" job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Build and test
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Mentioned in Gitter chat, should prevent CI from getting stuck for 6 hours.