### PR TITLE
loop unrolling in pack_memory

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -632,9 +632,18 @@ CPU.prototype.pack_memory = function()
         const view = this.mem32s.subarray(offset >> 2, offset + 0x1000 >> 2);
         let is_zero = true;
 
-        for(let i = 0; i < view.length; i++)
+        // partial loop unrolling to check 64 bytes per iteration
+        for(let i = 0; i < view.length; i += 8)
         {
-            if(view[i] !== 0)
+            if(   view[i+0]
+                | view[i+1]
+                | view[i+2]
+                | view[i+3]
+                | view[i+4]
+                | view[i+5]
+                | view[i+6]
+                | view[i+7]
+                !== 0)
             {
                 is_zero = false;
                 break;

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -642,8 +642,7 @@ CPU.prototype.pack_memory = function()
                 | view[i+4]
                 | view[i+5]
                 | view[i+6]
-                | view[i+7]
-                !== 0)
+                | view[i+7])
             {
                 is_zero = false;
                 break;


### PR DESCRIPTION
To improve the state saving time for very large and sparse memories, we unroll the loop that checks for non-zero pages to work with blocks of 64 bytes per iteration.

Context: Towards implementing [playable quotes](https://adamsmith.as/papers/fdg2023_tenmile.pdf) for PC games, I want to take whole-system snapshots quite frequently (e.g. once or more per second). I found that the scan for non-zero pages was dominating the overall time spent in saving state. It looks like the code was already someone optimized for speed (by working with mem32 rather than mem8), so this enhancement, while somewhat ugly, might fit the surrounding code. In microbenching with a VM with 128MB of guest memory (and an M3 Max host processor) this lead to a ~2x speedup for the loop in question. Deeper unrolling helps slightly more on my processor, but that is probably overspecializing for my wide cache lines (128 bytes). The code here only exploits 64-byte lines.