### PR TITLE
fix opening folder in `fs2json` and `copy-to-sha256` on Windows

### DIFF
--- a/tools/copy-to-sha256.py
+++ b/tools/copy-to-sha256.py
@@ -35,9 +35,9 @@ def main():
     from_path = os.path.normpath(args.from_path)
     to_path = os.path.normpath(args.to_path)
 
-    try:
+    if os.path.isfile(from_path):
         tar = tarfile.open(from_path, "r")
-    except IsADirectoryError:
+    else:
         tar = None
 
     if tar:

--- a/tools/fs2json.py
+++ b/tools/fs2json.py
@@ -52,7 +52,7 @@ def main():
     logger.setLevel(logging.DEBUG)
 
     args = argparse.ArgumentParser(description="Create filesystem JSON. Example:\n"
-                                               "    ./fs2xml.py --exclude /boot/ --out fs.json /mnt/",
+                                               "    ./fs2json.py --exclude /boot/ --out fs.json /mnt/",
                                    formatter_class=argparse.RawTextHelpFormatter
                                   )
     args.add_argument("--exclude",
@@ -73,9 +73,9 @@ def main():
 
     path = os.path.normpath(args.path)
 
-    try:
+    if os.path.isfile(path):
         tar = tarfile.open(path, "r")
-    except IsADirectoryError:
+    else:
         tar = None
 
     if tar:


### PR DESCRIPTION
Fixes #1270