### PR TITLE
fix: Invalid invocation of fetch()

### DIFF
--- a/src/browser/fetch_network.js
+++ b/src/browser/fetch_network.js
@@ -21,7 +21,7 @@ function FetchNetworkAdapter(bus, config)
     this.doh_server = config.doh_server;
     this.tcp_conn = {};
     this.eth_encoder_buf = create_eth_encoder_buf();
-    this.fetch = fetch;
+    this.fetch = (...args) => fetch(...args);
 
     // Ex: 'https://corsproxy.io/?'
     this.cors_proxy = config.cors_proxy;
@@ -33,8 +33,6 @@ function FetchNetworkAdapter(bus, config)
     {
         this.send(data);
     }, this);
-
-    //Object.seal(this);
 }
 
 FetchNetworkAdapter.prototype.destroy = function()


### PR DESCRIPTION
The original code in `fetch_network` binds `fetch` to `FetchNetworkAdapter`. In many modern browsers (including Chromium), binding `fetch` results in a `Illegal invocation` error.

An alternative solution to fix this would be to just call `globalThis.fetch()` or `fetch()` directly in the adapter but I didn't want to touch on any toes in case having a method on the prototype is useful for anyone.