### PR TITLE
improve fake network write() efficiency

### DIFF
--- a/src/browser/fake_network.js
+++ b/src/browser/fake_network.js
@@ -1207,6 +1207,18 @@ TCPConnection.prototype.write = function(data) {
     this.pump();
 };
 
+/**
+ * @param {!Array<Uint8Array>} data_array
+ */
+TCPConnection.prototype.writev = function(data_array) {
+    if(!this.in_active_close) {
+        for(const data of data_array) {
+            this.send_buffer.write(data);
+        }
+    }
+    this.pump();
+};
+
 TCPConnection.prototype.close = function() {
     if(!this.in_active_close) {
         this.in_active_close = true;

--- a/src/browser/fake_network.js
+++ b/src/browser/fake_network.js
@@ -1238,7 +1238,7 @@ TCPConnection.prototype.close = function() {
 };
 
 TCPConnection.prototype.on_passive_close = function() {
-}
+};
 
 TCPConnection.prototype.release = function() {
     if(this.net.tcp_conn[this.tuple]) {

--- a/src/browser/fake_network.js
+++ b/src/browser/fake_network.js
@@ -404,41 +404,31 @@ function handle_fake_dhcp(packet, adapter) {
 function handle_fake_networking(data, adapter) {
     let packet = {};
     parse_eth(data, packet);
-    if(packet.tcp) {
-        if(handle_fake_tcp(packet, adapter)) {
-            return true;
+
+    if(packet.ipv4) {
+        if(packet.tcp) {
+            handle_fake_tcp(packet, adapter);
+        }
+        else if(packet.udp) {
+            if(packet.dns) {
+                handle_fake_dns(packet, adapter);
+            }
+            else if(packet.dhcp) {
+                handle_fake_dhcp(packet, adapter);
+            }
+            else if(packet.ntp) {
+                handle_fake_ntp(packet, adapter);
+            }
+            else if(packet.udp.dport === 8) {
+                handle_udp_echo(packet, adapter);
+            }
+        }
+        else if(packet.icmp && packet.icmp.type === 8) {
+            handle_fake_ping(packet, adapter);
         }
     }
-
-    if(packet.arp && packet.arp.oper === 1 && packet.arp.ptype === ETHERTYPE_IPV4) {
+    else if(packet.arp && packet.arp.oper === 1 && packet.arp.ptype === ETHERTYPE_IPV4) {
         arp_whohas(packet, adapter);
-    }
-
-    if(packet.dns) {
-        if(handle_fake_dns(packet, adapter)) {
-            return;
-        }
-    }
-
-    if(packet.ntp) {
-        if(handle_fake_ntp(packet, adapter)) {
-            return;
-        }
-    }
-
-    // ICMP Ping
-    if(packet.icmp && packet.icmp.type === 8) {
-        handle_fake_ping(packet, adapter);
-    }
-
-    if(packet.dhcp) {
-        if(handle_fake_dhcp(packet, adapter)) {
-            return;
-        }
-    }
-
-    if(packet.udp && packet.udp.dport === 8) {
-        handle_udp_echo(packet, adapter);
     }
 }
 

--- a/src/browser/fake_network.js
+++ b/src/browser/fake_network.js
@@ -351,7 +351,7 @@ function handle_fake_dns_doh(packet, adapter)
 
 function handle_fake_dns(packet, adapter)
 {
-    if(adapter.dns_method === 'static') {
+    if(adapter.dns_method === "static") {
         return handle_fake_dns_static(packet, adapter);
     }
     else {

--- a/src/browser/fake_network.js
+++ b/src/browser/fake_network.js
@@ -1017,7 +1017,7 @@ function fake_tcp_connect(dport, adapter)
  */
 function TCPConnection()
 {
-    this.send_stream = new Uint8Stream(512, 0);
+    this.send_stream = new Uint8Stream(2048, 0);
     this.send_chunk_buf = new Uint8Array(TCP_PAYLOAD_SIZE);
     this.seq_history = [];
 }
@@ -1191,7 +1191,7 @@ TCPConnection.prototype.pump = function() {
         const n_ready = this.send_stream.peek(data, data.length);
         const reply = this.ipv4_reply();
         this.pending = true;
-        if(this.state === TCP_STATE_FIN_WAIT_1 && this.send_stream.length - n_ready === 0) {
+        if(this.state === TCP_STATE_FIN_WAIT_1 && this.send_stream.length === n_ready) {
             reply.tcp.fin = true;
         }
         reply.tcp.psh = true;

--- a/src/browser/fake_network.js
+++ b/src/browser/fake_network.js
@@ -1131,7 +1131,7 @@ TCPConnection.prototype.process = function(packet) {
             // dbg_log(`TCP[${this.tuple}]: received FIN in state "${this.state}, next "${TCP_STATE_CLOSE_WAIT}""`, LOG_FETCH);
             reply.tcp.ack = true;
             this.state = TCP_STATE_CLOSE_WAIT;
-            this.on_passive_close();
+            // NOTE that we should forward the CLOSE event from the guest here, but neither WISP nor fetch() support that
         }
         else if(this.state === TCP_STATE_FIN_WAIT_1) {
             if(packet.tcp.ack) {
@@ -1235,9 +1235,6 @@ TCPConnection.prototype.close = function() {
         }
     }
     this.pump();
-};
-
-TCPConnection.prototype.on_passive_close = function() {
 };
 
 TCPConnection.prototype.release = function() {

--- a/src/browser/fake_network.js
+++ b/src/browser/fake_network.js
@@ -93,12 +93,12 @@ class Uint8Stream
         const src_length = src_array.length;
         const total_length = this.length + src_length;
         let capacity = this.buffer.length;
-        if (capacity < total_length) {
-            while (capacity < total_length) {
+        if(capacity < total_length) {
+            while(capacity < total_length) {
                 capacity *= 2;
             }
-            if (this.maximum_capacity && capacity > this.maximum_capacity) {
-                console.error('stream capacity overflow in Uint8Stream.write()');
+            if(this.maximum_capacity && capacity > this.maximum_capacity) {
+                console.error("stream capacity overflow in Uint8Stream.write()");
                 return;
             }
             this.resize(capacity);
@@ -107,7 +107,7 @@ class Uint8Stream
 
         /*
         let head = this.head;
-        for (let i=0; i<src_length; ++i) {
+        for(let i=0; i<src_length; ++i) {
             buffer[head] = src_array[i];
             head = (head + 1) % capacity;
         }
@@ -115,7 +115,7 @@ class Uint8Stream
         this.length += src_length;
         */
         const new_head = this.head + src_length;
-        if (new_head > capacity) {
+        if(new_head > capacity) {
             const i_split = capacity - this.head;
             buffer.set(src_array.subarray(0, i_split), this.head);
             buffer.set(src_array.subarray(i_split));
@@ -133,20 +133,20 @@ class Uint8Stream
      */
     peek(dst_array, length)
     {
-        if (length > this.length) {
+        if(length > this.length) {
             length = this.length;
         }
-        if (length) {
+        if(length) {
             const buffer = this.buffer;
             const capacity = buffer.length;
             /*
-            for (let i=0, tail = this.tail; i<length; ++i) {
+            for(let i=0, tail = this.tail; i<length; ++i) {
                 dst_array[i] = buffer[tail];
                 tail = (tail + 1) % capacity;
             }
             */
             const new_tail = this.tail + length;
-            if (new_tail > capacity) {
+            if(new_tail > capacity) {
                 const buf_len_left = new_tail % capacity;
                 const buf_len_right = capacity - this.tail;
                 dst_array.set(buffer.subarray(this.tail));
@@ -164,10 +164,10 @@ class Uint8Stream
      */
     remove(length)
     {
-        if (length > this.length) {
+        if(length > this.length) {
             length = this.length;
         }
-        if (length) {
+        if(length) {
             this.tail = (this.tail + length) % this.buffer.length;
             this.length -= length;
         }
@@ -188,7 +188,7 @@ class EthernetPacketEncoder
         this.ipv4_payload_view = new DataView(eth_frame.buffer, offset + IPV4_PAYLOAD_OFFSET, IPV4_PAYLOAD_SIZE);
         this.udp_payload_view = new DataView(eth_frame.buffer, offset + UDP_PAYLOAD_OFFSET, UDP_PAYLOAD_SIZE);
 
-        for (const view of [this.eth_frame_view, this.eth_payload_view, this.ipv4_payload_view, this.udp_payload_view]) {
+        for(const view of [this.eth_frame_view, this.eth_payload_view, this.ipv4_payload_view, this.udp_payload_view]) {
             view.setArray = this.view_setArray.bind(this, view);
             view.setString = this.view_setString.bind(this, view);
             view.setInetChecksum = this.view_setInetChecksum.bind(this, view);
@@ -238,13 +238,13 @@ class EthernetPacketEncoder
         const data = this.eth_frame;
         const offset = dst_view.byteOffset;
         const uint16_end = offset + (length & ~1);
-        for (let i = offset; i < uint16_end; i += 2) {
+        for(let i = offset; i < uint16_end; i += 2) {
             checksum += data[i] << 8 | data[i+1];
         }
-        if (length & 1) {
+        if(length & 1) {
             checksum += data[uint16_end] << 8;
         }
-        while (checksum >> 16) {
+        while(checksum >> 16) {
             checksum = (checksum & 0xffff) + (checksum >> 16);
         }
         dst_view.setUint16(dst_offset, ~checksum);
@@ -284,7 +284,7 @@ function handle_fake_tcp(packet, adapter)
     const tuple = `${packet.ipv4.src.join(".")}:${packet.tcp.sport}:${packet.ipv4.dest.join(".")}:${packet.tcp.dport}`;
 
     if(packet.tcp.syn) {
-        if(adapter.tcp_conn.hasOwnProperty(tuple)) {
+        if(adapter.tcp_conn[tuple]) {
             dbg_log("SYN to already opened port", LOG_FETCH);
         }
         if(adapter.on_tcp_connection(adapter, packet, tuple)) {
@@ -292,7 +292,7 @@ function handle_fake_tcp(packet, adapter)
         }
     }
 
-    if(!adapter.tcp_conn.hasOwnProperty(tuple)) {
+    if(!adapter.tcp_conn[tuple]) {
         dbg_log(`I dont know about ${tuple}, so resetting`, LOG_FETCH);
         let bop = packet.tcp.ackn;
         if(packet.tcp.fin || packet.tcp.syn) bop += 1;
@@ -978,7 +978,7 @@ function fake_tcp_connect(dport, adapter)
     do {
         sport = 1000 + Math.random() * 64535 | 0;
         tuple = `${vm_ip_str}:${dport}:${router_ip_str}:${sport}`;
-    } while (adapter.tcp_conn.hasOwnProperty(tuple));
+    } while(adapter.tcp_conn[tuple]);
 
     let reader;
     let connector;
@@ -1184,15 +1184,15 @@ TCPConnection.prototype.close = function() {
 };
 
 TCPConnection.prototype.pump = function() {
-    if (this.send_stream.length > 0 && !this.pending) {
+    if(this.send_stream.length > 0 && !this.pending) {
         const data = this.send_chunk_buf;
         const n_ready = this.send_stream.peek(data, data.length);
         const reply = this.ipv4_reply();
         this.pending = true;
 /*
-        if (this.send_stream.length - n_ready < 1) {
+        if(this.send_stream.length - n_ready < 1) {
 */
-        if (this.send_stream.length < 1) {  // TODO: this can never be true!?
+        if(this.send_stream.length < 1) {  // TODO: this can never be true!?
             reply.tcp.fin = true;
         }
         reply.tcp.psh = true;

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -38,7 +38,7 @@ FetchNetworkAdapter.prototype.destroy = function()
 {
 };
 
-FetchNetworkAdapter.prototype.on_tcp_connection = function(adapter, packet, tuple)
+FetchNetworkAdapter.prototype.on_tcp_connection = function(packet, tuple)
 {
     if(packet.tcp.dport === 80) {
         let conn = new TCPConnection();
@@ -47,7 +47,7 @@ FetchNetworkAdapter.prototype.on_tcp_connection = function(adapter, packet, tupl
         conn.on_data = on_data_http;
         conn.tuple = tuple;
         conn.accept(packet);
-        adapter.tcp_conn[tuple] = conn;
+        this.tcp_conn[tuple] = conn;
         return true;
     }
     return false;

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -16,9 +16,9 @@ function FetchNetworkAdapter(bus, config)
     this.vm_ip = new Uint8Array((config.vm_ip || "192.168.86.100").split(".").map(function(x) { return parseInt(x, 10); }));
     this.masquerade = config.masquerade === undefined || !!config.masquerade;
     this.vm_mac = new Uint8Array(6);
-
     this.tcp_conn = {};
     this.eth_encoder_buf = create_eth_encoder_buf();
+    this.dns_method = "static";
 
     // Ex: 'https://corsproxy.io/?'
     this.cors_proxy = config.cors_proxy;

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -18,6 +18,7 @@ function FetchNetworkAdapter(bus, config)
     this.vm_mac = new Uint8Array(6);
 
     this.tcp_conn = {};
+    this.eth_encoder_buf = create_eth_encoder_buf();
 
     // Ex: 'https://corsproxy.io/?'
     this.cors_proxy = config.cors_proxy;

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -160,12 +160,6 @@ FetchNetworkAdapter.prototype.send = function(data)
     handle_fake_networking(data, this);
 };
 
-
-FetchNetworkAdapter.prototype.tcp_connect = function(dport)
-{
-    return fake_tcp_connect(dport, this);
-};
-
 /**
  * @param {Uint8Array} data
  */

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -123,6 +123,7 @@ async function on_data_http(data)
 
         this.write(new TextEncoder().encode(lines.join("\r\n")));
         this.write(new Uint8Array(ab));
+        this.close();
     }
 }
 

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -177,7 +177,6 @@ async function on_data_http(data)
     }
 }
 
-/*
 FetchNetworkAdapter.prototype.fetch = async function(url, options)
 {
     if(this.cors_proxy) url = this.cors_proxy + encodeURIComponent(url);
@@ -203,7 +202,6 @@ FetchNetworkAdapter.prototype.fetch = async function(url, options)
         ];
     }
 };
-*/
 
 FetchNetworkAdapter.prototype.parse_http_header = function(header)
 {

--- a/src/browser/wisp_network.js
+++ b/src/browser/wisp_network.js
@@ -183,132 +183,130 @@ WispNetworkAdapter.prototype.send = function(data)
     let packet = {};
     parse_eth(data, packet);
 
-    if(packet.tcp) {
-        let reply = {};
-        reply.eth = { ethertype: ETHERTYPE_IPV4, src: this.router_mac, dest: packet.eth.src };
-        reply.ipv4 = {
-            proto: IPV4_PROTO_TCP,
-            src: packet.ipv4.dest,
-            dest: packet.ipv4.src
-        };
-
-        let tuple = [
-            packet.ipv4.src.join("."),
-            packet.tcp.sport,
-            packet.ipv4.dest.join("."),
-            packet.tcp.dport
-        ].join(":");
-
-        if(packet.tcp.syn) {
-            if(this.tcp_conn[tuple]) {
-                dbg_log("SYN to already opened port", LOG_FETCH);
-            }
-            const tcp_conn = new TCPConnection();
-
-            tcp_conn.state = TCP_STATE_SYN_RECEIVED;
-            tcp_conn.net = this;
-            tcp_conn.tuple = tuple;
-            tcp_conn.stream_id = this.last_stream++;
-            this.tcp_conn[tuple] = tcp_conn;
-
-            tcp_conn.on_data = (data) => {
-                if(data.length !== 0) {
-                    this.send_wisp_frame({
-                        type: "DATA",
-                        stream_id: tcp_conn.stream_id,
-                        data: data
-                    });
-                }
-            };
-
-            tcp_conn.on_shutdown = () => {
-                this.send_wisp_frame({
-                    type: "CLOSE",
-                    stream_id: tcp_conn.stream_id,
-                    reason: 0x02    // 0x02: Voluntary stream closure
-                });
-            };
-
-            tcp_conn.on_close = () => {
-                this.send_wisp_frame({
-                    type: "CLOSE",
-                    stream_id: tcp_conn.stream_id,
-                    reason: 0x02    // 0x02: Voluntary stream closure
-                });
-            };
-
-            this.send_wisp_frame({
-                type: "CONNECT",
-                stream_id: tcp_conn.stream_id,
-                hostname: packet.ipv4.dest.join("."),
-                port: packet.tcp.dport,
-                data_callback: (data) => {
-                    tcp_conn.write(data);
-                },
-                close_callback: (data) => {
-                    tcp_conn.close();
-                }
-            });
-
-            tcp_conn.accept(packet);
-            return;
-        }
-
-        if(!this.tcp_conn[tuple]) {
-            dbg_log(`I dont know about ${tuple}, so restting`, LOG_FETCH);
-            let bop = packet.tcp.ackn;
-            if(packet.tcp.fin || packet.tcp.syn) bop += 1;
-            reply.tcp = {
-                sport: packet.tcp.dport,
-                dport: packet.tcp.sport,
-                seq: bop,
-                ackn: packet.tcp.seq + (packet.tcp.syn ? 1: 0),
-                winsize: packet.tcp.winsize,
-                rst: true,
-                ack: packet.tcp.syn
-            };
-            this.receive(make_packet(this.eth_encoder_buf, reply));
-            return;
-        }
-
-        this.tcp_conn[tuple].process(packet);
-    }
-
-    if(packet.arp && packet.arp.oper === 1 && packet.arp.ptype === ETHERTYPE_IPV4) {
-        arp_whohas(packet, this);
-    }
-
-    if(packet.dns) {
-        // TODO: remove when this wisp client supports udp
-        (async () => {
+    if(packet.ipv4) {
+        if(packet.tcp) {
             let reply = {};
             reply.eth = { ethertype: ETHERTYPE_IPV4, src: this.router_mac, dest: packet.eth.src };
             reply.ipv4 = {
-                proto: IPV4_PROTO_UDP,
-                src: this.router_ip,
-                dest: packet.ipv4.src,
+                proto: IPV4_PROTO_TCP,
+                src: packet.ipv4.dest,
+                dest: packet.ipv4.src
             };
-            reply.udp = { sport: 53, dport: packet.udp.sport };
-            const result = await ((await fetch(`https://${this.doh_server}/dns-query`, {method: "POST", headers: [["content-type", "application/dns-message"]], body: packet.udp.data})).arrayBuffer());
-            reply.udp.data = new Uint8Array(result);
-            this.receive(make_packet(this.eth_encoder_buf, reply));
-        })();
-    }
 
-    if(packet.ntp) {
-        // TODO: remove when this wisp client supports udp
-        handle_fake_ntp(packet, this);
-        return;
-    }
+            let tuple = [
+                packet.ipv4.src.join("."),
+                packet.tcp.sport,
+                packet.ipv4.dest.join("."),
+                packet.tcp.dport
+            ].join(":");
 
-    if(packet.dhcp) {
-        handle_fake_dhcp(packet, this);
-        return;
-    }
+            if(packet.tcp.syn) {
+                if(this.tcp_conn[tuple]) {
+                    dbg_log("SYN to already opened port", LOG_FETCH);
+                }
+                const tcp_conn = new TCPConnection();
 
-    if(packet.udp && packet.udp.dport === 8) {
-        // TODO: remove when this wisp client supports udp
-        handle_udp_echo(packet, this);
+                tcp_conn.state = TCP_STATE_SYN_RECEIVED;
+                tcp_conn.net = this;
+                tcp_conn.tuple = tuple;
+                tcp_conn.stream_id = this.last_stream++;
+                this.tcp_conn[tuple] = tcp_conn;
+
+                tcp_conn.on_data = (data) => {
+                    if(data.length !== 0) {
+                        this.send_wisp_frame({
+                            type: "DATA",
+                            stream_id: tcp_conn.stream_id,
+                            data: data
+                        });
+                    }
+                };
+
+                tcp_conn.on_shutdown = () => {
+                    this.send_wisp_frame({
+                        type: "CLOSE",
+                        stream_id: tcp_conn.stream_id,
+                        reason: 0x02    // 0x02: Voluntary stream closure
+                    });
+                };
+
+                tcp_conn.on_close = () => {
+                    this.send_wisp_frame({
+                        type: "CLOSE",
+                        stream_id: tcp_conn.stream_id,
+                        reason: 0x02    // 0x02: Voluntary stream closure
+                    });
+                };
+
+                this.send_wisp_frame({
+                    type: "CONNECT",
+                    stream_id: tcp_conn.stream_id,
+                    hostname: packet.ipv4.dest.join("."),
+                    port: packet.tcp.dport,
+                    data_callback: (data) => {
+                        tcp_conn.write(data);
+                    },
+                    close_callback: (data) => {
+                        tcp_conn.close();
+                    }
+                });
+
+                tcp_conn.accept(packet);
+                return;
+            }
+
+            if(!this.tcp_conn[tuple]) {
+                dbg_log(`I dont know about ${tuple}, so restting`, LOG_FETCH);
+                let bop = packet.tcp.ackn;
+                if(packet.tcp.fin || packet.tcp.syn) bop += 1;
+                reply.tcp = {
+                    sport: packet.tcp.dport,
+                    dport: packet.tcp.sport,
+                    seq: bop,
+                    ackn: packet.tcp.seq + (packet.tcp.syn ? 1: 0),
+                    winsize: packet.tcp.winsize,
+                    rst: true,
+                    ack: packet.tcp.syn
+                };
+                this.receive(make_packet(this.eth_encoder_buf, reply));
+                return;
+            }
+
+            this.tcp_conn[tuple].process(packet);
+        }
+        else if(packet.udp) {
+            // TODO: remove when this wisp client supports udp
+            if(packet.dns) {
+                (async () => {
+                    let reply = {};
+                    reply.eth = { ethertype: ETHERTYPE_IPV4, src: this.router_mac, dest: packet.eth.src };
+                    reply.ipv4 = {
+                        proto: IPV4_PROTO_UDP,
+                        src: this.router_ip,
+                        dest: packet.ipv4.src,
+                    };
+                    reply.udp = { sport: 53, dport: packet.udp.sport };
+                    const result = await ((await fetch(`https://${this.doh_server}/dns-query`, {method: "POST", headers: [["content-type", "application/dns-message"]], body: packet.udp.data})).arrayBuffer());
+                    reply.udp.data = new Uint8Array(result);
+                    this.receive(make_packet(this.eth_encoder_buf, reply));
+                })();
+            }
+            else if(packet.dhcp) {
+                handle_fake_dhcp(packet, this);
+            }
+            else if(packet.ntp) {
+                handle_fake_ntp(packet, this);
+            }
+            else if(packet.udp.dport === 8) {
+                handle_udp_echo(packet, this);
+            }
+        }
+        else if(packet.icmp && packet.icmp.type === 8) {
+            handle_fake_ping(packet, this);
+        }
+    }
+    else if(packet.arp && packet.arp.oper === 1 && packet.arp.ptype === ETHERTYPE_IPV4) {
+        arp_whohas(packet, this);
     }
 };
 

--- a/src/browser/wisp_network.js
+++ b/src/browser/wisp_network.js
@@ -224,7 +224,7 @@ WispNetworkAdapter.prototype.on_tcp_connection = function(packet, tuple)
 
     conn.accept(packet);
     return true;
-}
+};
 
 /**
  * @param {Uint8Array} data

--- a/src/browser/wisp_network.js
+++ b/src/browser/wisp_network.js
@@ -219,6 +219,14 @@ WispNetworkAdapter.prototype.send = function(data)
                 }
             };
 
+            tcp_conn.on_passive_close = () => {
+                this.send_wisp_frame({
+                    type: "CLOSE",
+                    stream_id: tcp_conn.stream_id,
+                    reason: 0x02    // 0x02: Voluntary stream closure
+                });
+            };
+
             this.send_wisp_frame({
                 type: "CONNECT",
                 stream_id: tcp_conn.stream_id,

--- a/src/browser/wisp_network.js
+++ b/src/browser/wisp_network.js
@@ -249,7 +249,7 @@ WispNetworkAdapter.prototype.send = function(data)
                 rst: true,
                 ack: packet.tcp.syn
             };
-            adapter_receive(this, reply);
+            this.receive(make_packet(this.eth_encoder_buf, reply));
             return;
         }
 
@@ -273,7 +273,7 @@ WispNetworkAdapter.prototype.send = function(data)
             reply.udp = { sport: 53, dport: packet.udp.sport };
             const result = await ((await fetch(`https://${this.doh_server}/dns-query`, {method: "POST", headers: [["content-type", "application/dns-message"]], body: packet.udp.data})).arrayBuffer());
             reply.udp.data = new Uint8Array(result);
-            adapter_receive(this, reply);
+            this.receive(make_packet(this.eth_encoder_buf, reply));
         })();
     }
 

--- a/src/browser/wisp_network.js
+++ b/src/browser/wisp_network.js
@@ -219,14 +219,6 @@ WispNetworkAdapter.prototype.send = function(data)
                 }
             };
 
-            tcp_conn.on_passive_close = () => {
-                this.send_wisp_frame({
-                    type: "CLOSE",
-                    stream_id: tcp_conn.stream_id,
-                    reason: 0x02    // 0x02: Voluntary stream closure
-                });
-            };
-
             this.send_wisp_frame({
                 type: "CONNECT",
                 stream_id: tcp_conn.stream_id,

--- a/src/browser/wisp_network.js
+++ b/src/browser/wisp_network.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const DEFAULT_DOH_SERVER = "cloudflare-dns.com";
-
 /**
  * @constructor
  *
@@ -10,7 +8,6 @@ const DEFAULT_DOH_SERVER = "cloudflare-dns.com";
  */
 function WispNetworkAdapter(wisp_url, bus, config)
 {
-
     this.register_ws(wisp_url);
     this.last_stream = 1;
     this.connections = {0: {congestion: 0}};
@@ -24,15 +21,15 @@ function WispNetworkAdapter(wisp_url, bus, config)
     this.vm_ip = new Uint8Array((config.vm_ip || "192.168.86.100").split(".").map(function(x) { return parseInt(x, 10); }));
     this.masquerade = config.masquerade === undefined || !!config.masquerade;
     this.vm_mac = new Uint8Array(6);
-    this.doh_server =  config.doh_server || DEFAULT_DOH_SERVER;
     this.tcp_conn = {};
     this.eth_encoder_buf = create_eth_encoder_buf();
+    this.dns_method = "doh";
+    this.doh_server = config.doh_server;
 
     this.bus.register("net" + this.id + "-mac", function(mac) {
         this.vm_mac = new Uint8Array(mac.split(":").map(function(x) { return parseInt(x, 16); }));
     }, this);
-    this.bus.register("net" + this.id + "-send", function(data)
-    {
+    this.bus.register("net" + this.id + "-send", function(data) {
         this.send(data);
     }, this);
 }
@@ -231,47 +228,8 @@ WispNetworkAdapter.prototype.on_tcp_connection = function(packet, tuple)
  */
 WispNetworkAdapter.prototype.send = function(data)
 {
-    let packet = {};
-    parse_eth(data, packet);
-
-    if(packet.ipv4) {
-        if(packet.tcp) {
-            handle_fake_tcp(packet, this);
-        }
-        else if(packet.udp) {
-            // TODO: remove when this wisp client supports udp
-            if(packet.dns) {
-                (async () => {
-                    const reply = {
-                        eth: { ethertype: ETHERTYPE_IPV4, src: this.router_mac, dest: packet.eth.src },
-                        ipv4: { proto: IPV4_PROTO_UDP, src: this.router_ip, dest: packet.ipv4.src },
-                        udp: { sport: 53, dport: packet.udp.sport }
-                    };
-                    const result = await (await fetch(`https://${this.doh_server}/dns-query`, {
-                        method: "POST",
-                        headers: [["content-type", "application/dns-message"]],
-                        body: packet.udp.data})).arrayBuffer();
-                    reply.udp.data = new Uint8Array(result);
-                    this.receive(make_packet(this.eth_encoder_buf, reply));
-                })();
-            }
-            else if(packet.dhcp) {
-                handle_fake_dhcp(packet, this);
-            }
-            else if(packet.ntp) {
-                handle_fake_ntp(packet, this);
-            }
-            else if(packet.udp.dport === 8) {
-                handle_udp_echo(packet, this);
-            }
-        }
-        else if(packet.icmp && packet.icmp.type === 8) {
-            handle_fake_ping(packet, this);
-        }
-    }
-    else if(packet.arp && packet.arp.oper === 1 && packet.arp.ptype === ETHERTYPE_IPV4) {
-        arp_whohas(packet, this);
-    }
+    // TODO: forward UDP traffic to WISP server once this WISP client supports UDP
+    handle_fake_networking(data, this);
 };
 
 /**


### PR DESCRIPTION
Several improvements in fake network code that deal with data flowing towards the guest OS (i.e. package encoding and downstream buffering) and TCP state mechanics.

- new: improved support for TCP connection state mechanics, implemented graceful shutdown, fixed FIN flag in generated TCP packet stream ([context](https://github.com/copy/v86/discussions/1175#discussioncomment-11147174))
- new: member eth_encoder_buf[] in classes FetchNetworkAdapter and WispNetworkAdapter, a buffer allocated once per adapter instance to encode single ethernet frames
- new: class GrowableRingbuffer, designed to replace array TCPConnection.send_buffer[] with a growable ringbuffer
- new: added internet checksum to synthesized UDP packets (required by mTCP) in function write_udp()
- replaced internet checksum calculation with more efficient algorithm from RFC1071 (chapter 4.1)
- increased TCP chunk size in TCPConnection.pump() from 500 to 1460 bytes (max. TCP payload size)
- added function to efficiently copy an array into a DataView using TypedArray.set(), replaces a bunch of for-loops
- added function to efficiently encode a string into a DataView using TextEncoder.encodeInto()
- refactored all write_...()-functions to use encoder buffer
- added several named constants for ethernet/ipv4/udp/tcp-related offsets
- removed several apparently unused "return true" statements