### PR TITLE
Fine-tune OS filter behaviour in web UI

### DIFF
--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1534,7 +1534,7 @@
             };
         });
 
-        const filter_categories = [
+        const known_filter = [
             [   // Family:
                 { id: "linux", condition: os => os.family === "Linux" },
                 { id: "bsd", condition: os => os.family === "BSD" },
@@ -1577,32 +1577,30 @@
             ],
         ];
 
-        for(const filter_category of filter_categories)
+        const defined_filter = [];
+        for(const known_category of known_filter)
         {
-            for(const filter of filter_category)
-            {
+            const category = known_category.filter(filter => {
                 const element = document.getElementById(`filter_${filter.id}`);
-                filter.element = element;
                 if(element)
                 {
                     element.onchange = update_filters;
+                    filter.element = element;
                 }
+                return element;
+            });
+            if(category.length)
+            {
+                defined_filter.push(category);
             }
         }
 
         function update_filters()
         {
             const conjunction = [];
-            for(const filter_category of filter_categories)
+            for(const category of defined_filter)
             {
-                const disjunction = [];
-                for(const filter of filter_category)
-                {
-                    if(filter.element && filter.element.checked)
-                    {
-                        disjunction.push(filter.condition);
-                    }
-                }
+                const disjunction = category.filter(filter => filter.element.checked);
                 if(disjunction.length)
                 {
                     conjunction.push(disjunction);
@@ -1610,7 +1608,7 @@
             }
             for(const os of os_info)
             {
-                os.element.style.display = conjunction.every(disjunction => disjunction.some(condition => condition(os))) ? "" : "none";
+                os.element.style.display = conjunction.every(disjunction => disjunction.some(filter => filter.condition(os))) ? "" : "none";
             }
         }
 

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1581,8 +1581,8 @@
         for(const element of document.querySelectorAll("#filter input"))
         {
             const label = element.id.replace(/filter_/, "");
-            dbg_assert(filter_categories.some(category => category.hasOwnProperty(label)));
-            dbg_assert(!filter_element.hasOwnProperty(label));
+            dbg_assert(filter_categories.some(category => Object.prototype.hasOwnProperty.call(category, label)));
+            dbg_assert(!Object.prototype.hasOwnProperty.call(filter_element, label));
             filter_element[label] = element;
             element.onchange = update_filters;
         }

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1536,44 +1536,44 @@
 
         const filter_categories = [
             [   // Family:
-                { label: "linux", condition: os => os.family === "Linux" },
-                { label: "bsd", condition: os => os.family === "BSD" },
-                { label: "windows", condition: os => os.family === "Windows" },
-                { label: "unix", condition: os => os.family === "Unix" },
-                { label: "dos", condition: os => os.family === "DOS" },
-                { label: "custom", condition: os => os.family === "Custom" },
+                { id: "linux", condition: os => os.family === "Linux" },
+                { id: "bsd", condition: os => os.family === "BSD" },
+                { id: "windows", condition: os => os.family === "Windows" },
+                { id: "unix", condition: os => os.family === "Unix" },
+                { id: "dos", condition: os => os.family === "DOS" },
+                { id: "custom", condition: os => os.family === "Custom" },
             ],
             [   // UI:
-                { label: "graphical", condition: os => os.graphical },
-                { label: "text", condition: os => !os.graphical },
+                { id: "graphical", condition: os => os.graphical },
+                { id: "text", condition: os => !os.graphical },
             ],
             [   // Medium:
-                { label: "floppy", condition: os => os.medium === "Floppy" },
-                { label: "cd", condition: os => os.medium === "CD" },
-                { label: "hd", condition: os => os.medium === "HD" },
+                { id: "floppy", condition: os => os.medium === "Floppy" },
+                { id: "cd", condition: os => os.medium === "CD" },
+                { id: "hd", condition: os => os.medium === "HD" },
             ],
             [   // Size:
-                { label: "bootsector", condition: os => os.size <= 512 },
-                { label: "lt5mb", condition: os => os.size <= 5 * 1024 * 1024 },
-                { label: "gt5mb", condition: os => os.size > 5 * 1024 * 1024 },
+                { id: "bootsector", condition: os => os.size <= 512 },
+                { id: "lt5mb", condition: os => os.size <= 5 * 1024 * 1024 },
+                { id: "gt5mb", condition: os => os.size > 5 * 1024 * 1024 },
             ],
             [   // Status:
-                { label: "modern", condition: os => os.status === "Modern" },
-                { label: "historic", condition: os => os.status === "Historic" },
+                { id: "modern", condition: os => os.status === "Modern" },
+                { id: "historic", condition: os => os.status === "Historic" },
             ],
             [   // License:
-                { label: "opensource", condition: os => os.source === "Open-source" },
-                { label: "proprietary", condition: os => os.source === "Proprietary" },
+                { id: "opensource", condition: os => os.source === "Open-source" },
+                { id: "proprietary", condition: os => os.source === "Proprietary" },
             ],
             [   // Arch:
-                { label: "16bit", condition: os => os.arch === "16-bit" },
-                { label: "32bit", condition: os => os.arch === "32-bit" },
+                { id: "16bit", condition: os => os.arch === "16-bit" },
+                { id: "32bit", condition: os => os.arch === "32-bit" },
             ],
             [   // Lang:
-                { label: "asm", condition: os => os.languages.has("ASM") },
-                { label: "c", condition: os => os.languages.has("C") },
-                { label: "cpp", condition: os => os.languages.has("C++") },
-                { label: "other_lang", condition: os => ["ASM", "C", "C++"].every(lang => !os.languages.has(lang)) },
+                { id: "asm", condition: os => os.languages.has("ASM") },
+                { id: "c", condition: os => os.languages.has("C") },
+                { id: "cpp", condition: os => os.languages.has("C++") },
+                { id: "other_lang", condition: os => ["ASM", "C", "C++"].every(lang => !os.languages.has(lang)) },
             ],
         ];
 
@@ -1581,10 +1581,12 @@
         {
             for(const filter of filter_category)
             {
-                const element = document.getElementById(`filter_${filter.label}`);
-                dbg_assert(element);
-                element.onchange = update_filters;
+                const element = document.getElementById(`filter_${filter.id}`);
                 filter.element = element;
+                if(element)
+                {
+                    element.onchange = update_filters;
+                }
             }
         }
 
@@ -1596,7 +1598,7 @@
                 const disjunction = [];
                 for(const filter of filter_category)
                 {
-                    if(filter.element.checked)
+                    if(filter.element && filter.element.checked)
                     {
                         disjunction.push(filter.condition);
                     }

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1535,69 +1535,70 @@
         });
 
         const filter_categories = [
-            {   // Family:
-                "linux": os => os.family === "Linux",
-                "bsd": os => os.family === "BSD",
-                "windows": os => os.family === "Windows",
-                "unix": os => os.family === "Unix",
-                "dos": os => os.family === "DOS",
-                "custom": os => os.family === "Custom",
-            },
-            {   // UI:
-                "graphical": os => os.graphical,
-                "text": os => !os.graphical,
-            },
-            {   // Medium:
-                "floppy": os => os.medium === "Floppy",
-                "cd": os => os.medium === "CD",
-                "hd": os => os.medium === "HD",
-            },
-            {   // Size:
-                "bootsector": os => os.size <= 512,
-                "lt5mb": os => os.size <= 5 * 1024 * 1024,
-                "gt5mb": os => os.size > 5 * 1024 * 1024,
-            },
-            {   // Status:
-                "modern": os => os.status === "Modern",
-                "historic": os => os.status === "Historic",
-            },
-            {   // License:
-                "opensource": os => os.source === "Open-source",
-                "proprietary": os => os.source === "Proprietary",
-            },
-            {   // Arch:
-                "16bit": os => os.arch === "16-bit",
-                "32bit": os => os.arch === "32-bit",
-            },
-            {   // Lang:
-                "asm": os => os.languages.has("ASM"),
-                "c": os => os.languages.has("C"),
-                "cpp": os => os.languages.has("C++"),
-                "other_lang": os => !os.languages.has("ASM") && !os.languages.has("C") && !os.languages.has("C++"),
-            },
+            [   // Family:
+                { label: "linux", condition: os => os.family === "Linux" },
+                { label: "bsd", condition: os => os.family === "BSD" },
+                { label: "windows", condition: os => os.family === "Windows" },
+                { label: "unix", condition: os => os.family === "Unix" },
+                { label: "dos", condition: os => os.family === "DOS" },
+                { label: "custom", condition: os => os.family === "Custom" },
+            ],
+            [   // UI:
+                { label: "graphical", condition: os => os.graphical },
+                { label: "text", condition: os => !os.graphical },
+            ],
+            [   // Medium:
+                { label: "floppy", condition: os => os.medium === "Floppy" },
+                { label: "cd", condition: os => os.medium === "CD" },
+                { label: "hd", condition: os => os.medium === "HD" },
+            ],
+            [   // Size:
+                { label: "bootsector", condition: os => os.size <= 512 },
+                { label: "lt5mb", condition: os => os.size <= 5 * 1024 * 1024 },
+                { label: "gt5mb", condition: os => os.size > 5 * 1024 * 1024 },
+            ],
+            [   // Status:
+                { label: "modern", condition: os => os.status === "Modern" },
+                { label: "historic", condition: os => os.status === "Historic" },
+            ],
+            [   // License:
+                { label: "opensource", condition: os => os.source === "Open-source" },
+                { label: "proprietary", condition: os => os.source === "Proprietary" },
+            ],
+            [   // Arch:
+                { label: "16bit", condition: os => os.arch === "16-bit" },
+                { label: "32bit", condition: os => os.arch === "32-bit" },
+            ],
+            [   // Lang:
+                { label: "asm", condition: os => os.languages.has("ASM") },
+                { label: "c", condition: os => os.languages.has("C") },
+                { label: "cpp", condition: os => os.languages.has("C++") },
+                { label: "other_lang", condition: os => ["ASM", "C", "C++"].every(lang => !os.languages.has(lang)) },
+            ],
         ];
 
-        const filter_element = {};
-        for(const element of document.querySelectorAll("#filter input"))
+        for(const filter_category of filter_categories)
         {
-            const label = element.id.replace(/filter_/, "");
-            dbg_assert(filter_categories.some(category => Object.prototype.hasOwnProperty.call(category, label)));
-            dbg_assert(!Object.prototype.hasOwnProperty.call(filter_element, label));
-            filter_element[label] = element;
-            element.onchange = update_filters;
+            for(const filter of filter_category)
+            {
+                const element = document.getElementById(`filter_${filter.label}`);
+                dbg_assert(element);
+                element.onchange = update_filters;
+                filter.element = element;
+            }
         }
 
         function update_filters()
         {
             const conjunction = [];
-            for(const filter_conditions of filter_categories)
+            for(const filter_category of filter_categories)
             {
                 const disjunction = [];
-                for(const [label, condition] of Object.entries(filter_conditions))
+                for(const filter of filter_category)
                 {
-                    if(filter_element[label].checked)
+                    if(filter.element.checked)
                     {
-                        disjunction.push(condition);
+                        disjunction.push(filter.condition);
                     }
                 }
                 if(disjunction.length)


### PR DESCRIPTION
Currently, the different guest OS filters are logically combined in function `update_filters()` by `OR`-ing them together.

This patch splits filters into the same categories that are already defined in the UI (`Family`, `UI`, `Medium`, ...). Filters within a category are logically combined using `OR`, and categories are then combined using `AND`.

Note that the web UI DOM is left unchanged by this patch.

Fixes issue #1268.
