### PR TITLE
alpine: update to 3.21.0

### DIFF
--- a/tools/docker/alpine/Dockerfile
+++ b/tools/docker/alpine/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "root:" | chpasswd
 RUN setup-hostname localhost
 
 # Adding networking.sh script
-RUN echo -e "rmmod ne2k-pci && modprobe ne2k-pci\nhwclock -s\nsetup-interfaces -a -r" > /root/networking.sh && chmod +x /root/networking.sh
+RUN echo -e "rmmod ne2k-pci && modprobe ne2k-pci\nrmmod virtio-net && modprobe virtio-net\nhwclock -s\nsetup-interfaces -a -r" > /root/networking.sh && chmod +x /root/networking.sh
 
 RUN echo 'console.log("Hello, world!");' > /root/hello.js
 

--- a/tools/docker/alpine/Dockerfile
+++ b/tools/docker/alpine/Dockerfile
@@ -1,17 +1,9 @@
-FROM docker.io/i386/alpine:3.20.0
+FROM docker.io/i386/alpine:3.21.0
 
-ENV KERNEL=lts
+ENV KERNEL=virt
 ENV ADDPKGS=nodejs
 
-RUN apk add openrc alpine-base agetty alpine-conf $ADDPKGS
-
-RUN if [ "$KERNEL" == "lts" ]; then \
-    apk add linux-lts \
-            linux-firmware-none \
-            linux-firmware-sb16; \
-else \
-    apk add linux-$KERNEL; \
-fi
+RUN apk add openrc alpine-base agetty alpine-conf linux-$KERNEL linux-firmware-none $ADDPKGS
 
 RUN sed -i 's/getty 38400 tty1/agetty --autologin root tty1 linux/' /etc/inittab
 RUN echo 'ttyS0::respawn:/sbin/agetty --autologin root -s ttyS0 115200 vt100' >> /etc/inittab
@@ -19,11 +11,8 @@ RUN echo "root:" | chpasswd
 
 RUN setup-hostname localhost
 
-# Adding networking.sh script (works only on lts kernel yet)
-RUN if [ "$KERNEL" == "lts" ]; then \
-    echo -e "rmmod ne2k-pci && modprobe ne2k-pci\nhwclock -s\nsetup-interfaces -a -r" > /root/networking.sh && \
-    chmod +x /root/networking.sh; \
-fi
+# Adding networking.sh script
+RUN echo -e "rmmod ne2k-pci && modprobe ne2k-pci\nhwclock -s\nsetup-interfaces -a -r" > /root/networking.sh && chmod +x /root/networking.sh
 
 RUN echo 'console.log("Hello, world!");' > /root/hello.js
 
@@ -33,4 +22,4 @@ RUN for i in hwclock modules sysctl hostname syslog bootmisc; do rc-update add $
 RUN rc-update add killprocs shutdown
 
 # Generate initramfs with 9p modules
-RUN mkinitfs -F "ata base ide scsi virtio ext4 9p" $(cat /usr/share/kernel/$KERNEL/kernel.release)
+RUN mkinitfs -F "base virtio 9p" $(cat /usr/share/kernel/$KERNEL/kernel.release)

--- a/tools/docker/alpine/Readme.md
+++ b/tools/docker/alpine/Readme.md
@@ -1,6 +1,6 @@
 You can build a Alpine Linux 9p image using Docker:
 
-1. As needed, kernel flavor (`virt` is smaller than `lts`, but don't have networking) and set of additional packages (community repo is enabled by default) can be edited in `Dockerfile`
+1. As needed, kernel flavor (`virt` is smaller than `lts`) and set of additional packages (community repo is enabled by default) can be edited in `Dockerfile`
 2. Check and run `./build.sh` with started dockerd (podman works)
 3. Run local webserver (e.g. `make run`) and open `examples/alpine.html`
 4. (optional) Run `./build-state.js` and add `initial_state: { url: "../images/alpine-state.bin" }` to `alpine.html`


### PR DESCRIPTION
Changed the default kernel flavor to `virt` and added virtio-net support