### PR TITLE
fetch-networking: fix parsing of HTTP headers

### DIFF
--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -83,9 +83,9 @@ async function on_data_http(data)
 
         let req_headers = new Headers();
         for(let i = 1; i < headers.length; ++i) {
-            let parts = headers[i].split(": ");
+            let parts = headers[i].split(/:(.+)/);
             let key =  parts[0].toLowerCase();
-            let value = parts[1];
+            let value = parts[1].trim();
             if( key === "host" ) target.host = value;
             else if( key.length > 1 ) req_headers.set(parts[0], value);
         }

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -85,7 +85,7 @@ async function on_data_http(data)
         for(let i = 1; i < headers.length; ++i) {
             const header = this.net.parse_http_header(headers[i]);
             if(!header) {
-                console.warn('The request contains an invalid header: "%s"', header);
+                console.warn('The request contains an invalid header: "%s"', headers[i]);
                 this.write(new TextEncoder().encode("HTTP/1.1 400 Bad Request\r\nContent-Length: 0"));
                 return;
             }

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -157,7 +157,7 @@ FetchNetworkAdapter.prototype.fetch = async function(url, options)
 FetchNetworkAdapter.prototype.parse_http_header = function(header)
 {
     const parts = header.match(/^([^:]*):(.*)$/);
-    if(parts === null || parts.length !== 3) {
+    if(!parts) {
         dbg_log("Unable to parse HTTP header", LOG_FETCH);
         return;
     }

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -85,6 +85,7 @@ async function on_data_http(data)
         for(let i = 1; i < headers.length; ++i) {
             const header = this.net.parse_http_header(headers[i]);
             if(!header) {
+                console.warn('The request contains an invalid header: "%s"', header);
                 this.write(new TextEncoder().encode("HTTP/1.1 400 Bad Request\r\nContent-Length: 0"));
                 return;
             }
@@ -155,12 +156,6 @@ FetchNetworkAdapter.prototype.fetch = async function(url, options)
 
 FetchNetworkAdapter.prototype.parse_http_header = function(header)
 {
-    if(!header.includes(":"))
-    {
-        dbg_log("Header doesn't have a separator", LOG_FETCH);
-        return;
-    }
-
     const parts = header.match(/^([^:]*):(.*)$/);
     if(parts === null || parts.length !== 3) {
         dbg_log("Unable to parse HTTP header", LOG_FETCH);
@@ -172,7 +167,7 @@ FetchNetworkAdapter.prototype.parse_http_header = function(header)
 
     if(key.length === 0)
     {
-        dbg_log("Header key is empty", LOG_FETCH);
+        dbg_log("Header key is empty, raw header", LOG_FETCH);
         return;
     }
     if(value.length === 0)

--- a/tests/devices/fetch_network.js
+++ b/tests/devices/fetch_network.js
@@ -124,7 +124,45 @@ const tests =
             assert(/This domain is for use in illustrative examples in documents/.test(capture), "got example.org text");
         },
     },
-
+    {
+        name: "Forbidden character in header name",
+        start: () =>
+        {
+            emulator.serial0_send("wget --header='test.v86: 123' -T 10 -O - test.domain\n");
+            emulator.serial0_send("echo -e done\\\\tincorrect header name\n");
+        },
+        end_trigger: "done\tincorrect header name",
+        end: (capture) =>
+        {
+            assert(/400 Bad Request/.test(capture), "got error 400");
+        },
+    },
+    {
+        name: "Empty header value",
+        start: () =>
+        {
+            emulator.serial0_send("wget --header='test:' -T 10 -O - test.domain\n");
+            emulator.serial0_send("echo -e done\\\\tempty header value\n");
+        },
+        end_trigger: "done\tempty header value",
+        end: (capture) =>
+        {
+            assert(/400 Bad Request/.test(capture), "got error 400");
+        },
+    },
+    {
+        name: "Header without separator",
+        start: () =>
+        {
+            emulator.serial0_send("wget --spider --header='testheader' -T 10 -O - test.domain\n");
+            emulator.serial0_send("echo -e done\\\\theader without colon\n");
+        },
+        end_trigger: "done\theader without colon",
+        end: (capture) =>
+        {
+            assert(/400 Bad Request/.test(capture), "got error 400");
+        },
+    }
 ];
 
 const emulator = new V86({


### PR DESCRIPTION
Currently, I have only seen this bug in older versions of Dillo, but it's possible that other HTTP clients have it too.

**Test-case**: boot from https://distro.ibiblio.org/damnsmall/current/current.iso with enabled fetch networking and then try to open any page in Dillo, you get in the browser console:
```
TypeError: Headers.set: accept-encoding:gzip is an invalid header name.
```

![dillo-bug](https://github.com/user-attachments/assets/463c58e8-9eac-4fbe-bb91-bd9672c1fb03)

A raw HTTP request from Dillo looks like this:

```http
GET / HTTP/1.0
Host: copy.sh
User-Agent: Dillo/0.8.5-i18n-misc
Accept-Language: en-us, ja
Accept-Encoding:gzip
Accept-Charset:utf-8,ISO8859-1
Cookie2: $Version="1"
```

According to [RFC 2616 (section 4.2)](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2), HTTP client/server can use any amount of whitespaces after separator, previous code expected only one space after the colon (separator).

