### PR TITLE
Expanding the V86 networking documentation

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -158,7 +158,7 @@ The `fetch` backend uses the browser's [`fetch()`](https://developer.mozilla.org
 
 Even though a proxy server is optional with this backend, a CORS proxy server is generally indispensable in order to evade the limitations imposed by CORS and to access the open Internet. Yet, this backend is highly useful in special cases where CORS is not in the way.
 
-This backend handles DHCP and ARP requests from guests internally (DNS lookups are handled by the browser), and also monitors the guest's outbound traffic for HTTP requests which it translates into calls to `fetch()`. Additionally, NTP, ICMP pings and UDP echo packets are handled to a certain degree. See PR [#1061](https://github.com/copy/v86/pull/1061) for additional technical details.
+This backend handles DHCP and ARP requests from guests internally (DNS lookups are handled by `fetch()`), and also monitors the guest's outbound traffic for HTTP requests which it translates into calls to `fetch()`. Additionally, NTP, ICMP pings and UDP echo packets are handled to a certain degree. See PR [#1061](https://github.com/copy/v86/pull/1061) for additional technical details.
 
 v86 guests are isolated from each other when using the `fetch` backend.
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,53 +1,183 @@
 # v86 networking
 
-Emulating a network card is supported. It can be used by passing the
-`network_relay_url` option to `V86`. The url must point to a running
-WebSockets Proxy. The source code for the WebSockets Proxy can be found at
-[benjamincburns/websockproxy](https://github.com/benjamincburns/websockproxy).
-An alternative, Node-based implementation is
-[krishenriksen/node-relay](https://github.com/krishenriksen/node-relay).
+On the simplest level, networking in v86 is comprised of two components:
 
-The network card could also be controlled programatically, but this is
-currently not exposed.
+* an emulation of the guest's Network Interface Card (NIC), and
+* a network backend which passes ethernet frames between the NIC and a virtual and/or physical network.
 
-There is no built-in support for NodeJS, but networking only depends on a
-browser-compatible `WebSocket` constructor being present in the global scope.
+There are two **NIC emulations** supported by v86 to chose from, either **`ne2k`** (NE2000/RTL8390-compatible NIC) or **`virtio`** ([VirtIO](http://wiki.osdev.org/Virtio)-compatible device). The right choice simply depends on the driver support in the guest OS, older OSes like FreeDOS only support NE2000, more modern ones usually support VirtIO. In case both are supported by the guest OS it's recommended to try VirtIO first and only fall back to NE2000 if that fails. In some cases it will also be necessary to manually load a driver or similar to activate the NIC and/or networking in the guest OS, yet modern systems usually auto-detect an available NIC during installation and when booting.
 
-**NOTE:** original `benjamincburns/jor1k-relay:latest` docker image has
-throttling built-in by default which will degrade the networking.
-`bellenottelling/websockproxy`docker image has this throttling removed via
-[websockproxy/issues/4#issuecomment-317255890](https://github.com/benjamincburns/websockproxy/issues/4#issuecomment-317255890).
+There are also several **network backends** to chose from, they differ in their requirements and in the degree of network access and services provided to guests. Some provide only limited network access, others full access to a physical network which may include a gateway to the Internet. Backends may require a specific type of proxy server to operate.
 
-### fetch-based networking
+The active network backend is configured through a user-specified **backend URL**. Each backend has at least one distinct URL scheme as specified below, where `PROXY` is the DNS hostname or IP address of a compatible proxy server, `PORT` its optional TCP port number (and its default), and `QUERY` is some HTTP query field fragment:
 
-v86 supports an experimental networking mode, which is enabled by specifying
-`"fetch"` as the relay url. In this mode, no external relay is used and packets
-are parsed internally by v86. DHCP and ARP requests are handled by an internal
-router, and HTTP requests are translated into calls to `fetch` (which only
-works on [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)-enabled
-hosts). Additionally, NTP, ICMP pings and UDP echo packets are handled to a
-certain degree. See [#1061](https://github.com/copy/v86/pull/1061) for some
-technical details.
+| Backend | Backend URL scheme(s) | Example |
+| :------ | :-------------------- | :------ |
+| **[localhub](#the-localhub-backend)** | `localhub` | `localhub` |
+| **[wsproxy](#the-wsproxy-backend)** | `"ws://" PROXY [":" PORT=80] ["/" ...]`<br>`"wss://" PROXY [":" PORT=443] ["/" ...]` | `wss://relay.widgetry.org/` |
+| **[wisp](#the-wisp-backend)** | `"wisp://" PROXY [":" PORT=80] ["/" ...]`<br>`"wisps://" PROXY [":" PORT=443] ["/" ...]` | `wisp://localhost:12345` |
+| **[fetch](#the-fetch-backend)** | `"fetch" [ "://" PROXY [":" PORT] ["/?" QUERY] ]` | `fetch`<br>`fetch://localhost:1234/?url=` |
 
-You can pass the following flags to chromium to allow browsing without
-restrictions in `fetch` mode:
-    `--disable-web-security --user-data-dir=/tmp/test`
-Note that this turns off the same-origin policy and should only be used
-temporarily.
+Note that `wss://` and `wisps://` are the TLS-secured transports of `ws://` and `wisps://`, respectively.
 
-### wisp networking
+> [!TIP]
+> Since public proxy servers provide only limited bandwidth it is recommended to install and use a local, private proxy server for best results. All proxy servers allow to be executed on the local machine, in a VM running on the local machine, in a local network or even publicly on the Internet (which is generally not recommended, of course). Many proxy servers are distributed as Docker containers which is the recommended way of installing them, otherwise install into a VM.
 
-v86 also supports the [wisp
-protocol](https://github.com/MercuryWorkshop/wisp-protocol) as a networking
-proxy. Wisp servers can be specified with the `wisp://` or `wisps://` prefix.
-See #1097 for some information.
+## Setup
 
-### Interaction with state images
+### Network setup in the v86 web interface
 
-When using state images, v86 randomises the MAC address after the state has
-been loaded, so that multiple VMs don't receive the same address. However, the
-guest OS is not aware that the MAC address has changed, which prevents it from
-sending and receiving packets correctly. There are several workarounds:
+Setting up networking in the web interface at https://copy.sh/v86/ is simple.
+
+To configure the network backend, simply copy the backend URL into the text box named `Networking proxy`.
+
+The guest's NIC emulation (NE2000 or VirtIO) is automatically configured when selecting the guest image in the web interface.
+
+### Network setup using `net_device` options
+
+In order to embed the v86 emulator in another project an instance of class `V86` needs to be created. The constructor expects a `config` object, and the network settings are controlled through its member **`config.net_device`**.
+
+#### Basic `net_device` settings
+
+All network setups support the following options:
+
+| net_device   | type | description |
+| :----------- | :--- | :--- |
+| `type`       | str  | The type of emulated NIC provided to the guest OS, either `ne2k` (default) or `virtio` |
+| `relay_url`  | str  | The network backend URL, either `localhub`, `ws[s]://...`, `wisp[s]://...` or `fetch`. Note that the CORS proxy server of the fetch backend is defined in field `cors_proxy` below. Also see the backend URL schemes described in the previous section. |
+| `id`         | int  | Network id, all v86 network instances with the same id share the same network namespace, default: `0` (TODO: NetworkAdapter in browser/starter.js should also get options.net_device as the last argument ) |
+
+#### Advanced `net_device` settings
+
+Network backends `fetch` and `wisp` support some advanced settings in `net_device` that control the network components emulated by v86:
+
+| net_device   | type | description |
+| :----------- | :--- | :--- |
+| `router_mac` | str  | Emulated router's MAC address, default `52:54:0:1:2:3` |
+| `router_ip`  | str  | Emulated router's IP address in dotted IP notation, default `192.168.86.1` |
+| `vm_ip`      | str  | IP address to be assigned to the guest VM in dotted IP notation, default `192.168.86.100` |
+| `masquerade` | bool | `False`: TODO, `True`: TODO |
+| `cors_proxy` | str  | URL including HTTP query fragment of the HTTP CORS proxy server to use with the fetch backend |
+| `dns_method` | str  | DNS method to use, either `static` or `doh`. `static`: use built-in DNS server, `doh`: use DNS-over-HTTPS. Defaults to `static` for fetch and to `doh` for wisp |
+| `doh_server` | str  | Host name (and optional port number) of the DoH-server if `dns_method` is `doh`. The value is expanded to the URL `https://DOH_SERVER/dns-query`. Default: `cloudflare-dns.com` |
+
+#### Example `net_device` settings
+
+* **Example 1:** Provide an emulated NE2000 NIC to the guest OS and use the wsproxy backend with a secure wsproxy server at public host `relay.widgetry.org` listening at default TLS port 443:
+   ```
+   let example_1 = new V86({
+       net_device: {
+           type: "ne2k",
+           relay_url: "wss://relay.widgetry.org/"
+       },
+       // ...
+   });
+   ```
+
+* **Example 2:** Provide a VirtIO NIC to the guest OS and use the fetch backend with a HTTP CORS proxy server at the local machine listening at port number 23456:
+   ```
+   let example_2 = new V86({
+       net_device: {
+           type: "virtio",
+           relay_url: "fetch",
+           cors_proxy: "https://localhost:23456/?url="
+       },
+       // ...
+   });
+   ```
+
+## Network backends
+
+One way to look at the different types of network backends supported by v86 is how they operate on different layers in the [OSI reference model](https://en.wikipedia.org/wiki/OSI_model), approximately:
+
+       Network Peer               Backend                 v86 Guest
+
+    [ 7: Application  ] <--- fetch ---> +-----+      [ 7: Application  ]
+    [ 6: Presentation ]                 |     |      [ 6: Presentation ]
+    [ 5: Session      ]                 | v86 |      [ 5: Session      ]
+    [ 4: Transport    ] <--- wisp ----> |     |      [ 4: Transport    ]
+    [ 3: Network      ]                 |     |      [ 3: Network      ]
+    [ 2: Data Link    ] <-- wsproxy --> +-----+ <--> [ 2: Data Link    ]
+    [ 1: Physical     ] <-------- localhub --------> [ 1: Physical     ]
+
+                      Fig. 1: Network backends in v86
+
+v86 guests strictly expect to exchange layer-2 ethernet frames with their (emulated) network card, hence the higher the OSI layer that a v86 network backend operates on the more virtualized the network becomes and the more work has to be done by the backend to fill in for the missing layers.
+
+In order to facilitate this for backend implementations, v86 provides helper functions to encode/decode ethernet frames, ARP and IPv4 packets, UDP datagrams, TCP streams and HTTP requests/responses. v86 can also provide minimal but sufficient ICMP, DHCP, DNS (including DoH) and NTP services to guests.
+
+### The `localhub` backend
+
+This backend provides layer-2 networking services for multiple v86 guests running within the same browser process (meaning within the same web page and/or in separate browser tabs). It works without a proxy server, but it also does not provide any access to external networks. v86 is not involved in the exchange of frames between guests beyond emulating the guests' network cards, hence the stretch to place it in Layer 1 in Fig. 1.
+
+The localhub backend is implemented using the [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) browser API.
+
+**Example**
+
+* [`examples/broadcast-network.html`](../examples/broadcast-network.html)
+
+### The `wsproxy` backend
+
+A backend based on a proxy server that provides layer-2 networking services to guests using the [WebSocket](https://en.wikipedia.org/wiki/WebSocket) protocol for transport. It depends on the specific proxy server what kind of network configuration it presents to guests, but usually a separate IP subnet with DHCP and DNS services and optional access to the server's physical network and possibly Internet is provided to guests.
+
+Since this type of backend simply forwards raw ethernet frames in v86 as well as in the proxy server it is generally very efficient and provides full physical network emulation to guests.
+
+**Proxy server**
+
+* **[websockproxy](https://github.com/benjamincburns/websockproxy)** -- uses a single TAP device for all clients, integrates dnsmasq for DHCP/DNS, original server implementation by benjamincburns
+  * Docker `benjamincburns/jor1k-relay:latest` is throttled, see [this comment](https://github.com/benjamincburns/websockproxy/issues/4#issuecomment-317255890)
+  * Docker `bellenottelling/websockproxy` is unthrottled
+  * See [here](https://github.com/copy/v86/discussions/1175#discussioncomment-11199254) for step-by-step instructions on how to unthrottle websockproxy manually.
+* **[wsnic](https://github.com/chschnell/wsnic)** -- uses a single bridge and one TAP device per client, integrates dnsmasq for DHCP/DNS and stunnel for TLS
+* **[node-relay](https://github.com/krishenriksen/node-relay)** -- NodeJs
+* **[go-websockproxy](https://github.com/gdm85/go-websockproxy)** -- Go
+
+### The `wisp` backend
+
+This backend implements the client side of the [WISP protocol](https://github.com/MercuryWorkshop/wisp-protocol). WISP is a client/server protocol designed to exchange WebSocket messages containing UDP and TCP payloads between a WebSocket client and a WISP-compatible proxy server. Note that WISP transports only the payloads, not the full UDP or TCP packets. See PR [#1097](https://github.com/copy/v86/pull/1097) for additional information about the WISP backend.
+
+TODO: are v86 guests bridged or isolated in WISP (can they communicate with each other or not)?
+
+**WISP-compatible proxy server**
+
+* **[wisp-js](https://www.npmjs.com/package/@mercuryworkshop/wisp-js)**
+* **[epoxy-tls](https://github.com/MercuryWorkshop/epoxy-tls)**
+
+> [!NOTE]
+> WISP only supports TCP client sockets in the v86 guest, TCP server sockets listening in the guest are not supported.
+
+> [!NOTE]
+> The WISP implementation in v86 is missing support for UDP.
+
+### The `fetch` backend
+
+The fetch backend uses the browser's [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API to allow guests to send HTTP requests to external HTTP servers and to receive related HTTP responses. This is however complicated by the fact that browsers add [HTTP CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) to HTTP requests initiated by `fetch()`, and that they check the CORS headers of related HTTP responses to block access to external web resources not authorized to `fetch()` in the current context.
+
+Even though a proxy server is optional with this backend, a HTTP CORS proxy server is generally indispensable in order to evade the limitations imposed by CORS and to access the open Internet. Yet, this backend is highly useful in special cases where CORS is not in the way.
+
+This backend handles DHCP and ARP requests from the guest internally, and monitors the guest's outbound traffic for HTTP requests which it translates into calls to `fetch()`. Additionally, NTP, ICMP pings and UDP echo packets are handled to a certain degree. See PR [#1061](https://github.com/copy/v86/pull/1061) for additional technical details.
+
+v86 guests are isolated from each other when using the fetch backend.
+
+**HTTP CORS proxy server**
+
+* **[cors-anywhere](https://github.com/Rob--W/cors-anywhere)** -- NodeJS
+* **[uncors](https://github.com/chschnell/uncors)** -- A simple PHP-based HTTP CORS proxy server for Apache2.
+
+> [!TIP]
+> You can pass the following flags to **chromium** to allow browsing without restrictions in fetch mode:
+>
+>        --disable-web-security --user-data-dir=/tmp/test
+>
+> but note that this turns off the same-origin policy and should only be used temporarily!
+
+## Related topics
+
+### v86 run-time state images
+
+v86 supports saving and restoring the guest's and emulator's run-time state in **state image** files.
+
+When restoring a state image, v86 randomises the restored guest's MAC address to make sure that multiple VMs restored from the same state image use different MAC addresses. However, the restored guest OS is unaware that its NIC's MAC address has changed which prevents it from sending and receiving packets correctly. There are several workarounds:
 
 - Unload the network driver before saving the state. On Linux, unloading can be
   done using `rmmod ne2k-pci` or `echo 0000:00:05.0 >
@@ -69,3 +199,11 @@ sending and receiving packets correctly. There are several workarounds:
 
 Note that the same applies to IP addresses, so a DHCP client should only be run
 after the state has been loaded.
+
+### NodeJS
+
+There is no built-in support for v86 networking under NodeJS, but network backends `wsproxy` and `wisp` only depend on a browser-compatible `WebSocket` constructor being present in the global scope, whereas backends `localhub` and `fetch` should work directly.
+
+## Links
+
+*TODO*

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -58,7 +58,7 @@ Backends `fetch` and `wisp` support a couple of special settings in `config.net_
 | **router_mac** | str  | MAC address of virtual network peers (ARP, PING, DHCP, DNS, NTP, UDP echo and TCP peers) in common MAC address notation. Default `52:54:0:1:2:3`. |
 | **router_ip**  | str  | IP address of virtual network peers (ARP, PING, DHCP, DNS and TCP peers) in dotted IP notation. Default `192.168.86.1`. |
 | **vm_ip**      | str  | IP address to be assigned to the guest by DHCP in dotted IP notation. Default `192.168.86.100`. |
-| **masquerade** | bool | `False`: TODO, `True`: TODO. Default: `True`. |
+| **masquerade** | bool | If `True`, announce `router_ip` as the router's and DNS server's IP addresses in generated DHCP replies, and also generate ARP replies to IPs outside the router's subnet `255.255.255.0`. Default: `True`. |
 | **dns_method** | str  | DNS method to use, either `static` or `doh`. `static`: use built-in DNS server, `doh`: use [DNS-over-HTTPS](https://en.wikipedia.org/wiki/DNS_over_HTTPS) (DoH). Defaults to `static` for `fetch` and to `doh` for `wisp` backend. |
 | **doh_server** | str  | Host name or IP address (and optional port number) of the DoH server if `dns_method` is `doh`. The value is expanded to the URL `https://DOH_SERVER/dns-query`. Default: `cloudflare-dns.com`. |
 | **cors_proxy** | str  | CORS proxy server URL, do not use a proxy if undefined. Default: undefined (`fetch` backend only). |

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -113,10 +113,6 @@ This backend provides layer-2 networking services for multiple v86 guests runnin
 
 The `inbrowser` backend is implemented using the browser-internal [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) API, due to its simplicity it is the most efficient backend, however all VMs have to share the same browser resources.
 
-**Example**
-
-* [`examples/broadcast-network.html`](../examples/broadcast-network.html)
-
 ### The `wsproxy` backend
 
 A backend based on a proxy server that provides layer-2 networking services to guests using the [WebSocket](https://en.wikipedia.org/wiki/WebSocket) protocol for transport. It depends on the specific proxy server what kind of network configuration it presents to guests, but usually a separate IP subnet with DHCP and DNS services and optional access to the server's physical network and possibly Internet are provided.
@@ -209,6 +205,7 @@ There is no built-in support for v86 networking under NodeJS, but network backen
 
 ## Links
 
-* [`examples/two_instances.html`](../examples/two_instances.html), example code that shows how to connect two V86 instances in a web page with a virtual ethernet crossover cable.
-* [DC through windows OS for experimental lab #1195](https://github.com/copy/v86/discussions/1195), demonstrates how to setup a Domain Controller for two Windows VMs (XP and Windows Server 2003) using a virtual crossover cable.
+* [`examples/two_instances.html`](../examples/two_instances.html), example code that shows how to connect two VMs in a web page with a virtual ethernet crossover cable.
+* [`examples/broadcast-network.html`](../examples/broadcast-network.html), example code that shows how the `inbrowser` backend works.
+* [DC through windows OS for experimental lab #1195](https://github.com/copy/v86/discussions/1195), demonstrates how to setup a Domain Controller for two Windows VMs (XP and Server 2003) using a virtual crossover cable.
 * [Working on a new cross-platform network relay that is a full virtualized network #1064](https://github.com/copy/v86/discussions/1064) (used in [env86 #1085](https://github.com/copy/v86/discussions/1085))

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -122,9 +122,9 @@ Since this backend (including its proxy server) only forwards unmodified etherne
 **Proxy server**
 
 * **[websockproxy](https://github.com/benjamincburns/websockproxy)** -- one TAP device for all clients, integrates dnsmasq for DHCP/DNS, no TLS, original server by benjamincburns
-  * Docker container `benjamincburns/jor1k-relay` is throttled, see [this comment](https://github.com/benjamincburns/websockproxy/issues/4#issuecomment-317255890)
-  * Docker container `bellenottelling/websockproxy` is unthrottled
-  * See [here](https://github.com/copy/v86/discussions/1175#discussioncomment-11199254) for step-by-step instructions on how to unthrottle websockproxy manually.
+  * Docker container [`benjamincburns/jor1k-relay`](https://hub.docker.com/r/benjamincburns/jor1k-relay) is throttled, see [this comment](https://github.com/benjamincburns/websockproxy/issues/4#issuecomment-317255890)
+  * Docker container [`bellenottelling/websockproxy`](https://hub.docker.com/r/bellenottelling/websockproxy) is unthrottled
+  * [See here](https://github.com/copy/v86/discussions/1175#discussioncomment-11199254) for step-by-step instructions on how to unthrottle websockproxy manually.
 * **[go-websockproxy](https://github.com/gdm85/go-websockproxy)** -- one TAP device for all clients, written in Go, without integraded DHCP but with integrated TLS support
 * **[node-relay](https://github.com/krishenriksen/node-relay)** -- like websockproxy but written for NodeJS (dnsmasq/no TLS), see [New websocket ethernet switch built using Node.js #777](https://github.com/copy/v86/discussions/777)
 * **[wsnic](https://github.com/chschnell/wsnic)** -- uses a single bridge and one TAP device per client, integrates dnsmasq for DHCP/DNS and stunnel for TLS

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -130,7 +130,7 @@ Since this backend (including its proxy server) only forwards unmodified etherne
   * Docker container `bellenottelling/websockproxy` is unthrottled
   * See [here](https://github.com/copy/v86/discussions/1175#discussioncomment-11199254) for step-by-step instructions on how to unthrottle websockproxy manually.
 * **[wsnic](https://github.com/chschnell/wsnic)** -- uses a single bridge and one TAP device per client, integrates dnsmasq for DHCP/DNS and stunnel for TLS (see [here](https://github.com/copy/v86/discussions/1199#discussion-7726530) for a benchmark comparison with `websockproxy`)
-* **[node-relay](https://github.com/krishenriksen/node-relay)** -- NodeJs
+* **[node-relay](https://github.com/krishenriksen/node-relay)** -- see [New websocket ethernet switch built using Node.js #777](https://github.com/copy/v86/discussions/777)
 * **[go-websockproxy](https://github.com/gdm85/go-websockproxy)** -- Go
 
 ### The `wisp` backend
@@ -209,4 +209,6 @@ There is no built-in support for v86 networking under NodeJS, but network backen
 
 ## Links
 
-*TODO: Add relevant links to discussions and PRs that provide further information.*
+* [`examples/two_instances.html`](examples/two_instances.html), example code that shows how to connect two V86 instances in a web page with a virtual ethernet crossover cable.
+* [DC through windows OS for experimental lab #1195](https://github.com/copy/v86/discussions/1195), demonstrates how to setup a Domain Controller for two Windows VMs (XP and Windows Server 2003) using a virtual crossover cable.
+* [Working on a new cross-platform network relay that is a full virtualized network #1064](https://github.com/copy/v86/discussions/1064) (used in [env86 #1085](https://github.com/copy/v86/discussions/1085))

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,80 +1,81 @@
 # v86 networking
 
-On the simplest level, networking in v86 is comprised of two components:
+User guide to networking in v86.
 
-* an emulation of the guest's Network Interface Card (NIC), and
-* a network backend which passes ethernet frames between the NIC and a virtual and/or physical network.
+## Introduction
+
+On the most basic level, networking in v86 is comprised of two components:
+
+* an emulation of the guest's [Network Interface Controller](https://en.wikipedia.org/wiki/Network_interface_controller) (NIC), and
+* a network backend which passes ethernet frames between the NIC and a virtual and/or physical [ethernet network](https://en.wikipedia.org/wiki/Ethernet).
 
 There are two **NIC emulations** supported by v86 to chose from, either **`ne2k`** (NE2000/RTL8390-compatible NIC) or **`virtio`** ([VirtIO](http://wiki.osdev.org/Virtio)-compatible device). The right choice simply depends on the driver support in the guest OS, older OSes like FreeDOS only support NE2000, more modern ones usually support VirtIO. In case both are supported by the guest OS it's recommended to try VirtIO first and only fall back to NE2000 if that fails. In some cases it will also be necessary to manually load a driver or similar to activate the NIC and/or networking in the guest OS, yet modern systems usually auto-detect an available NIC during installation and when booting.
 
-There are also several **network backends** to chose from, they differ in their requirements and in the degree of network access and services provided to guests. Some provide only limited network access, others full access to a physical network which may include a gateway to the Internet. Backends may require a specific type of proxy server to operate.
+There are also several **network backends** to chose from which emulate the network that the virtual NIC is connected to, they differ in their requirements and in the degree of network access and services provided to guests. Some provide only limited network access, others full access to a physical network which may include a gateway to the Internet. Backends may require a specific type of proxy server to operate.
+
+### Backend URL schemes
 
 The active network backend is configured through a user-specified **backend URL**. Each backend has at least one distinct URL scheme as specified below, where `PROXY` is the DNS hostname or IP address of a compatible proxy server, `PORT` its optional TCP port number (and its default), and `QUERY` is some HTTP query field fragment:
 
-| Backend | Backend URL scheme(s) | Example |
-| :------ | :-------------------- | :------ |
+| Backend | Backend URL scheme(s) | Example(s) |
+| :------ | :-------------------- | :--------- |
 | **[localhub](#the-localhub-backend)** | `localhub` | `localhub` |
 | **[wsproxy](#the-wsproxy-backend)** | `"ws://" PROXY [":" PORT=80] ["/" ...]`<br>`"wss://" PROXY [":" PORT=443] ["/" ...]` | `wss://relay.widgetry.org/` |
 | **[wisp](#the-wisp-backend)** | `"wisp://" PROXY [":" PORT=80] ["/" ...]`<br>`"wisps://" PROXY [":" PORT=443] ["/" ...]` | `wisp://localhost:12345` |
-| **[fetch](#the-fetch-backend)** | `"fetch" [ "://" PROXY [":" PORT] ["/?" QUERY] ]` | `fetch`<br>`fetch://localhost:1234/?url=` |
+| **[fetch](#the-fetch-backend)** | `"fetch" [ "://" PROXY [":" PORT] ["/" QUERY] ]` | `fetch`<br>`fetch://localhost:1234/?url=` |
 
-Note that `wss://` and `wisps://` are the TLS-secured transports of `ws://` and `wisps://`, respectively.
+Note that `wss://` and `wisps://` are the TLS-secured transports of `ws://` and `wisp://`, respectively.
 
 > [!TIP]
 > Since public proxy servers provide only limited bandwidth it is recommended to install and use a local, private proxy server for best results. All proxy servers allow to be executed on the local machine, in a VM running on the local machine, in a local network or even publicly on the Internet (which is generally not recommended, of course). Many proxy servers are distributed as Docker containers which is the recommended way of installing them, otherwise install into a VM.
 
-## Setup
+## Network setup
 
-### Network setup in the v86 web interface
+### Web interface setup
 
-Setting up networking in the web interface at https://copy.sh/v86/ is simple.
+Network setup in the v86 web interface at **https://copy.sh/v86/** is straightforward, simply copy the backend URL into the text box named **`Networking proxy`** or select one of the presets to configure the network backend. The guest's NIC emulation (NE2000 or VirtIO) is automatically configured when selecting the guest image in the web interface.
 
-To configure the network backend, simply copy the backend URL into the text box named `Networking proxy`.
+### Embedded v86 setup
 
-The guest's NIC emulation (NE2000 or VirtIO) is automatically configured when selecting the guest image in the web interface.
+JavaScript applications that do not use the v86 web interface (but instead embed V86 into their architecture) setup their network by using the common `config` object that they pass to the V86 constructor. Network settings are members of the object **`config.net_device`**, all settings are optional except for `relay_url`.
 
-### Network setup using `net_device` options
+#### General `net_device` settings
 
-In order to embed the v86 emulator in another project an instance of class `V86` needs to be created. The constructor expects a `config` object, and the network settings are controlled through its member **`config.net_device`**.
+Common options in `config.net_device`:
 
-#### Basic `net_device` settings
+| net_device    | type | description |
+| :------------ | :--- | :--- |
+| **type**      | str  | The type of emulated NIC provided to the guest OS, either `ne2k` or `virtio`. Default: `ne2k`. |
+| **relay_url** | str  | The network backend URL, see [Backend URL schemes](#backend-url-schemes) for details. Note that the CORS proxy server of the `fetch` backend is defined in field `cors_proxy` below. This option is required. |
+| **id**        | int  | Network id, all v86 network instances with the same id share the same network namespace. Default: `0`.<br>*(TODO: class `NetworkAdapter` should also get options.net_device as an argument, at least options.net_device.id).* |
 
-All network setups support the following options:
+#### Special `net_device` settings
 
-| net_device   | type | description |
-| :----------- | :--- | :--- |
-| `type`       | str  | The type of emulated NIC provided to the guest OS, either `ne2k` (default) or `virtio` |
-| `relay_url`  | str  | The network backend URL, either `localhub`, `ws[s]://...`, `wisp[s]://...` or `fetch`. Note that the CORS proxy server of the fetch backend is defined in field `cors_proxy` below. Also see the backend URL schemes described in the previous section. |
-| `id`         | int  | Network id, all v86 network instances with the same id share the same network namespace, default: `0` (TODO: NetworkAdapter in browser/starter.js should also get options.net_device as the last argument ) |
+Backends `fetch` and `wisp` support a couple of special settings in `config.net_device` to control virtual network components emulated by the backend:
 
-#### Advanced `net_device` settings
-
-Network backends `fetch` and `wisp` support some advanced settings in `net_device` that control the network components emulated by v86:
-
-| net_device   | type | description |
-| :----------- | :--- | :--- |
-| `router_mac` | str  | Emulated router's MAC address, default `52:54:0:1:2:3` |
-| `router_ip`  | str  | Emulated router's IP address in dotted IP notation, default `192.168.86.1` |
-| `vm_ip`      | str  | IP address to be assigned to the guest VM in dotted IP notation, default `192.168.86.100` |
-| `masquerade` | bool | `False`: TODO, `True`: TODO |
-| `cors_proxy` | str  | URL including HTTP query fragment of the HTTP CORS proxy server to use with the fetch backend |
-| `dns_method` | str  | DNS method to use, either `static` or `doh`. `static`: use built-in DNS server, `doh`: use DNS-over-HTTPS. Defaults to `static` for fetch and to `doh` for wisp |
-| `doh_server` | str  | Host name (and optional port number) of the DoH-server if `dns_method` is `doh`. The value is expanded to the URL `https://DOH_SERVER/dns-query`. Default: `cloudflare-dns.com` |
+| net_device     | type | description |
+| :------------- | :--- | :--- |
+| **router_mac** | str  | MAC address of virtual network peers (ARP, PING, DHCP, DNS, NTP, UDP echo and TCP peers) in common MAC address notation. Default `52:54:0:1:2:3`. |
+| **router_ip**  | str  | IP address of virtual network peers (ARP, PING, DHCP, DNS and TCP peers) in dotted IP notation. Default `192.168.86.1`. |
+| **vm_ip**      | str  | IP address to be assigned to the guest by DHCP in dotted IP notation. Default `192.168.86.100`. |
+| **masquerade** | bool | `False`: TODO, `True`: TODO. Default: `True`. |
+| **dns_method** | str  | DNS method to use, either `static` or `doh`. `static`: use built-in DNS server, `doh`: use [DNS-over-HTTPS](https://de.wikipedia.org/wiki/DNS_over_HTTPS) (DoH). Defaults to `static` for `fetch` and to `doh` for `wisp` backend. |
+| **doh_server** | str  | Host name or IP address (and optional port number) of the DoH server if `dns_method` is `doh`. The value is expanded to the URL `https://DOH_SERVER/dns-query`. Default: `cloudflare-dns.com`. |
+| **cors_proxy** | str  | CORS proxy server URL, do not use a proxy if undefined. Default: undefined (`fetch` backend only). |
 
 #### Example `net_device` settings
 
-* **Example 1:** Provide an emulated NE2000 NIC to the guest OS and use the wsproxy backend with a secure wsproxy server at public host `relay.widgetry.org` listening at default TLS port 443:
+* **Example 1:** Provide an emulated NE2000 NIC to the guest OS and use the `wsproxy` backend with a secure wsproxy server at public host `relay.widgetry.org` listening at default TLS port 443:
    ```
    let example_1 = new V86({
        net_device: {
-           type: "ne2k",
            relay_url: "wss://relay.widgetry.org/"
        },
        // ...
    });
    ```
 
-* **Example 2:** Provide a VirtIO NIC to the guest OS and use the fetch backend with a HTTP CORS proxy server at the local machine listening at port number 23456:
+* **Example 2:** Provide a VirtIO NIC to the guest OS and use the `fetch` backend with a CORS proxy server at the local machine listening at port number 23456:
    ```
    let example_2 = new V86({
        net_device: {
@@ -88,29 +89,29 @@ Network backends `fetch` and `wisp` support some advanced settings in `net_devic
 
 ## Network backends
 
-One way to look at the different types of network backends supported by v86 is how they operate on different layers in the [OSI reference model](https://en.wikipedia.org/wiki/OSI_model), approximately:
+One way to compare the different network backends is how they operate on different layers in the [OSI reference model](https://en.wikipedia.org/wiki/OSI_model) (roughly):
 
-       Network Peer               Backend                 v86 Guest
+       Network Peer                Backend                   v86 Guest
 
-    [ 7: Application  ] <--- fetch ---> +-----+      [ 7: Application  ]
-    [ 6: Presentation ]                 |     |      [ 6: Presentation ]
-    [ 5: Session      ]                 | v86 |      [ 5: Session      ]
-    [ 4: Transport    ] <--- wisp ----> |     |      [ 4: Transport    ]
-    [ 3: Network      ]                 |     |      [ 3: Network      ]
-    [ 2: Data Link    ] <-- wsproxy --> +-----+ <--> [ 2: Data Link    ]
-    [ 1: Physical     ] <-------- localhub --------> [ 1: Physical     ]
+    [ 7: Application  ] <---- fetch ----> +-----+       [ 7: Application  ]
+    [ 6: Presentation ]                   |     |       [ 6: Presentation ]
+    [ 5: Session      ]                   |     |       [ 5: Session      ]
+    [ 4: Transport    ] <---- wisp -----> | v86 |       [ 4: Transport    ]
+    [ 3: Network      ]                   |     |       [ 3: Network      ]
+    [ 2: Data Link    ] <--- wsproxy ---> |     | <---> [ 2: Data Link    ]
+    [ 1: Physical     ]    and localhub   +-----+       [ 1: Physical     ]
 
-                      Fig. 1: Network backends in v86
+                        Fig. 1: Network backends in v86
 
 v86 guests strictly expect to exchange layer-2 ethernet frames with their (emulated) network card, hence the higher the OSI layer that a v86 network backend operates on the more virtualized the network becomes and the more work has to be done by the backend to fill in for the missing layers.
 
-In order to facilitate this for backend implementations, v86 provides helper functions to encode/decode ethernet frames, ARP and IPv4 packets, UDP datagrams, TCP streams and HTTP requests/responses. v86 can also provide minimal but sufficient ICMP, DHCP, DNS (including DoH) and NTP services to guests.
+In order to facilitate this for backend implementations, v86 provides helper functions to encode/decode ethernet frames, ARP and IPv4 packets, UDP datagrams, TCP streams and HTTP requests/responses. v86 can also provide minimal but sufficient ARP, ICMP-echo, DHCP, DNS (including DoH) and NTP services to guests.
 
 ### The `localhub` backend
 
-This backend provides layer-2 networking services for multiple v86 guests running within the same browser process (meaning within the same web page and/or in separate browser tabs). It works without a proxy server, but it also does not provide any access to external networks. v86 is not involved in the exchange of frames between guests beyond emulating the guests' network cards, hence the stretch to place it in Layer 1 in Fig. 1.
+This backend provides layer-2 networking services for multiple v86 guests running within the same browser process (meaning within the same web page and/or in separate browser tabs). It works standalone without a proxy server, but it also does not provide any access to external networks.
 
-The localhub backend is implemented using the [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) browser API.
+The `localhub` backend is implemented using the browser-internal [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) API, due to its simplicity it is the most efficient backend, however all VMs have to share the same browser resources.
 
 **Example**
 
@@ -118,25 +119,27 @@ The localhub backend is implemented using the [BroadcastChannel](https://develop
 
 ### The `wsproxy` backend
 
-A backend based on a proxy server that provides layer-2 networking services to guests using the [WebSocket](https://en.wikipedia.org/wiki/WebSocket) protocol for transport. It depends on the specific proxy server what kind of network configuration it presents to guests, but usually a separate IP subnet with DHCP and DNS services and optional access to the server's physical network and possibly Internet is provided to guests.
+A backend based on a proxy server that provides layer-2 networking services to guests using the [WebSocket](https://en.wikipedia.org/wiki/WebSocket) protocol for transport. It depends on the specific proxy server what kind of network configuration it presents to guests, but usually a separate IP subnet with DHCP and DNS services and optional access to the server's physical network and possibly Internet are provided.
 
-Since this type of backend simply forwards raw ethernet frames in v86 as well as in the proxy server it is generally very efficient and provides full physical network emulation to guests.
+Since this backend (including its proxy server) only forwards unmodified ethernet frames it is inherently efficient while providing full physical network emulation to guests.
 
 **Proxy server**
 
 * **[websockproxy](https://github.com/benjamincburns/websockproxy)** -- uses a single TAP device for all clients, integrates dnsmasq for DHCP/DNS, original server implementation by benjamincburns
-  * Docker `benjamincburns/jor1k-relay:latest` is throttled, see [this comment](https://github.com/benjamincburns/websockproxy/issues/4#issuecomment-317255890)
-  * Docker `bellenottelling/websockproxy` is unthrottled
+  * Docker container `benjamincburns/jor1k-relay:latest` is throttled, see [this comment](https://github.com/benjamincburns/websockproxy/issues/4#issuecomment-317255890)
+  * Docker container `bellenottelling/websockproxy` is unthrottled
   * See [here](https://github.com/copy/v86/discussions/1175#discussioncomment-11199254) for step-by-step instructions on how to unthrottle websockproxy manually.
 * **[wsnic](https://github.com/chschnell/wsnic)** -- uses a single bridge and one TAP device per client, integrates dnsmasq for DHCP/DNS and stunnel for TLS
 * **[node-relay](https://github.com/krishenriksen/node-relay)** -- NodeJs
 * **[go-websockproxy](https://github.com/gdm85/go-websockproxy)** -- Go
 
+See [here](https://github.com/copy/v86/discussions/1199#discussion-7726530) for a benchmark comparison between `websockproxy` and `wsnic`.
+
 ### The `wisp` backend
 
-This backend implements the client side of the [WISP protocol](https://github.com/MercuryWorkshop/wisp-protocol). WISP is a client/server protocol designed to exchange WebSocket messages containing UDP and TCP payloads between a WebSocket client and a WISP-compatible proxy server. Note that WISP transports only the payloads, not the full UDP or TCP packets. See PR [#1097](https://github.com/copy/v86/pull/1097) for additional information about the WISP backend.
+This backend implements the client side of the [WISP protocol](https://github.com/MercuryWorkshop/wisp-protocol). WISP is a client/server protocol designed to exchange messages containing UDP and TCP payloads between a WebSocket client and a WISP-compatible proxy server. Note that WISP transports only the payloads, not the raw UDP or TCP packets. See PR [#1097](https://github.com/copy/v86/pull/1097) for additional information about the `wisp` backend.
 
-TODO: are v86 guests bridged or isolated in WISP (can they communicate with each other or not)?
+v86 guests are isolated from each other when using the `wisp` backend.
 
 **WISP-compatible proxy server**
 
@@ -144,32 +147,32 @@ TODO: are v86 guests bridged or isolated in WISP (can they communicate with each
 * **[epoxy-tls](https://github.com/MercuryWorkshop/epoxy-tls)**
 
 > [!NOTE]
-> WISP only supports TCP client sockets in the v86 guest, TCP server sockets listening in the guest are not supported.
+> The WISP protocol only supports UDP and TCP client sockets in the v86 guest, any server sockets listening in the guest are not supported.
 
 > [!NOTE]
 > The WISP implementation in v86 is missing support for UDP.
 
 ### The `fetch` backend
 
-The fetch backend uses the browser's [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API to allow guests to send HTTP requests to external HTTP servers and to receive related HTTP responses. This is however complicated by the fact that browsers add [HTTP CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) to HTTP requests initiated by `fetch()`, and that they check the CORS headers of related HTTP responses to block access to external web resources not authorized to `fetch()` in the current context.
+The `fetch` backend uses the browser's [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) API to allow guests to send HTTP requests to external HTTP servers and to receive related HTTP responses. This is however complicated by the fact that browsers add [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) to HTTP requests initiated by `fetch()`, and that they check the CORS headers of related HTTP responses to block access to external web resources not authorized to `fetch()` in the given context.
 
-Even though a proxy server is optional with this backend, a HTTP CORS proxy server is generally indispensable in order to evade the limitations imposed by CORS and to access the open Internet. Yet, this backend is highly useful in special cases where CORS is not in the way.
+Even though a proxy server is optional with this backend, a CORS proxy server is generally indispensable in order to evade the limitations imposed by CORS and to access the open Internet. Yet, this backend is highly useful in special cases where CORS is not in the way.
 
-This backend handles DHCP and ARP requests from the guest internally, and monitors the guest's outbound traffic for HTTP requests which it translates into calls to `fetch()`. Additionally, NTP, ICMP pings and UDP echo packets are handled to a certain degree. See PR [#1061](https://github.com/copy/v86/pull/1061) for additional technical details.
+This backend handles DHCP and ARP requests from guests internally (DNS lookups are handled by the browser), and also monitors the guest's outbound traffic for HTTP requests which it translates into calls to `fetch()`. Additionally, NTP, ICMP pings and UDP echo packets are handled to a certain degree. See PR [#1061](https://github.com/copy/v86/pull/1061) for additional technical details.
 
-v86 guests are isolated from each other when using the fetch backend.
+v86 guests are isolated from each other when using the `fetch` backend.
 
-**HTTP CORS proxy server**
+**CORS proxy server**
 
 * **[cors-anywhere](https://github.com/Rob--W/cors-anywhere)** -- NodeJS
-* **[uncors](https://github.com/chschnell/uncors)** -- A simple PHP-based HTTP CORS proxy server for Apache2.
+* **[uncors](https://github.com/chschnell/uncors)** -- A simple PHP-based CORS proxy server for Apache2.
 
 > [!TIP]
-> You can pass the following flags to **chromium** to allow browsing without restrictions in fetch mode:
+> You can pass the following flags to **chromium** to allow browsing without restrictions when using the fetch backend:
 >
->        --disable-web-security --user-data-dir=/tmp/test
+>     --disable-web-security --user-data-dir=/tmp/test
 >
-> but note that this turns off the same-origin policy and should only be used temporarily!
+> **NOTE:** This turns off the same-origin policy and should only be used temporarily!
 
 ## Related topics
 
@@ -206,4 +209,4 @@ There is no built-in support for v86 networking under NodeJS, but network backen
 
 ## Links
 
-*TODO*
+*TODO: Add relevant links to discussions and PRs that provide further information.*

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -121,13 +121,15 @@ Since this backend (including its proxy server) only forwards unmodified etherne
 
 **Proxy server**
 
-* **[websockproxy](https://github.com/benjamincburns/websockproxy)** -- uses a single TAP device for all clients, integrates dnsmasq for DHCP/DNS, original server implementation by benjamincburns
-  * Docker container `benjamincburns/jor1k-relay:latest` is throttled, see [this comment](https://github.com/benjamincburns/websockproxy/issues/4#issuecomment-317255890)
+* **[websockproxy](https://github.com/benjamincburns/websockproxy)** -- one TAP device for all clients, integrates dnsmasq for DHCP/DNS, no TLS, original server by benjamincburns
+  * Docker container `benjamincburns/jor1k-relay` is throttled, see [this comment](https://github.com/benjamincburns/websockproxy/issues/4#issuecomment-317255890)
   * Docker container `bellenottelling/websockproxy` is unthrottled
   * See [here](https://github.com/copy/v86/discussions/1175#discussioncomment-11199254) for step-by-step instructions on how to unthrottle websockproxy manually.
-* **[wsnic](https://github.com/chschnell/wsnic)** -- uses a single bridge and one TAP device per client, integrates dnsmasq for DHCP/DNS and stunnel for TLS (see [here](https://github.com/copy/v86/discussions/1199#discussion-7726530) for a benchmark comparison with `websockproxy`)
-* **[node-relay](https://github.com/krishenriksen/node-relay)** -- see [New websocket ethernet switch built using Node.js #777](https://github.com/copy/v86/discussions/777)
-* **[go-websockproxy](https://github.com/gdm85/go-websockproxy)** -- Go
+* **[go-websockproxy](https://github.com/gdm85/go-websockproxy)** -- one TAP device for all clients, written in Go, without integraded DHCP but with integrated TLS support
+* **[node-relay](https://github.com/krishenriksen/node-relay)** -- like websockproxy but written for NodeJS (dnsmasq/no TLS), see [New websocket ethernet switch built using Node.js #777](https://github.com/copy/v86/discussions/777)
+* **[wsnic](https://github.com/chschnell/wsnic)** -- uses a single bridge and one TAP device per client, integrates dnsmasq for DHCP/DNS and stunnel for TLS
+
+[See here](https://github.com/copy/v86/discussions/1199#discussioncomment-12026845) for a benchmark comparing the download performance of these proxy servers.
 
 ### The `wisp` backend
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -59,7 +59,7 @@ Backends `fetch` and `wisp` support a couple of special settings in `config.net_
 | **router_ip**  | str  | IP address of virtual network peers (ARP, PING, DHCP, DNS and TCP peers) in dotted IP notation. Default `192.168.86.1`. |
 | **vm_ip**      | str  | IP address to be assigned to the guest by DHCP in dotted IP notation. Default `192.168.86.100`. |
 | **masquerade** | bool | `False`: TODO, `True`: TODO. Default: `True`. |
-| **dns_method** | str  | DNS method to use, either `static` or `doh`. `static`: use built-in DNS server, `doh`: use [DNS-over-HTTPS](https://de.wikipedia.org/wiki/DNS_over_HTTPS) (DoH). Defaults to `static` for `fetch` and to `doh` for `wisp` backend. |
+| **dns_method** | str  | DNS method to use, either `static` or `doh`. `static`: use built-in DNS server, `doh`: use [DNS-over-HTTPS](https://en.wikipedia.org/wiki/DNS_over_HTTPS) (DoH). Defaults to `static` for `fetch` and to `doh` for `wisp` backend. |
 | **doh_server** | str  | Host name or IP address (and optional port number) of the DoH server if `dns_method` is `doh`. The value is expanded to the URL `https://DOH_SERVER/dns-query`. Default: `cloudflare-dns.com`. |
 | **cors_proxy** | str  | CORS proxy server URL, do not use a proxy if undefined. Default: undefined (`fetch` backend only). |
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -158,7 +158,7 @@ The `fetch` backend uses the browser's [`fetch()`](https://developer.mozilla.org
 
 Even though a proxy server is optional with this backend, a CORS proxy server is generally indispensable in order to evade the limitations imposed by CORS and to access the open Internet. Yet, this backend is highly useful in special cases where CORS is not in the way.
 
-This backend handles DHCP and ARP requests from guests internally (DNS lookups are handled by `fetch()`), and also monitors the guest's outbound traffic for HTTP requests which it translates into calls to `fetch()`. Additionally, NTP, ICMP pings and UDP echo packets are handled to a certain degree. See PR [#1061](https://github.com/copy/v86/pull/1061) for additional technical details.
+This backend handles DHCP and ARP requests from guests internally, and also monitors the guest's outbound traffic for HTTP requests which it translates into calls to `fetch()`. Additionally, NTP, ICMP pings and UDP echo packets are handled to a certain degree. Note that `fetch()` performs the DNS lookup using the browser's internal DNS client. See PR [#1061](https://github.com/copy/v86/pull/1061) for additional technical details.
 
 v86 guests are isolated from each other when using the `fetch` backend.
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -19,7 +19,7 @@ The active network backend is configured through a user-specified **backend URL*
 
 | Backend | Backend URL scheme(s) | Example(s) |
 | :------ | :-------------------- | :--------- |
-| **[localhub](#the-localhub-backend)** | `localhub` | `localhub` |
+| **[inbrowser](#the-inbrowser-backend)** | `inbrowser` | `inbrowser` |
 | **[wsproxy](#the-wsproxy-backend)** | `"ws://" PROXY [":" PORT=80] ["/" ...]`<br>`"wss://" PROXY [":" PORT=443] ["/" ...]` | `wss://relay.widgetry.org/` |
 | **[wisp](#the-wisp-backend)** | `"wisp://" PROXY [":" PORT=80] ["/" ...]`<br>`"wisps://" PROXY [":" PORT=443] ["/" ...]` | `wisp://localhost:12345` |
 | **[fetch](#the-fetch-backend)** | `"fetch" [ "://" PROXY [":" PORT] ["/" QUERY] ]` | `fetch`<br>`fetch://localhost:1234/?url=` |
@@ -99,7 +99,7 @@ One way to compare the different network backends is how they operate on differe
     [ 4: Transport    ] <---- wisp -----> | v86 |       [ 4: Transport    ]
     [ 3: Network      ]                   |     |       [ 3: Network      ]
     [ 2: Data Link    ] <--- wsproxy ---> |     | <---> [ 2: Data Link    ]
-    [ 1: Physical     ]    and localhub   +-----+       [ 1: Physical     ]
+    [ 1: Physical     ]   and inbrowser   +-----+       [ 1: Physical     ]
 
                         Fig. 1: Network backends in v86
 
@@ -107,11 +107,11 @@ v86 guests strictly expect to exchange layer-2 ethernet frames with their (emula
 
 In order to facilitate this for backend implementations, v86 provides helper functions to encode/decode ethernet frames, ARP and IPv4 packets, UDP datagrams, TCP streams and HTTP requests/responses. v86 can also provide minimal but sufficient ARP, ICMP-echo, DHCP, DNS (including DoH) and NTP services to guests.
 
-### The `localhub` backend
+### The `inbrowser` backend
 
 This backend provides layer-2 networking services for multiple v86 guests running within the same browser process (meaning within the same web page and/or in separate browser tabs). It works standalone without a proxy server, but it also does not provide any access to external networks.
 
-The `localhub` backend is implemented using the browser-internal [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) API, due to its simplicity it is the most efficient backend, however all VMs have to share the same browser resources.
+The `inbrowser` backend is implemented using the browser-internal [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) API, due to its simplicity it is the most efficient backend, however all VMs have to share the same browser resources.
 
 **Example**
 
@@ -205,7 +205,7 @@ after the state has been loaded.
 
 ### NodeJS
 
-There is no built-in support for v86 networking under NodeJS, but network backends `wsproxy` and `wisp` only depend on a browser-compatible `WebSocket` constructor being present in the global scope, whereas backends `localhub` and `fetch` should work directly.
+There is no built-in support for v86 networking under NodeJS, but network backends `wsproxy` and `wisp` only depend on a browser-compatible `WebSocket` constructor being present in the global scope, whereas backends `inbrowser` and `fetch` should work directly.
 
 ## Links
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -209,6 +209,6 @@ There is no built-in support for v86 networking under NodeJS, but network backen
 
 ## Links
 
-* [`examples/two_instances.html`](examples/two_instances.html), example code that shows how to connect two V86 instances in a web page with a virtual ethernet crossover cable.
+* [`examples/two_instances.html`](../examples/two_instances.html), example code that shows how to connect two V86 instances in a web page with a virtual ethernet crossover cable.
 * [DC through windows OS for experimental lab #1195](https://github.com/copy/v86/discussions/1195), demonstrates how to setup a Domain Controller for two Windows VMs (XP and Windows Server 2003) using a virtual crossover cable.
 * [Working on a new cross-platform network relay that is a full virtualized network #1064](https://github.com/copy/v86/discussions/1064) (used in [env86 #1085](https://github.com/copy/v86/discussions/1085))


### PR DESCRIPTION
Many changes to the current networking documentation.

Added new terms *network backend* and *backend URL* as they stand for central concepts in the V86 networking architecture, and I found it a lot easier and clearer to write about the topics using them.

