### PR TITLE
fix: Correctly detect Node environment

### DIFF
--- a/lib/jor1k.js
+++ b/lib/jor1k.js
@@ -54,7 +54,7 @@ message.Abort = function()
 // XXX: Should go through emulator interface
 var LoadBinaryResource;
 
-if(typeof XMLHttpRequest !== "undefined")
+if(typeof XMLHttpRequest !== "undefined" && !(typeof process !== "undefined" && process.versions && process.versions.node))
 {
     LoadBinaryResource = function(url, OnSuccess, OnError) {
         var req = new XMLHttpRequest();

--- a/src/buffer.js
+++ b/src/buffer.js
@@ -703,7 +703,7 @@
         return file;
     };
 
-    if(typeof XMLHttpRequest === "undefined")
+    if(typeof XMLHttpRequest === "undefined" || (typeof process !== "undefined" && process.versions && process.versions.node))
     {
         var determine_size = function(path, cb)
         {

--- a/src/lib.js
+++ b/src/lib.js
@@ -542,7 +542,7 @@ v86util.Bitmap.prototype.get_buffer = function()
 };
 
 
-if(typeof XMLHttpRequest === "undefined")
+if(typeof XMLHttpRequest === "undefined" || (typeof process !== "undefined" && process.versions && process.versions.node))
 {
     v86util.load_file = load_file_nodejs;
 }


### PR DESCRIPTION
Right now, v86 prefers `XMLHttpRequest` when available. I'm patching this in my Electron use case to prefer `fs` for performance reasons.

With this change, v86 prefers `XMLHttpRequest` when available _and_ `process.versions.node` is undefined. If desired, I'm also happy to write a simple `try/catch` function that returns a boolean if `require('fs')` works.