### PR TITLE
Convert exports to closures export system and add a ES6 module build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 WASM_OPT ?= false
 
 default: build/v86-debug.wasm
-all: build/v86_all.js build/libv86.js build/v86.wasm
+all: build/v86_all.js build/libv86.js build/libv86.mjs build/v86.wasm
 all-debug: build/libv86-debug.js build/v86-debug.wasm
 browser: build/v86_all.js
 
@@ -142,6 +142,23 @@ build/libv86.js: $(CLOSURE) src/*.js lib/*.js src/browser/*.js
 		--js $(LIB_FILES)
 	ls -lh build/libv86.js
 
+build/libv86.mjs: $(CLOSURE) src/*.js lib/*.js src/browser/*.js
+	mkdir -p build
+	-ls -lh build/libv86.js
+	java -jar $(CLOSURE) \
+		--js_output_file build/libv86.mjs\
+		--define=DEBUG=false\
+		$(CLOSURE_FLAGS)\
+		--compilation_level SIMPLE\
+		--jscomp_off=missingProperties\
+		--output_wrapper ';let module = {exports:{}}; %output%; export default module.exports.V86;'\
+		--js $(CORE_FILES)\
+		--js $(BROWSER_FILES)\
+		--js $(LIB_FILES)\
+		--chunk_output_type=ES_MODULES\
+		--emit_use_strict=false
+	ls -lh build/libv86.mjs
+
 build/libv86-debug.js: $(CLOSURE) src/*.js lib/*.js src/browser/*.js
 	mkdir -p build
 	java -jar $(CLOSURE) \
@@ -222,6 +239,7 @@ build/zstddeclib.o: lib/zstd/zstddeclib.c
 
 clean:
 	-rm build/libv86.js
+	-rm build/libv86.mjs
 	-rm build/libv86-debug.js
 	-rm build/v86_all.js
 	-rm build/v86.wasm

--- a/nodejs-loader.mjs
+++ b/nodejs-loader.mjs
@@ -88,9 +88,10 @@ for( let f of files ) {
 }
 
 export let {
-    V86,
-    CPU,
     FetchNetworkAdapter,
     MemoryFileStorage,
     ServerFileStorageWrapper,
 } = globals;
+
+export default V86;
+

--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -5,6 +5,7 @@
  *
  * @param {BusConnector} bus
  * @param {*=} config
+ * @export
  */
 function FetchNetworkAdapter(bus, config)
 {
@@ -242,9 +243,3 @@ FetchNetworkAdapter.prototype.receive = function(data)
 {
     this.bus.send("net" + this.id + "-receive", new Uint8Array(data));
 };
-
-if(typeof module !== "undefined" && typeof module.exports !== "undefined")
-{
-    // only for testing
-    module.exports["FetchNetworkAdapter"] = FetchNetworkAdapter;
-}

--- a/src/browser/print_stats.js
+++ b/src/browser/print_stats.js
@@ -1,5 +1,8 @@
 "use strict";
 
+/**
+ * @export
+ */
 const print_stats = {
     stats_to_string: function(cpu)
     {
@@ -282,8 +285,3 @@ const print_stats = {
         return text;
     },
 };
-
-if(typeof module !== "undefined" && typeof module.exports !== "undefined")
-{
-    module.exports["print_stats"] = print_stats;
-}

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -105,6 +105,7 @@
       } | undefined),
     }} options
  * @constructor
+ * @export
  */
 function V86(options)
 {
@@ -1468,18 +1469,3 @@ function FileNotFoundError(message)
     this.message = message || "File not found";
 }
 FileNotFoundError.prototype = Error.prototype;
-
-// Closure Compiler's way of exporting
-if(typeof module !== "undefined" && typeof module.exports !== "undefined")
-{
-    module.exports["V86"] = V86;
-}
-else if(typeof window !== "undefined")
-{
-    window["V86"] = V86;
-}
-else if(typeof importScripts === "function")
-{
-    // web worker
-    self["V86"] = V86;
-}

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,7 +1,21 @@
 "use strict";
 
 var goog = goog || {};
-goog.exportSymbol = function() {};
+goog.exportSymbol = function(name, sym) {
+    if(typeof module !== "undefined" && typeof module.exports !== "undefined")
+    {
+        module.exports[name] = sym;
+    }
+    else if(typeof window !== "undefined")
+    {
+        window[name] = sym;
+    }
+    else if(typeof importScripts === "function")
+    {
+        // web worker
+        self[name] = sym;
+    }
+};
 goog.exportProperty = function() {};
 
 var v86util = v86util || {};


### PR DESCRIPTION
This fixes compatibility issues when used with vite inside a service worker, and should be a bit more idiomatic in general.