### PR TITLE
Export `cycle_internal` for single stepping

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -220,6 +220,8 @@ CPU.prototype.wasm_patch = function()
         return f;
     };
 
+    this.cycle_internal = get_import("cycle_internal");
+
     this.reset_cpu = get_import("reset_cpu");
 
     this.getiopl = get_import("getiopl");

--- a/src/rust/cpu/cpu.rs
+++ b/src/rust/cpu/cpu.rs
@@ -2856,6 +2856,7 @@ pub unsafe fn run_instruction(opcode: i32) { ::gen::interpreter::run(opcode as u
 pub unsafe fn run_instruction0f_16(opcode: i32) { ::gen::interpreter0f::run(opcode as u32) }
 pub unsafe fn run_instruction0f_32(opcode: i32) { ::gen::interpreter0f::run(opcode as u32 | 0x100) }
 
+#[no_mangle]
 pub unsafe fn cycle_internal() {
     profiler::stat_increment(CYCLE_INTERNAL);
     let mut jit_entry = None;


### PR DESCRIPTION
Using a `cycle`s function approach was suggested in #103 as a single-stepping solution.

The exported `cycle` was removed however.

I think it could be useful to export such a function, maybe the `cycle_internal` should be having some wrapping before it can be shipped, but I think it'd beneficial overall.