### PR TITLE
Relax bottleneck in VirtIO network adapter

### DIFF
--- a/src/virtio_net.js
+++ b/src/virtio_net.js
@@ -40,8 +40,8 @@ function VirtioNet(cpu, bus, preserve_mac_from_state_image)
 
     for(let i = 0; i < this.pairs; ++i)
     {
-        queues.push({size_supported: 32, notify_offset: 0});
-        queues.push({size_supported: 32, notify_offset: 1});
+        queues.push({size_supported: 1024, notify_offset: 0});
+        queues.push({size_supported: 1024, notify_offset: 1});
     }
     queues.push({
         size_supported: 16,


### PR DESCRIPTION
I noticed plenty of `No buffer to write into!` console messages when putting high pressure on virtio_net.js. For example, when booting my [iSCSI-experiment](https://github.com/copy/v86/discussions/1254) there are 808 of these messages directly after login.

This message is generated in the [net-receive bus message handler](https://github.com/copy/v86/blob/ec3ecde20335eb1f162c7141c1b4fbd36483dd7e/src/virtio_net.js#L191-L207) of virtio_net when its preallocated set of buffers is exhausted, causing the handler to drop the ethernet frame instead of handling it.

The number of preallocated buffers is determined by the size of the send- and receive-queues passed into the [VirtIO-constructor in virtio_net.js](https://github.com/copy/v86/blob/ec3ecde20335eb1f162c7141c1b4fbd36483dd7e/src/virtio_net.js#L41-L45), currently set to **32**.

I tested queue sizes of 256, 512, 1024 and 4096 using `iperf` and found **1024** to yield the best results:

1. No console messages after login
2. Guest's upstream bandwidth raised from 315 Mbits/sec to 360 Mbits/sec
3. Guest's downstream bandwidth raised from 231 Mbits/sec to **528 Mbits/sec (!)**

I still see these console messages when running `iperf` (which attempts to cause maximum network pressure), I don't know where the limit is.

When measuring CPU load on the proxy server (`wsnic`) while running `iperf`, I see around 90% load during the guest's upstream bandwith test, and around 30% during the downstream test. The WebSocket protocol requires traffic from client to server (upstream) to be masked with a 32-bit mask, and that causes computational load in the proxy server which likely explains the difference in bandwith depending on the direction of traffic, I believe this bandwidth mismatch to be reasonable now (as opposed to before), the proxy server is now the bottleneck here.

The fact that this has more than doubled the guest's download bandwidth to half a GBit/sec was really unexpected.

**Details**

<details>
<summary>iperf with 32 buffers</summary>

```bash
root@debian-iscsi:~# iperf -c 192.168.86.1 -r -i 2
[  1] local 192.168.86.17 port 54346 connected with 192.168.86.1 port 5001 (icwnd/mss/irtt=14/1448/1044)
[ ID] Interval       Transfer     Bandwidth
[  1] 0.0000-2.0000 sec  71.6 MBytes   300 Mbits/sec
[  1] 2.0000-4.0000 sec  74.4 MBytes   312 Mbits/sec
[  1] 4.0000-6.0000 sec  75.0 MBytes   315 Mbits/sec
[  1] 6.0000-8.0000 sec  76.6 MBytes   321 Mbits/sec
[  1] 8.0000-10.0000 sec  81.6 MBytes   342 Mbits/sec
[  1] 0.0000-10.1184 sec   379 MBytes   315 Mbits/sec
[  2] local 192.168.86.17 port 5001 connected with 192.168.86.1 port 41220
[ ID] Interval       Transfer     Bandwidth
[  2] 0.0000-2.0000 sec  53.3 MBytes   224 Mbits/sec
[  2] 2.0000-4.0000 sec  55.7 MBytes   234 Mbits/sec
[  2] 4.0000-6.0000 sec  52.0 MBytes   218 Mbits/sec
[  2] 6.0000-8.0000 sec  57.6 MBytes   242 Mbits/sec
[  2] 8.0000-10.0000 sec  57.0 MBytes   239 Mbits/sec
[  2] 0.0000-10.0374 sec   276 MBytes   231 Mbits/sec
```

</details>

<details>
<summary>iperf with 1024 buffers</summary>

```bash
root@debian-iscsi:~# iperf -c 192.168.86.1 -r -i 2
[  1] local 192.168.86.12 port 49054 connected with 192.168.86.1 port 5001 (icwnd/mss/irtt=14/1448/1660)
[ ID] Interval       Transfer     Bandwidth
[  1] 0.0000-2.0000 sec  79.3 MBytes   332 Mbits/sec
[  1] 2.0000-4.0000 sec  93.5 MBytes   392 Mbits/sec
[  1] 4.0000-6.0000 sec  84.5 MBytes   354 Mbits/sec
[  1] 6.0000-8.0000 sec  85.9 MBytes   360 Mbits/sec
[  1] 8.0000-10.0000 sec  87.2 MBytes   366 Mbits/sec
[  1] 0.0000-10.0208 sec   431 MBytes   360 Mbits/sec
[  2] local 192.168.86.12 port 5001 connected with 192.168.86.1 port 38716
[ ID] Interval       Transfer     Bandwidth
[  2] 0.0000-2.0000 sec   123 MBytes   514 Mbits/sec
[  2] 2.0000-4.0000 sec   127 MBytes   535 Mbits/sec
[  2] 4.0000-6.0000 sec   126 MBytes   530 Mbits/sec
[  2] 6.0000-8.0000 sec   123 MBytes   517 Mbits/sec
[  2] 8.0000-10.0000 sec   129 MBytes   541 Mbits/sec
[  2] 0.0000-10.0566 sec   632 MBytes   528 Mbits/sec
```

</details>
