### PR TITLE
Reset PS/2 runtime state when soft-resetting CPU

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -688,6 +688,10 @@ CPU.prototype.reboot_internal = function()
     {
         this.devices.virtio_net.reset();
     }
+    if(this.devices.ps2)
+    {
+        this.devices.ps2.reset();
+    }
 
     this.load_bios();
 };

--- a/src/ps2.js
+++ b/src/ps2.js
@@ -141,7 +141,7 @@ PS2.prototype.reset = function()
     this.read_output_register = false;
     this.read_command_register = false;
     this.read_controller_output_port = false;
-}
+};
 
 PS2.prototype.get_state = function()
 {


### PR DESCRIPTION
Added PS/2 to devices which are reset in CPU.reboot_internal().

- Moved assignment of all member variables from constructor to new method PS2.reset().
- Added call to PS2.reset() in PS2 constructor and in CPU.reboot_internal().

Fixes issue #1300.