### PR TITLE
fake-network: fix incorrect source IP for ICMP

### DIFF
--- a/src/browser/fake_network.js
+++ b/src/browser/fake_network.js
@@ -1388,7 +1388,7 @@ function handle_fake_ping(packet, adapter) {
     reply.eth = { ethertype: ETHERTYPE_IPV4, src: adapter.router_mac, dest: packet.eth.src };
     reply.ipv4 = {
         proto: IPV4_PROTO_ICMP,
-        src: adapter.router_ip,
+        src: packet.ipv4.dest,
         dest: packet.ipv4.src,
     };
     reply.icmp = {

--- a/tests/devices/fetch_network.js
+++ b/tests/devices/fetch_network.js
@@ -85,6 +85,7 @@ const tests =
         end: (capture) =>
         {
             assert(/2 packets transmitted, 2 (packets )?received, 0% packet loss/.test(capture), "2 packets transmitted, 2 packets received, 0% packet loss");
+            assert(/from 1\.2\.3\.4:/.test(capture), "got correct source ip");
         },
     },
     {


### PR DESCRIPTION
Fixes "different address" warning in busybox's `ping` on [buildroot6](https://copy.sh/v86/?profile=buildroot6&relay_url=fetch):
```
~% ping -c 4 1.2.3.4
PING 1.2.3.4 (1.2.3.4) 56(84) bytes of data.
64 bytes from 192.168.86.1: icmp_seq=1 ttl=32 time=2.10 ms (DIFFERENT ADDRESS!)
64 bytes from 192.168.86.1: icmp_seq=2 ttl=32 time=1.84 ms (DIFFERENT ADDRESS!)
64 bytes from 192.168.86.1: icmp_seq=3 ttl=32 time=1.06 ms (DIFFERENT ADDRESS!)
64 bytes from 192.168.86.1: icmp_seq=4 ttl=32 time=1.42 ms (DIFFERENT ADDRESS!)
```