### PR TITLE
ci: update actions from v3 to latest v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: make rustfmt
 
       - name: Fetch kvm-unit-test cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-kvm-unit-test
         with:
           path: tests/kvm-unit-tests/
@@ -67,7 +67,7 @@ jobs:
         run: tests/kvm-unit-tests/run.js tests/kvm-unit-tests/x86/realmode.flat
 
       - name: Fetch namsmtests cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-nasmtests
         with:
           path: tests/nasm/build/
@@ -83,7 +83,7 @@ jobs:
         run: make rust-test
 
       - name: Fetch image cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-images
         with:
           path: images/
@@ -115,7 +115,7 @@ jobs:
         run: make expect-tests
 
       - name: Upload the artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: v86
           path: |
@@ -138,7 +138,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: v86
           path: build


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ and https://github.com/actions/cache/discussions/1510