### PR TITLE
Allow embedding of CORS proxy in fetch relay_url

### DIFF
--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -16,9 +16,10 @@ function FetchNetworkAdapter(bus, config)
     this.vm_ip = new Uint8Array((config.vm_ip || "192.168.86.100").split(".").map(function(x) { return parseInt(x, 10); }));
     this.masquerade = config.masquerade === undefined || !!config.masquerade;
     this.vm_mac = new Uint8Array(6);
+    this.dns_method = config.dns_method || "static";
+    this.doh_server = config.doh_server;
     this.tcp_conn = {};
     this.eth_encoder_buf = create_eth_encoder_buf();
-    this.dns_method = "static";
 
     // Ex: 'https://corsproxy.io/?'
     this.cors_proxy = config.cors_proxy;

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1737,6 +1737,10 @@
             settings.relay_url = $("relay_url").value;
             if(!DEFAULT_NETWORKING_PROXIES.includes(settings.relay_url)) new_query_args.set("relay_url", settings.relay_url);
         }
+        if (settings.relay_url.startsWith("fetch") && settings.relay_url.length > 6 && settings.relay_url[5] === ":") {
+            settings.cors_proxy = settings.relay_url.slice(6);
+            settings.relay_url = "fetch";
+        }
         settings.disable_audio = $("disable_audio").checked || settings.disable_audio;
         if(settings.disable_audio) new_query_args.set("mute", "1");
 
@@ -1852,6 +1856,7 @@
             net_device: {
                 type: settings.net_device_type || "ne2k",
                 relay_url: settings.relay_url,
+                cors_proxy: settings.cors_proxy
             },
             autostart: true,
 

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1737,7 +1737,8 @@
             settings.relay_url = $("relay_url").value;
             if(!DEFAULT_NETWORKING_PROXIES.includes(settings.relay_url)) new_query_args.set("relay_url", settings.relay_url);
         }
-        if(settings.relay_url.startsWith("fetch") && settings.relay_url.length > 6 && settings.relay_url[5] === ":") {
+        if(settings.relay_url.startsWith("fetch:"))
+        {
             settings.cors_proxy = settings.relay_url.slice(6);
             settings.relay_url = "fetch";
         }

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1737,7 +1737,7 @@
             settings.relay_url = $("relay_url").value;
             if(!DEFAULT_NETWORKING_PROXIES.includes(settings.relay_url)) new_query_args.set("relay_url", settings.relay_url);
         }
-        if (settings.relay_url.startsWith("fetch") && settings.relay_url.length > 6 && settings.relay_url[5] === ":") {
+        if(settings.relay_url.startsWith("fetch") && settings.relay_url.length > 6 && settings.relay_url[5] === ":") {
             settings.cors_proxy = settings.relay_url.slice(6);
             settings.relay_url = "fetch";
         }

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -311,9 +311,12 @@ V86.prototype.continue_init = async function(emulator, options)
     if(relay_url)
     {
         // TODO: remove bus, use direct calls instead
-        if(relay_url === "fetch")
-        {
-            this.network_adapter = new FetchNetworkAdapter(this.bus);
+        if(relay_url.startsWith("fetch")) {
+            const fetch_options = {};
+            if(relay_url.length > 6 && relay_url[5] === ":") {
+                fetch_options.cors_proxy = relay_url.slice(6);
+            }
+            this.network_adapter = new FetchNetworkAdapter(this.bus, fetch_options);
         }
         else if(relay_url.startsWith("wisp://") || relay_url.startsWith("wisps://"))
         {

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -311,12 +311,9 @@ V86.prototype.continue_init = async function(emulator, options)
     if(relay_url)
     {
         // TODO: remove bus, use direct calls instead
-        if(relay_url.startsWith("fetch")) {
-            const fetch_options = {};
-            if(relay_url.length > 6 && relay_url[5] === ":") {
-                fetch_options.cors_proxy = relay_url.slice(6);
-            }
-            this.network_adapter = new FetchNetworkAdapter(this.bus, fetch_options);
+        if(relay_url === "fetch")
+        {
+            this.network_adapter = new FetchNetworkAdapter(this.bus, options.net_device ? options.net_device : {});
         }
         else if(relay_url.startsWith("wisp://") || relay_url.startsWith("wisps://"))
         {

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -313,11 +313,11 @@ V86.prototype.continue_init = async function(emulator, options)
         // TODO: remove bus, use direct calls instead
         if(relay_url === "fetch")
         {
-            this.network_adapter = new FetchNetworkAdapter(this.bus, options.net_device ? options.net_device : {});
+            this.network_adapter = new FetchNetworkAdapter(this.bus, options.net_device);
         }
         else if(relay_url.startsWith("wisp://") || relay_url.startsWith("wisps://"))
         {
-            this.network_adapter = new WispNetworkAdapter(relay_url, this.bus, options);
+            this.network_adapter = new WispNetworkAdapter(relay_url, this.bus, options.net_device);
         }
         else
         {

--- a/src/browser/wisp_network.js
+++ b/src/browser/wisp_network.js
@@ -3,6 +3,7 @@
 /**
  * @constructor
  *
+ * @param {String} wisp_url
  * @param {BusConnector} bus
  * @param {*=} config
  */
@@ -21,10 +22,10 @@ function WispNetworkAdapter(wisp_url, bus, config)
     this.vm_ip = new Uint8Array((config.vm_ip || "192.168.86.100").split(".").map(function(x) { return parseInt(x, 10); }));
     this.masquerade = config.masquerade === undefined || !!config.masquerade;
     this.vm_mac = new Uint8Array(6);
+    this.dns_method = config.dns_method || "doh";
+    this.doh_server = config.doh_server;
     this.tcp_conn = {};
     this.eth_encoder_buf = create_eth_encoder_buf();
-    this.dns_method = "doh";
-    this.doh_server = config.doh_server;
 
     this.bus.register("net" + this.id + "-mac", function(mac) {
         this.vm_mac = new Uint8Array(mac.split(":").map(function(x) { return parseInt(x, 16); }));


### PR DESCRIPTION
Extends the syntax of relay_url for fetch to:

    fetch[:CORS-PROXY-URL]

where CORS-PROXY-URL is a full URL pointing to the CORS proxy server, for example:

    fetch:https://example.com/?url=

Fixes issue #1188.