### PR TITLE
Improve IDE Controller

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -212,6 +212,7 @@
         <input type="button" value="Get second hard disk image" id="get_hdb_image">
         <input type="button" value="Get CD-ROM image" id="get_cdrom_image">
         <input type="button" value="Insert floppy image" id="change_fda_image">
+        <input type="button" value="Insert CD image" id="change_cdrom_image">
         <input type="button" value="Save State" id="save_state">
         <input type="button" value="Load State" id="load_state"> <input type="file" style="display: none" id="load_state_input">
         <input type="button" value="Memory Dump" id="memory_dump">

--- a/index.html
+++ b/index.html
@@ -241,6 +241,7 @@
         <input type="button" value="Get second hard disk image" id="get_hdb_image">
         <input type="button" value="Get CD-ROM image" id="get_cdrom_image">
         <input type="button" value="Insert floppy image" id="change_fda_image">
+        <input type="button" value="Insert CD image" id="change_cdrom_image">
         <input type="button" value="Save State" id="save_state">
         <input type="button" value="Load State" id="load_state"> <input type="file" style="display: none" id="load_state_input">
         <input type="button" value="Memory Dump" id="memory_dump">

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -2395,6 +2395,32 @@ function init_ui(profile, settings, emulator)
         $("change_fda_image").blur();
     };
 
+    $("change_cdrom_image").value = settings.cdrom ? "Eject CD image" : "Insert CD image";
+    $("change_cdrom_image").onclick = function()
+    {
+        if(emulator.v86.cpu.devices.cdrom.master.buffer)
+        {
+            emulator.eject_cdrom();
+            $("change_cdrom_image").value = "Insert CD image";
+        }
+        else
+        {
+            const file_input = document.createElement("input");
+            file_input.type = "file";
+            file_input.onchange = async function(e)
+            {
+                const file = file_input.files[0];
+                if(file)
+                {
+                    await emulator.set_cdrom({ buffer: file });
+                    $("change_cdrom_image").value = "Eject CD image";
+                }
+            };
+            file_input.click();
+        }
+        $("change_cdrom_image").blur();
+    };
+
     $("memory_dump").onclick = function()
     {
         const mem8 = emulator.v86.cpu.mem8;

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -2398,7 +2398,7 @@ function init_ui(profile, settings, emulator)
     $("change_cdrom_image").value = settings.cdrom ? "Eject CD image" : "Insert CD image";
     $("change_cdrom_image").onclick = function()
     {
-        if(emulator.v86.cpu.devices.cdrom.master.buffer)
+        if(emulator.v86.cpu.devices.cdrom.has_disk())
         {
             emulator.eject_cdrom();
             $("change_cdrom_image").value = "Insert CD image";

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -457,13 +457,6 @@ V86.prototype.continue_init = async function(emulator, options)
             return;
         }
 
-        if(name === "cdrom" && file.ejected)
-        {
-            // the "ejected file" is a special CD-ROM file object, pass it to settings.cdrom and let CPU.init() handle it
-            settings.cdrom = file;
-            return;
-        }
-
         if(file.get && file.set && file.load)
         {
             files_to_load.push({

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -995,7 +995,7 @@ V86.prototype.set_cdrom = async function(file)
         load_file(file.url, {
             done: result =>
             {
-                this.v86.cpu.devices.cdrom.master.set_cdrom(new SyncBuffer(result));
+                this.v86.cpu.devices.cdrom.set_cdrom(new SyncBuffer(result));
             },
         });
     }
@@ -1004,7 +1004,7 @@ V86.prototype.set_cdrom = async function(file)
         const image = buffer_from_object(file, this.zstd_decompress_worker.bind(this));
         image.onload = () =>
         {
-            this.v86.cpu.devices.cdrom.master.set_cdrom(image);
+            this.v86.cpu.devices.cdrom.set_cdrom(image);
         };
         await image.load();
     }
@@ -1015,7 +1015,7 @@ V86.prototype.set_cdrom = async function(file)
  */
 V86.prototype.eject_cdrom = function()
 {
-    this.v86.cpu.devices.cdrom.master.eject();
+    this.v86.cpu.devices.cdrom.eject();
 };
 
 /**

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -119,14 +119,6 @@ import { EEXIST, ENOENT } from "../../lib/9p.js";
  *   }
  *   ```
  *
- * In order to create a CD-ROM device with ejected disk use:
- *
- *   ```javascript
- *   cdrom: {
- *       ejected: true
- *   }
- *   ```
- *
  * @param {{
       disable_mouse: (boolean|undefined),
       disable_keyboard: (boolean|undefined),

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -537,8 +537,8 @@ CPU.prototype.get_state = function()
     state[53] = this.devices.ps2;
     state[54] = this.devices.uart0;
     state[55] = this.devices.fdc;
-    state[56] = this.devices.cdrom.channel;
-    state[57] = this.devices.hda? this.devices.hda.channel : undefined;
+    state[56] = this.devices.ide.secondary;
+    state[57] = this.devices.ide.primary ? this.devices.ide.primary : undefined;
     state[58] = this.devices.pit;
     state[59] = this.devices.net;
     state[60] = this.get_state_pic();
@@ -692,8 +692,8 @@ CPU.prototype.set_state = function(state)
     this.devices.ps2 && this.devices.ps2.set_state(state[53]);
     this.devices.uart0 && this.devices.uart0.set_state(state[54]);
     this.devices.fdc && this.devices.fdc.set_state(state[55]);
-    this.devices.cdrom && this.devices.cdrom.channel.set_state(state[56]);
-    this.devices.hda && this.devices.hda.channel.set_state(state[57]);
+    this.devices.ide.secondary.set_state(state[56]);
+    this.devices.ide.primary && this.devices.ide.primary.set_state(state[57]);
     this.devices.pit && this.devices.pit.set_state(state[58]);
     this.devices.net && this.devices.net.set_state(state[59]);
     this.set_state_pic(state[60]);
@@ -1105,19 +1105,14 @@ CPU.prototype.init = function(settings, device_bus)
 
         this.devices.fdc = new FloppyController(this, settings.fda, settings.fdb);
 
-        let cdrom_channel = 0;
         const ide_config = [[undefined, undefined], [undefined, undefined]];
         if(settings.hda) {
             ide_config[0][0] = {buffer: settings.hda};
             ide_config[0][1] = {buffer: settings.hdb};
-            cdrom_channel++;
         }
-        ide_config[cdrom_channel][0] = {is_cdrom: true, buffer: settings.cdrom};
+        ide_config[1][0] = {is_cdrom: true, buffer: settings.cdrom};
         this.devices.ide = new IDEController(this, device_bus, ide_config);
-        if(settings.hda) {
-            this.devices.hda = this.devices.ide.primary.master;
-        }
-        this.devices.cdrom = this.devices.ide.channels[cdrom_channel].master;
+        this.devices.cdrom = this.devices.ide.secondary.master;
 
         this.devices.pit = new PIT(this, device_bus);
 

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -29,7 +29,6 @@ import { PS2 } from "./ps2.js";
 import { read_elf } from "./elf.js";
 
 import { FloppyController } from "./floppy.js";
-/// import { IDEDevice } from "./ide.js";
 import { IDEPCIAdapter } from "./ide.js";
 import { VirtioNet } from "./virtio_net.js";
 import { VGAScreen } from "./vga.js";
@@ -1107,15 +1106,15 @@ CPU.prototype.init = function(settings, device_bus)
         this.devices.fdc = new FloppyController(this, settings.fda, settings.fdb);
 
         if(settings.hda || settings.cdrom) {
-            let ide_device_count = 0;
+            let cdrom_channel = 0;
             const ide_config = [[undefined, undefined], [undefined, undefined]];
             if(settings.hda) {
-                ide_config[ide_device_count][0] = {buffer: settings.hda};
-                ide_config[ide_device_count][1] = {buffer: settings.hdb};
-                ide_device_count++;
+                ide_config[0][0] = {buffer: settings.hda};
+                ide_config[0][1] = {buffer: settings.hdb};
+                cdrom_channel++;
             }
             if(settings.cdrom) {
-                ide_config[ide_device_count][0] = {
+                ide_config[cdrom_channel][0] = {
                     is_cdrom: true,
                     buffer: settings.cdrom.ejected ? undefined : settings.cdrom
                 };
@@ -1124,11 +1123,11 @@ CPU.prototype.init = function(settings, device_bus)
             this.devices.ide = new IDEPCIAdapter(this, device_bus, ide_config);
 
             if(settings.hda) {
-                this.devices.hda = this.devices.ide.primary;
+                this.devices.hda = this.devices.ide.channels[0];
 //                this.devices.hdb = ?  // TODO: this.devices.hda/hdb/cdrom should point to IDEInterface, not IDEDevice objects?!
             }
             if(settings.cdrom) {
-                this.devices.cdrom = settings.hda ? this.devices.ide.secondary : this.devices.ide.primary;
+                this.devices.cdrom = this.devices.ide.channels[cdrom_channel];
             }
         }
 

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -537,8 +537,8 @@ CPU.prototype.get_state = function()
     state[53] = this.devices.ps2;
     state[54] = this.devices.uart0;
     state[55] = this.devices.fdc;
-    state[56] = this.devices.cdrom;
-    state[57] = this.devices.hda;
+    state[56] = this.devices.cdrom.channel;
+    state[57] = this.devices.hda? this.devices.hda.channel : undefined;
     state[58] = this.devices.pit;
     state[59] = this.devices.net;
     state[60] = this.get_state_pic();
@@ -692,8 +692,8 @@ CPU.prototype.set_state = function(state)
     this.devices.ps2 && this.devices.ps2.set_state(state[53]);
     this.devices.uart0 && this.devices.uart0.set_state(state[54]);
     this.devices.fdc && this.devices.fdc.set_state(state[55]);
-    this.devices.cdrom && this.devices.cdrom.set_state(state[56]);
-    this.devices.hda && this.devices.hda.set_state(state[57]);
+    this.devices.cdrom && this.devices.cdrom.channel.set_state(state[56]);
+    this.devices.hda && this.devices.hda.channel.set_state(state[57]);
     this.devices.pit && this.devices.pit.set_state(state[58]);
     this.devices.net && this.devices.net.set_state(state[59]);
     this.set_state_pic(state[60]);
@@ -1105,24 +1105,19 @@ CPU.prototype.init = function(settings, device_bus)
 
         this.devices.fdc = new FloppyController(this, settings.fda, settings.fdb);
 
-        if(settings.hda || settings.cdrom) {
-            let cdrom_channel = 0;
-            const ide_config = [[undefined, undefined], [undefined, undefined]];
-            if(settings.hda) {
-                ide_config[0][0] = {buffer: settings.hda};
-                ide_config[0][1] = {buffer: settings.hdb};
-                cdrom_channel++;
-            }
-            ide_config[cdrom_channel][0] = {is_cdrom: true, buffer: settings.cdrom};
-
-            this.devices.ide = new IDEController(this, device_bus, ide_config);
-
-            if(settings.hda) {
-                this.devices.hda = this.devices.ide.channels[0];
-//                this.devices.hdb = ?  // TODO: this.devices.hda/hdb/cdrom should point to IDEInterface, not IDEDevice objects?!
-            }
-            this.devices.cdrom = this.devices.ide.channels[cdrom_channel];
+        let cdrom_channel = 0;
+        const ide_config = [[undefined, undefined], [undefined, undefined]];
+        if(settings.hda) {
+            ide_config[0][0] = {buffer: settings.hda};
+            ide_config[0][1] = {buffer: settings.hdb};
+            cdrom_channel++;
         }
+        ide_config[cdrom_channel][0] = {is_cdrom: true, buffer: settings.cdrom};
+        this.devices.ide = new IDEController(this, device_bus, ide_config);
+        if(settings.hda) {
+            this.devices.hda = this.devices.ide.primary.master;
+        }
+        this.devices.cdrom = this.devices.ide.channels[cdrom_channel].master;
 
         this.devices.pit = new PIT(this, device_bus);
 

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -1121,9 +1121,7 @@ CPU.prototype.init = function(settings, device_bus)
                 this.devices.hda = this.devices.ide.channels[0];
 //                this.devices.hdb = ?  // TODO: this.devices.hda/hdb/cdrom should point to IDEInterface, not IDEDevice objects?!
             }
-            if(settings.cdrom) {
-                this.devices.cdrom = this.devices.ide.channels[cdrom_channel];
-            }
+            this.devices.cdrom = this.devices.ide.channels[cdrom_channel];
         }
 
         this.devices.pit = new PIT(this, device_bus);

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -29,7 +29,7 @@ import { PS2 } from "./ps2.js";
 import { read_elf } from "./elf.js";
 
 import { FloppyController } from "./floppy.js";
-import { IDEPCIAdapter } from "./ide.js";
+import { IDEController } from "./ide.js";
 import { VirtioNet } from "./virtio_net.js";
 import { VGAScreen } from "./vga.js";
 import { VirtioBalloon } from "./virtio_balloon.js";
@@ -1120,7 +1120,7 @@ CPU.prototype.init = function(settings, device_bus)
                 };
             }
 
-            this.devices.ide = new IDEPCIAdapter(this, device_bus, ide_config);
+            this.devices.ide = new IDEController(this, device_bus, ide_config);
 
             if(settings.hda) {
                 this.devices.hda = this.devices.ide.channels[0];

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -1113,12 +1113,7 @@ CPU.prototype.init = function(settings, device_bus)
                 ide_config[0][1] = {buffer: settings.hdb};
                 cdrom_channel++;
             }
-            if(settings.cdrom) {
-                ide_config[cdrom_channel][0] = {
-                    is_cdrom: true,
-                    buffer: settings.cdrom.ejected ? undefined : settings.cdrom
-                };
-            }
+            ide_config[cdrom_channel][0] = {is_cdrom: true, buffer: settings.cdrom};
 
             this.devices.ide = new IDEController(this, device_bus, ide_config);
 

--- a/src/ide.js
+++ b/src/ide.js
@@ -981,32 +981,35 @@ IDEInterface.prototype.set_disk_buffer = function(buffer)
         this.cylinder_count = Math.floor(this.cylinder_count);
     }
 
-    // for CMOS see:
-    //   https://github.com/copy/v86/blob/master/src/rtc.js
-    //   https://github.com/coreboot/seabios/blob/master/src/hw/rtc.h
-    //   https://web.archive.org/web/20240119203005/http://www.bioscentral.com/misc/cmosmap.htm
-    const rtc = this.cpu.devices.rtc;
+    if(this.interface_nr === 0)
+    {
+        // for CMOS see:
+        //   https://github.com/copy/v86/blob/master/src/rtc.js
+        //   https://github.com/coreboot/seabios/blob/master/src/hw/rtc.h
+        //   https://web.archive.org/web/20240119203005/http://www.bioscentral.com/misc/cmosmap.htm
+        const rtc = this.cpu.devices.rtc;
 
-    // master
-    rtc.cmos_write(CMOS_BIOS_DISKTRANSFLAG,     // TODO: what is this doing, setting LBA translation?
-                   rtc.cmos_read(CMOS_BIOS_DISKTRANSFLAG) | 1 << this.channel_nr * 4);
+        // master
+        rtc.cmos_write(CMOS_BIOS_DISKTRANSFLAG,     // TODO: what is this doing, setting LBA translation?
+                       rtc.cmos_read(CMOS_BIOS_DISKTRANSFLAG) | 1 << this.channel_nr * 4);
 
-    // set hard disk type (CMOS_DISK_DATA = 0x12) of C: to 0b1111, keep type of D:
-    //   bits 0-3: hard disk type of D:
-    //   bits 4-7: hard disk type of C:
-    // TODO: should this not also set CMOS_DISK_DRIVE1_TYPE to a hard disk type (see SeaBIOS rtc.h)?
-    rtc.cmos_write(CMOS_DISK_DATA, rtc.cmos_read(CMOS_DISK_DATA) & 0x0F | 0xF0);
+        // set hard disk type (CMOS_DISK_DATA = 0x12) of C: to 0b1111, keep type of D:
+        //   bits 0-3: hard disk type of D:
+        //   bits 4-7: hard disk type of C:
+        // TODO: should this not also set CMOS_DISK_DRIVE1_TYPE to a hard disk type (see SeaBIOS rtc.h)?
+        rtc.cmos_write(CMOS_DISK_DATA, rtc.cmos_read(CMOS_DISK_DATA) & 0x0F | 0xF0);
 
-    const drive_reg = this.channel_nr === 0 ? CMOS_DISK_DRIVE1_CYL : CMOS_DISK_DRIVE2_CYL;  // 0x1B : 0x24 (drive C: or D:)
-    rtc.cmos_write(drive_reg + 0, this.cylinder_count & 0xFF);        // number of cylinders least significant byte
-    rtc.cmos_write(drive_reg + 1, this.cylinder_count >> 8 & 0xFF);   // number of cylinders most significant byte
-    rtc.cmos_write(drive_reg + 2, this.head_count & 0xFF);            // number of heads
-    rtc.cmos_write(drive_reg + 3, 0xFF);                              // write precomp cylinder least significant byte
-    rtc.cmos_write(drive_reg + 4, 0xFF);                              // write precomp cylinder most significant byte
-    rtc.cmos_write(drive_reg + 5, 0xC8);                              // control byte
-    rtc.cmos_write(drive_reg + 6, this.cylinder_count & 0xFF);        // landing zone least significant byte
-    rtc.cmos_write(drive_reg + 7, this.cylinder_count >> 8 & 0xFF);   // landing zone most significant byte
-    rtc.cmos_write(drive_reg + 8, this.sectors_per_track & 0xFF);     // number of sectors
+        const drive_reg = this.channel_nr === 0 ? CMOS_DISK_DRIVE1_CYL : CMOS_DISK_DRIVE2_CYL;  // 0x1B : 0x24 (drive C: or D:)
+        rtc.cmos_write(drive_reg + 0, this.cylinder_count & 0xFF);        // number of cylinders least significant byte
+        rtc.cmos_write(drive_reg + 1, this.cylinder_count >> 8 & 0xFF);   // number of cylinders most significant byte
+        rtc.cmos_write(drive_reg + 2, this.head_count & 0xFF);            // number of heads
+        rtc.cmos_write(drive_reg + 3, 0xFF);                              // write precomp cylinder least significant byte
+        rtc.cmos_write(drive_reg + 4, 0xFF);                              // write precomp cylinder most significant byte
+        rtc.cmos_write(drive_reg + 5, 0xC8);                              // control byte
+        rtc.cmos_write(drive_reg + 6, this.cylinder_count & 0xFF);        // landing zone least significant byte
+        rtc.cmos_write(drive_reg + 7, this.cylinder_count >> 8 & 0xFF);   // landing zone most significant byte
+        rtc.cmos_write(drive_reg + 8, this.sectors_per_track & 0xFF);     // number of sectors
+    }
 
     if(this.channel.cpu)
     {

--- a/src/ide.js
+++ b/src/ide.js
@@ -713,7 +713,7 @@ IDEInterface.prototype.set_cdrom = function(buffer)
                    rtc.cmos_read(CMOS_BIOS_DISKTRANSFLAG) | 1 << this.nr * 4);
     rtc.cmos_write(CMOS_DISK_DATA, rtc.cmos_read(CMOS_DISK_DATA) & 0x0F | 0xF0);
 
-    var reg = this.nr == 0 ? CMOS_DISK_DRIVE1_CYL : CMOS_DISK_DRIVE2_CYL;
+    var reg = this.nr === 0 ? CMOS_DISK_DRIVE1_CYL : CMOS_DISK_DRIVE2_CYL;
     rtc.cmos_write(reg + 0, this.cylinder_count & 0xFF);
     rtc.cmos_write(reg + 1, this.cylinder_count >> 8 & 0xFF);
     rtc.cmos_write(reg + 2, this.head_count & 0xFF);
@@ -764,7 +764,7 @@ IDEInterface.prototype.ata_command = function(cmd)
 {
     dbg_log("ATA Command: " + h(cmd) + " slave=" + (this.drive_head >> 4 & 1), LOG_DISK);
 
-    if(!this.drive_connected && cmd != 0x90)
+    if(!this.drive_connected && cmd !== 0x90)
     {
         dbg_log("ignored: No slave drive connected", LOG_DISK);
         return;
@@ -1010,11 +1010,11 @@ IDEInterface.prototype.atapi_handle = function()
 
     this.data_pointer = 0;
     this.current_atapi_command = this.data[0];
-    if(!this.buffer && (this.current_atapi_command == 0x25 ||
-                        this.current_atapi_command == 0x28 ||
-                        this.current_atapi_command == 0x42 ||
-                        this.current_atapi_command == 0x43 ||
-                        this.current_atapi_command == 0x51))
+    if(!this.buffer && (this.current_atapi_command === 0x25 ||
+                        this.current_atapi_command === 0x28 ||
+                        this.current_atapi_command === 0x42 ||
+                        this.current_atapi_command === 0x43 ||
+                        this.current_atapi_command === 0x51))
     {
         dbg_log("dev "+this.device.name+" CD read-related action: no buffer", LOG_DISK);
         this.status = 0x51;

--- a/src/ide.js
+++ b/src/ide.js
@@ -340,7 +340,7 @@ IDEDevice.prototype.read_status = function()
 {
     /// temporary hack to indicate missing slave drive to host
     /// const ret = this.current_interface.status;
-    const ret = this.current_interface.is_atapi || this.current_interface.buffer ? this.current_interface.status : 0;
+    const ret = this.current_interface.drive_connected ? this.current_interface.status : 0;
     dbg_log("dev "+this.name+" ATA read status: " + h(ret, 2), LOG_DISK);
     return ret;
 };
@@ -520,6 +520,9 @@ function IDEInterface(device, cpu, buffer, is_cd, device_nr, interface_nr, bus)
     this.cpu = cpu;
 
     this.buffer = null;
+
+    /** @type {boolean} */
+    this.drive_connected = is_cd || buffer;
 
     /** @type {number} */
     this.sector_size = is_cd ? CDROM_SECTOR_SIZE : HD_SECTOR_SIZE;

--- a/src/ide.js
+++ b/src/ide.js
@@ -614,7 +614,7 @@ function IDEInterface(channel, cpu, buffer, is_cd, channel_nr, interface_nr, bus
      * @const
      * @type {number}
      */
-    this.nr = channel_nr;
+    this.channel_nr = channel_nr;
 
     /**
      * @const
@@ -786,22 +786,32 @@ IDEInterface.prototype.set_disk_buffer = function(buffer)
         this.cylinder_count = Math.floor(this.cylinder_count);
     }
 
-    var rtc = this.cpu.devices.rtc;
+    // for CMOS see:
+    //   https://github.com/copy/v86/blob/master/src/rtc.js
+    //   https://github.com/coreboot/seabios/blob/master/src/hw/rtc.h
+    //   https://web.archive.org/web/20240119203005/http://www.bioscentral.com/misc/cmosmap.htm
+    const rtc = this.cpu.devices.rtc;
+
     // master
-    rtc.cmos_write(CMOS_BIOS_DISKTRANSFLAG,
-                   rtc.cmos_read(CMOS_BIOS_DISKTRANSFLAG) | 1 << this.nr * 4);
+    rtc.cmos_write(CMOS_BIOS_DISKTRANSFLAG,     // TODO: what is this doing, setting LBA translation?
+                   rtc.cmos_read(CMOS_BIOS_DISKTRANSFLAG) | 1 << this.channel_nr * 4);
+
+    // set hard disk type (CMOS_DISK_DATA = 0x12) of C: to 0b1111, keep type of D:
+    //   bits 0-3: hard disk type of D:
+    //   bits 4-7: hard disk type of C:
+    // TODO: should this not also set CMOS_DISK_DRIVE1_TYPE to a hard disk type (see SeaBIOS rtc.h)?
     rtc.cmos_write(CMOS_DISK_DATA, rtc.cmos_read(CMOS_DISK_DATA) & 0x0F | 0xF0);
 
-    var reg = this.nr === 0 ? CMOS_DISK_DRIVE1_CYL : CMOS_DISK_DRIVE2_CYL;
-    rtc.cmos_write(reg + 0, this.cylinder_count & 0xFF);
-    rtc.cmos_write(reg + 1, this.cylinder_count >> 8 & 0xFF);
-    rtc.cmos_write(reg + 2, this.head_count & 0xFF);
-    rtc.cmos_write(reg + 3, 0xFF);
-    rtc.cmos_write(reg + 4, 0xFF);
-    rtc.cmos_write(reg + 5, 0xC8);
-    rtc.cmos_write(reg + 6, this.cylinder_count & 0xFF);
-    rtc.cmos_write(reg + 7, this.cylinder_count >> 8 & 0xFF);
-    rtc.cmos_write(reg + 8, this.sectors_per_track & 0xFF);
+    const drive_reg = this.channel_nr === 0 ? CMOS_DISK_DRIVE1_CYL : CMOS_DISK_DRIVE2_CYL;  // 0x1B : 0x24 (drive C: or D:)
+    rtc.cmos_write(drive_reg + 0, this.cylinder_count & 0xFF);        // number of cylinders least significant byte
+    rtc.cmos_write(drive_reg + 1, this.cylinder_count >> 8 & 0xFF);   // number of cylinders most significant byte
+    rtc.cmos_write(drive_reg + 2, this.head_count & 0xFF);            // number of heads
+    rtc.cmos_write(drive_reg + 3, 0xFF);                              // write precomp cylinder least significant byte
+    rtc.cmos_write(drive_reg + 4, 0xFF);                              // write precomp cylinder most significant byte
+    rtc.cmos_write(drive_reg + 5, 0xC8);                              // control byte
+    rtc.cmos_write(drive_reg + 6, this.cylinder_count & 0xFF);        // landing zone least significant byte
+    rtc.cmos_write(drive_reg + 7, this.cylinder_count >> 8 & 0xFF);   // landing zone most significant byte
+    rtc.cmos_write(drive_reg + 8, this.sectors_per_track & 0xFF);     // number of sectors
 
     if(this.channel.cpu)
     {
@@ -2214,13 +2224,13 @@ IDEInterface.prototype.report_read_start = function()
 IDEInterface.prototype.report_read_end = function(byte_count)
 {
     const sector_count = byte_count / this.sector_size | 0;
-    this.bus.send("ide-read-end", [this.nr, byte_count, sector_count]);
+    this.bus.send("ide-read-end", [this.channel_nr, byte_count, sector_count]);
 };
 
 IDEInterface.prototype.report_write = function(byte_count)
 {
     const sector_count = byte_count / this.sector_size | 0;
-    this.bus.send("ide-write-end", [this.nr, byte_count, sector_count]);
+    this.bus.send("ide-write-end", [this.channel_nr, byte_count, sector_count]);
 };
 
 IDEInterface.prototype.read_buffer = function(start, length, callback)

--- a/src/ide.js
+++ b/src/ide.js
@@ -17,6 +17,9 @@ import { BusConnector } from "./bus.js";
 //   PROPOSAL FOR CD-ROM IN SCSI-2 (X3T9.2/87) (Rev. 0, Jun. 30, 1987)
 //   https://www.t10.org/ftp/x3t9.2/document.87/87-106r0.txt
 //   https://www.t10.org/ftp/x3t9.2/document.87/87-106r1.txt (errata to r0)
+// - [MMC-2]
+//   Packet Commands for C/DVD Devices (1997)
+//   https://www.t10.org/ftp/t10/document.97/97-108r0.pdf
 
 const CDROM_SECTOR_SIZE = 2048;
 const HD_SECTOR_SIZE = 512;
@@ -70,56 +73,56 @@ const ATA_CR_HOB  = 0x80;  // 48-bit Address feature set
 
 // ATA commands
 const ATA_CMD_DEVICE_RESET = 0x08;                    // see [ATA-6] 8.10 and 9.11
-const ATA_CMD_10h = 0x10;                             // command obsolete, see [ATA-6] Table E.2
+const ATA_CMD_EXECUTE_DEVICE_DIAGNOSTIC = 0x90;       // see [ATA-6] 8.11
+const ATA_CMD_FLUSH_CACHE = 0xE7;                     // see [ATA-6] 8.12
+const ATA_CMD_FLUSH_CACHE_EXT = 0xEA;                 // see [ATA-6] 8.13
+const ATA_CMD_GET_MEDIA_STATUS = 0xDA;                // see [ATA-6] 8.14
+const ATA_CMD_IDENTIFY_DEVICE = 0xEC;                 // see [ATA-6] 8.15
+const ATA_CMD_IDENTIFY_PACKET_DEVICE = 0xA1;          // see [ATA-6] 8.16
+const ATA_CMD_IDLE_IMMEDIATE = 0xE1;                  // see [ATA-6] 8.18
+const ATA_CMD_INITIALIZE_DEVICE_PARAMETERS = 0x91;    // not mentioned in [ATA-6]
+const ATA_CMD_MEDIA_LOCK = 0xDE;                      // see [ATA-6] 8.20
+const ATA_CMD_PACKET = 0xA0;                          // see [ATA-6] 8.23
+const ATA_CMD_READ_DMA = 0xC8;                        // see [ATA-6] 8.26
+const ATA_CMD_READ_DMA_EXT = 0x25;                    // see [ATA-6] 8.25
+const ATA_CMD_READ_MULTIPLE = 0x29;                   // see [ATA-6] 8.30
+const ATA_CMD_READ_MULTIPLE_EXT = 0xC4;               // see [ATA-6] 8.31
 const ATA_CMD_READ_NATIVE_MAX_ADDRESS = 0xF8;         // see [ATA-6] 8.32
 const ATA_CMD_READ_NATIVE_MAX_ADDRESS_EXT = 0x27;     // see [ATA-6] 8.33
 const ATA_CMD_READ_SECTORS = 0x20;                    // see [ATA-6] 8.34
 const ATA_CMD_READ_SECTORS_EXT = 0x24;                // see [ATA-6] 8.35
-const ATA_CMD_READ_MULTIPLE = 0x29;                   // see [ATA-6] 8.30
-const ATA_CMD_READ_MULTIPLE_EXT = 0xC4;               // see [ATA-6] 8.31
-const ATA_CMD_WRITE_SECTORS = 0x30;                   // see [ATA-6] 8.62
-const ATA_CMD_WRITE_SECTORS_EXT = 0x34;               // see [ATA-6] 8.63
-const ATA_CMD_WRITE_MULTIPLE = 0x39;                  // see [ATA-6] 8.60
-const ATA_CMD_WRITE_MULTIPLE_EXT = 0xC5;              // see [ATA-6] 8.61
-const ATA_CMD_EXECUTE_DEVICE_DIAGNOSTIC = 0x90;       // see [ATA-6] 8.11
-const ATA_CMD_INITIALIZE_DEVICE_PARAMETERS = 0x91;    // not mentioned in [ATA-6]
-const ATA_CMD_PACKET = 0xA0;                          // see [ATA-6] 8.23
-const ATA_CMD_IDENTIFY_PACKET_DEVICE = 0xA1;          // see [ATA-6] 8.16
+const ATA_CMD_READ_VERIFY_SECTORS = 0x40;             // see [ATA-6] 8.36
+const ATA_CMD_SECURITY_FREEZE_LOCK = 0xF5;            // see [ATA-6] 8.41
+const ATA_CMD_SET_FEATURES = 0xEF;                    // see [ATA-6] 8.46
+const ATA_CMD_SET_MAX = 0xF9;                         // see [ATA-6] 8.47
 const ATA_CMD_SET_MULTIPLE_MODE = 0xC6;               // see [ATA-6] 8.49
-const ATA_CMD_READ_DMA = 0xC8;                        // see [ATA-6] 8.26
-const ATA_CMD_READ_DMA_EXT = 0x25;                    // see [ATA-6] 8.25
+const ATA_CMD_STANDBY_IMMEDIATE = 0xE0;               // see [ATA-6] 8.53
 const ATA_CMD_WRITE_DMA = 0xCA;                       // see [ATA-6] 8.55
 const ATA_CMD_WRITE_DMA_EXT = 0x35;                   // see [ATA-6] 8.56
-const ATA_CMD_READ_VERIFY_SECTORS = 0x40;             // see [ATA-6] 8.36
-const ATA_CMD_GET_MEDIA_STATUS = 0xDA;                // see [ATA-6] 8.14
-const ATA_CMD_STANDBY_IMMEDIATE = 0xE0;               // see [ATA-6] 8.53
-const ATA_CMD_IDLE_IMMEDIATE = 0xE1;                  // see [ATA-6] 8.18
-const ATA_CMD_FLUSH_CACHE = 0xE7;                     // see [ATA-6] 8.12
-const ATA_CMD_FLUSH_CACHE_EXT = 0xEA;                 // see [ATA-6] 8.13
-const ATA_CMD_IDENTIFY_DEVICE = 0xEC;                 // see [ATA-6] 8.15
-const ATA_CMD_SET_FEATURES = 0xEF;                    // see [ATA-6] 8.46
-const ATA_CMD_MEDIA_LOCK = 0xDE;                      // see [ATA-6] 8.20
-const ATA_CMD_SECURITY_FREEZE_LOCK = 0xF5;            // see [ATA-6] 8.41
-const ATA_CMD_SET_MAX = 0xF9;                         // see [ATA-6] 8.47
+const ATA_CMD_WRITE_MULTIPLE = 0x39;                  // see [ATA-6] 8.60
+const ATA_CMD_WRITE_MULTIPLE_EXT = 0xC5;              // see [ATA-6] 8.61
+const ATA_CMD_WRITE_SECTORS = 0x30;                   // see [ATA-6] 8.62
+const ATA_CMD_WRITE_SECTORS_EXT = 0x34;               // see [ATA-6] 8.63
+const ATA_CMD_10h = 0x10;                             // command obsolete/unknown, see [ATA-6] Table E.2
 
-// ATAPI (SCSI-2) commands, see [CD-SCSI-2]
-const ATAPI_CMD_TEST_UNIT_READY = 0x00;
-const ATAPI_CMD_REQUEST_SENSE = 0x03;
-const ATAPI_CMD_INQUIRY = 0x12;
-const ATAPI_CMD_MODE_SENSE_6 = 0x1A;
-const ATAPI_CMD_MODE_SENSE_10 = 0x5A;
-const ATAPI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL = 0x1E;
-const ATAPI_CMD_READ_CAPACITY = 0x25;
-const ATAPI_CMD_READ = 0x28;
-const ATAPI_CMD_READ_SUBCHANNEL = 0x42;
-const ATAPI_CMD_READ_TOC_PMA_ATIP = 0x43;
-const ATAPI_CMD_GET_CONFIGURATION = 0x46;
-const ATAPI_CMD_READ_DISK_INFORMATION = 0x51;
-const ATAPI_CMD_READ_TRACK_INFORMATION = 0x52;
-const ATAPI_CMD_MECHANISM_STATUS = 0xBD;
-const ATAPI_CMD_GET_EVENT_STATUS_NOTIFICATION = 0x4A;
-const ATAPI_CMD_READ_CD = 0xBE;
-//const ATAPI_CMD_LOAD_UNLOAD_MEDIUM = 0xA6;    // TODO: not implemented, might be useful
+// ATAPI (SCSI-2/MMC-2) commands
+const ATAPI_CMD_GET_CONFIGURATION = 0x46;             // see [CD-SCSI-2]
+const ATAPI_CMD_GET_EVENT_STATUS_NOTIFICATION = 0x4A; // see [MMC-2] 9.1.2
+const ATAPI_CMD_INQUIRY = 0x12;                       // see [MMC-2] 9.1.3
+//const ATAPI_CMD_LOAD_UNLOAD_MEDIUM = 0xA6;          // see [MMC-2] 9.1.4 -- TODO: not implemented, might be useful
+const ATAPI_CMD_MECHANISM_STATUS = 0xBD;              // see [MMC-2] 9.1.5
+const ATAPI_CMD_MODE_SENSE_6 = 0x1A;                  // see [CD-SCSI-2]
+const ATAPI_CMD_MODE_SENSE_10 = 0x5A;                 // see [MMC-2] 9.1.7
+const ATAPI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL = 0x1E;  // see [MMC-2] 9.1.9
+const ATAPI_CMD_READ = 0x28;                          // see [CD-SCSI-2]
+const ATAPI_CMD_READ_CAPACITY = 0x25;                 // see [MMC-2] 9.1.12
+const ATAPI_CMD_READ_CD = 0xBE;                       // see [CD-SCSI-2]
+const ATAPI_CMD_READ_DISK_INFORMATION = 0x51;         // see [CD-SCSI-2]
+const ATAPI_CMD_READ_SUBCHANNEL = 0x42;               // see [CD-SCSI-2]
+const ATAPI_CMD_READ_TOC_PMA_ATIP = 0x43;             // see [CD-SCSI-2]
+const ATAPI_CMD_READ_TRACK_INFORMATION = 0x52;        // see [CD-SCSI-2]
+const ATAPI_CMD_REQUEST_SENSE = 0x03;                 // see [MMC-2] 9.1.18
+const ATAPI_CMD_TEST_UNIT_READY = 0x00;               // see [MMC-2] 9.1.20
 
 /**
  * @constructor

--- a/src/ide.js
+++ b/src/ide.js
@@ -167,6 +167,7 @@ const ATAPI_CMD_INQUIRY = 0x12;                       // see [MMC-2] 9.1.3
 const ATAPI_CMD_MECHANISM_STATUS = 0xBD;              // see [MMC-2] 9.1.5
 const ATAPI_CMD_MODE_SENSE_6 = 0x1A;                  // see [CD-SCSI-2]
 const ATAPI_CMD_MODE_SENSE_10 = 0x5A;                 // see [MMC-2] 9.1.7
+const ATAPI_CMD_PAUSE = 0x45;                         // see [CD-SCSI-2]
 const ATAPI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL = 0x1E;  // see [MMC-2] 9.1.9
 const ATAPI_CMD_READ = 0x28;                          // see [CD-SCSI-2]
 const ATAPI_CMD_READ_CAPACITY = 0x25;                 // see [MMC-2] 9.1.12
@@ -191,6 +192,7 @@ const ATAPI_CMD =
     [ATAPI_CMD_MECHANISM_STATUS]:              {name: "MECHANISM STATUS",              flags: ATAPI_CF_NONE},
     [ATAPI_CMD_MODE_SENSE_6]:                  {name: "MODE SENSE (6)",                flags: ATAPI_CF_NONE},
     [ATAPI_CMD_MODE_SENSE_10]:                 {name: "MODE SENSE (10)",               flags: ATAPI_CF_NONE},
+    [ATAPI_CMD_PAUSE]:                         {name: "PAUSE",                         flags: ATAPI_CF_NONE},
     [ATAPI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL]:  {name: "PREVENT ALLOW MEDIUM REMOVAL",  flags: ATAPI_CF_NONE},
     [ATAPI_CMD_READ]:                          {name: "READ",                          flags: ATAPI_CF_NEEDS_DISK},
     [ATAPI_CMD_READ_CAPACITY]:                 {name: "READ CAPACITY",                 flags: ATAPI_CF_NEEDS_DISK},
@@ -1530,6 +1532,7 @@ IDEInterface.prototype.atapi_handle = function()
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC|ATA_SR_DRQ;
             break;
 
+        case ATAPI_CMD_PAUSE:
         case ATAPI_CMD_GET_EVENT_STATUS_NOTIFICATION:
             dbg_log_extra = "unimplemented";
             this.atapi_check_condition_response(ATAPI_SK_ILLEGAL_REQUEST, ATAPI_ASC_INV_FIELD_IN_CMD_PACKET);

--- a/src/ide.js
+++ b/src/ide.js
@@ -1856,7 +1856,14 @@ IDEInterface.prototype.ata_read_sectors = function(cmd)
             " lbacount=" + h(count) +
             " bytecount=" + h(byte_count), LOG_DISK);
 
-    if(start + byte_count > this.buffer.byteLength)
+    if(!this.buffer)
+    {
+        // TODO: Windows 95 treats our (empty) CD-ROM device as an ATA device, maybe a driver issue?
+        this.error_reg = ATA_ER_ABRT;
+        this.status_reg = ATA_SR_DRDY|ATA_SR_ERR;
+        this.push_irq();
+    }
+    else if(start + byte_count > this.buffer.byteLength)
     {
         dbg_assert(false, this.name + ": ATA read: Outside of disk", LOG_DISK);
 

--- a/src/ide.js
+++ b/src/ide.js
@@ -886,6 +886,11 @@ IDEInterface.prototype.init_interface = function()
     }
 };
 
+IDEInterface.prototype.has_disk = function()
+{
+    return this.buffer;
+};
+
 IDEInterface.prototype.eject = function()
 {
     if(this.is_atapi && this.buffer)

--- a/src/ide.js
+++ b/src/ide.js
@@ -502,13 +502,13 @@ IDEChannel.prototype.write_control = function(data)
 
 IDEChannel.prototype.dma_read_addr = function()
 {
-    dbg_log(this.current_interface.name + ": DMA get address: " + h(this.prdt_addr, 8), LOG_DISK);
+    //dbg_log(this.current_interface.name + ": DMA get address: " + h(this.prdt_addr, 8), LOG_DISK);
     return this.prdt_addr;
 };
 
 IDEChannel.prototype.dma_set_addr = function(data)
 {
-    dbg_log(this.current_interface.name + ": DMA set address: " + h(data, 8), LOG_DISK);
+    //dbg_log(this.current_interface.name + ": DMA set address: " + h(data, 8), LOG_DISK);
     this.prdt_addr = data;
 };
 
@@ -531,21 +531,20 @@ IDEChannel.prototype.dma_read_command = function()
 
 IDEChannel.prototype.dma_read_command8 = function()
 {
-    dbg_log(this.current_interface.name + ": DMA read command: " + h(this.dma_command), LOG_DISK);
+    //dbg_log(this.current_interface.name + ": DMA read command: " + h(this.dma_command), LOG_DISK);
     return this.dma_command;
 };
 
 IDEChannel.prototype.dma_write_command = function(value)
 {
-    dbg_log(this.current_interface.name + ": DMA write command: " + h(value), LOG_DISK);
-
+    //dbg_log(this.current_interface.name + ": DMA write command: " + h(value), LOG_DISK);
     this.dma_write_command8(value & 0xFF);
     this.dma_write_status(value >> 16 & 0xFF);
 };
 
 IDEChannel.prototype.dma_write_command8 = function(value)
 {
-    dbg_log(this.current_interface.name + ": DMA write command8: " + h(value), LOG_DISK);
+    //dbg_log(this.current_interface.name + ": DMA write command8: " + h(value), LOG_DISK);
 
     const old_command = this.dma_command;
     this.dma_command = value & 0x09;

--- a/src/ide.js
+++ b/src/ide.js
@@ -888,7 +888,7 @@ IDEInterface.prototype.init_interface = function()
 
 IDEInterface.prototype.has_disk = function()
 {
-    return this.buffer;
+    return !!this.buffer;
 };
 
 IDEInterface.prototype.eject = function()

--- a/src/ide.js
+++ b/src/ide.js
@@ -90,6 +90,7 @@ const ATA_CMD_IDENTIFY_PACKET_DEVICE = 0xA1;          // see [ATA-6] 8.16
 const ATA_CMD_IDLE_IMMEDIATE = 0xE1;                  // see [ATA-6] 8.18
 const ATA_CMD_INITIALIZE_DEVICE_PARAMETERS = 0x91;    // not mentioned in [ATA-6]
 const ATA_CMD_MEDIA_LOCK = 0xDE;                      // see [ATA-6] 8.20
+const ATA_CMD_NOP = 0x00;                             // see [ATA-6] 8.22
 const ATA_CMD_PACKET = 0xA0;                          // see [ATA-6] 8.23
 const ATA_CMD_READ_DMA = 0xC8;                        // see [ATA-6] 8.26
 const ATA_CMD_READ_DMA_EXT = 0x25;                    // see [ATA-6] 8.25
@@ -1114,6 +1115,13 @@ IDEInterface.prototype.ata_command = function(cmd)
 
         case ATA_CMD_SET_MAX:
             dbg_log(this.name + ": ATA set max address (unimplemented)", LOG_DISK);
+            this.error_reg = ATA_ER_ABRT;
+            this.status_reg = ATA_SR_DRDY|ATA_SR_ERR;
+            this.push_irq();
+            break;
+
+        case ATA_CMD_NOP:
+            dbg_log(this.name + ": ATA nop", LOG_DISK);
             this.error_reg = ATA_ER_ABRT;
             this.status_reg = ATA_SR_DRDY|ATA_SR_ERR;
             this.push_irq();

--- a/src/ide.js
+++ b/src/ide.js
@@ -49,7 +49,7 @@ export function IDEPCIAdapter(cpu, bus, adapter_config)
     const has_primary = adapter_config && adapter_config[0][0];
     const has_secondary = adapter_config && adapter_config[1][0];
     if(!has_primary && !has_secondary) {
-        DEBUG && Object.seal(this);
+        Object.seal(this);
         return;
     }
     if(has_primary) {
@@ -115,7 +115,7 @@ export function IDEPCIAdapter(cpu, bus, adapter_config)
     ];
     cpu.devices.pci.register_device(this);
 
-    DEBUG && Object.seal(this);
+    Object.seal(this);
 }
 
 /**
@@ -371,7 +371,7 @@ function IDEDevice(adapter, adapter_config, channel_nr, channel_config)     // T
     cpu.io.register_read(bus_master_port | 4, this, undefined, undefined, this.dma_read_addr);
     cpu.io.register_write(bus_master_port | 4, this, undefined, undefined, this.dma_set_addr);
 
-    Object.seal(this);
+    DEBUG && Object.seal(this);
 }
 
 IDEDevice.prototype.read_status = function()
@@ -508,7 +508,7 @@ IDEDevice.prototype.get_state = function()
     state[1] = this.slave;
     state[2] = this.ata_port;
     state[3] = this.irq;
-    state[4] = this.pci_id;
+    // state[4] = this.pci_id;
     state[5] = this.ata_port_high;
     // state[6] = this.bus_master_port;
     state[7] = this.name;
@@ -526,7 +526,7 @@ IDEDevice.prototype.set_state = function(state)
     this.slave.set_state(state[1]);
     this.ata_port = state[2];
     this.irq = state[3];
-    this.pci_id = state[4];
+    // this.pci_id = state[4];
     this.ata_port_high = state[5];
     // this.bus_master_port = state[6];
     this.name = state[7];

--- a/src/ide.js
+++ b/src/ide.js
@@ -114,11 +114,47 @@ const ATA_CMD_WRITE_SECTORS = 0x30;                   // see [ATA-6] 8.62
 const ATA_CMD_WRITE_SECTORS_EXT = 0x34;               // see [ATA-6] 8.63
 const ATA_CMD_10h = 0x10;                             // command obsolete/unknown, see [ATA-6] Table E.2
 
+const ATA_CMD_NAME =
+{
+    [ATA_CMD_DEVICE_RESET]:                 "DEVICE RESET",
+    [ATA_CMD_EXECUTE_DEVICE_DIAGNOSTIC]:    "EXECUTE DEVICE DIAGNOSTIC",
+    [ATA_CMD_FLUSH_CACHE]:                  "FLUSH CACHE",
+    [ATA_CMD_FLUSH_CACHE_EXT]:              "FLUSH CACHE EXT",
+    [ATA_CMD_GET_MEDIA_STATUS]:             "GET MEDIA STATUS",
+    [ATA_CMD_IDENTIFY_DEVICE]:              "IDENTIFY DEVICE",
+    [ATA_CMD_IDENTIFY_PACKET_DEVICE]:       "IDENTIFY PACKET DEVICE",
+    [ATA_CMD_IDLE_IMMEDIATE]:               "IDLE IMMEDIATE",
+    [ATA_CMD_INITIALIZE_DEVICE_PARAMETERS]: "INITIALIZE DEVICE PARAMETERS",
+    [ATA_CMD_MEDIA_LOCK]:                   "MEDIA LOCK",
+    [ATA_CMD_NOP]:                          "NOP",
+    [ATA_CMD_PACKET]:                       "PACKET",
+    [ATA_CMD_READ_DMA]:                     "READ DMA",
+    [ATA_CMD_READ_DMA_EXT]:                 "READ DMA EXT",
+    [ATA_CMD_READ_MULTIPLE]:                "READ MULTIPLE",
+    [ATA_CMD_READ_MULTIPLE_EXT]:            "READ MULTIPLE EXT",
+    [ATA_CMD_READ_NATIVE_MAX_ADDRESS]:      "READ NATIVE MAX ADDRESS",
+    [ATA_CMD_READ_NATIVE_MAX_ADDRESS_EXT]:  "READ NATIVE MAX ADDRESS EXT",
+    [ATA_CMD_READ_SECTORS]:                 "READ SECTORS",
+    [ATA_CMD_READ_SECTORS_EXT]:             "READ SECTORS EXT",
+    [ATA_CMD_READ_VERIFY_SECTORS]:          "READ VERIFY SECTORS",
+    [ATA_CMD_SECURITY_FREEZE_LOCK]:         "SECURITY FREEZE LOCK",
+    [ATA_CMD_SET_FEATURES]:                 "SET FEATURES",
+    [ATA_CMD_SET_MAX]:                      "SET MAX",
+    [ATA_CMD_SET_MULTIPLE_MODE]:            "SET MULTIPLE MODE",
+    [ATA_CMD_STANDBY_IMMEDIATE]:            "STANDBY IMMEDIATE",
+    [ATA_CMD_WRITE_DMA]:                    "WRITE DMA",
+    [ATA_CMD_WRITE_DMA_EXT]:                "WRITE DMA EXT",
+    [ATA_CMD_WRITE_MULTIPLE]:               "WRITE MULTIPLE",
+    [ATA_CMD_WRITE_MULTIPLE_EXT]:           "WRITE MULTIPLE EXT",
+    [ATA_CMD_WRITE_SECTORS]:                "WRITE SECTORS",
+    [ATA_CMD_WRITE_SECTORS_EXT]:            "WRITE SECTORS EXT",
+    [ATA_CMD_10h]:                          "<UNKWNON 10h>",
+};
+
 // ATAPI (SCSI-2/MMC-2) commands
 const ATAPI_CMD_GET_CONFIGURATION = 0x46;             // see [CD-SCSI-2]
 const ATAPI_CMD_GET_EVENT_STATUS_NOTIFICATION = 0x4A; // see [MMC-2] 9.1.2
 const ATAPI_CMD_INQUIRY = 0x12;                       // see [MMC-2] 9.1.3
-//const ATAPI_CMD_LOAD_UNLOAD_MEDIUM = 0xA6;          // see [MMC-2] 9.1.4 -- TODO: not implemented, might be useful
 const ATAPI_CMD_MECHANISM_STATUS = 0xBD;              // see [MMC-2] 9.1.5
 const ATAPI_CMD_MODE_SENSE_6 = 0x1A;                  // see [CD-SCSI-2]
 const ATAPI_CMD_MODE_SENSE_10 = 0x5A;                 // see [MMC-2] 9.1.7
@@ -132,6 +168,26 @@ const ATAPI_CMD_READ_TOC_PMA_ATIP = 0x43;             // see [CD-SCSI-2]
 const ATAPI_CMD_READ_TRACK_INFORMATION = 0x52;        // see [CD-SCSI-2]
 const ATAPI_CMD_REQUEST_SENSE = 0x03;                 // see [MMC-2] 9.1.18
 const ATAPI_CMD_TEST_UNIT_READY = 0x00;               // see [MMC-2] 9.1.20
+
+const ATAPI_CMD_NAME =
+{
+    [ATAPI_CMD_GET_CONFIGURATION]:             "GET CONFIGURATION",
+    [ATAPI_CMD_GET_EVENT_STATUS_NOTIFICATION]: "GET EVENT STATUS NOTIFICATION",
+    [ATAPI_CMD_INQUIRY]:                       "INQUIRY",
+    [ATAPI_CMD_MECHANISM_STATUS]:              "MECHANISM STATUS",
+    [ATAPI_CMD_MODE_SENSE_6]:                  "MODE SENSE (6)",
+    [ATAPI_CMD_MODE_SENSE_10]:                 "MODE SENSE (10)",
+    [ATAPI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL]:  "PREVENT ALLOW MEDIUM REMOVAL",
+    [ATAPI_CMD_READ]:                          "READ",
+    [ATAPI_CMD_READ_CAPACITY]:                 "READ CAPACITY",
+    [ATAPI_CMD_READ_CD]:                       "READ CD",
+    [ATAPI_CMD_READ_DISK_INFORMATION]:         "READ DISK INFORMATION",
+    [ATAPI_CMD_READ_SUBCHANNEL]:               "READ SUBCHANNEL",
+    [ATAPI_CMD_READ_TOC_PMA_ATIP]:             "READ TOC PMA ATIP",
+    [ATAPI_CMD_READ_TRACK_INFORMATION]:        "READ TRACK INFORMATION",
+    [ATAPI_CMD_REQUEST_SENSE]:                 "REQUEST SENSE",
+    [ATAPI_CMD_TEST_UNIT_READY]:               "TEST UNIT READY",
+};
 
 // ATAPI 4-bit Sense Keys, see [MMC-2] 9.1.18.3, Table 123
 const ATAPI_SK_NO_SENSE = 0;
@@ -148,6 +204,16 @@ const ATAPI_SK_ABORTED_COMMAND = 11;
 // ATAPI 8-bit Additional Sense Codes, see [MMC-2] 9.1.18.3, Table 124
 const ATAPI_ASC_INV_FIELD_IN_CMD_PACKET = 0x24;
 const ATAPI_ASC_MEDIUM_NOT_PRESENT = 0x3A;
+
+// Debug log detail bits (internal to this module)
+const LOG_DETAIL_NONE = 0x00;   // disable debug logging of details
+const LOG_DETAIL_REG_IO = 0x01; // log register read/write access
+const LOG_DETAIL_IRQ = 0x02;    // log IRQ raise/lower events
+const LOG_DETAIL_RW = 0x04;     // log data read/write-related events
+const LOG_DETAIL_RW_DMA = 0x08; // log DMA data read/write-related events
+const LOG_DETAIL_ALL = 0xFF;    // log all details
+// the bitset of active log details (should be 0 when not in DEBUG mode)
+const LOG_DETAILS = DEBUG ? LOG_DETAIL_NONE : 0;
 
 /**
  * @constructor
@@ -267,26 +333,13 @@ function IDEChannel(controller, channel_nr, channel_config, hw_settings)
     this.irq = hw_settings.irq;
     this.name = "ide" + channel_nr;
 
-    this.interfaces = [];
-    for(let interface_nr = 0; interface_nr < 2; interface_nr++)
-    {
-        const config = channel_config ? channel_config[interface_nr] : undefined;
-        const buffer = config ? config.buffer : undefined;
-        const is_cdrom = config ? !!config.is_cdrom : false;
-        const ide_interface = new IDEInterface(this, interface_nr, buffer, is_cdrom);
-        if(interface_nr === 0)
-        {
-            dbg_assert(ide_interface.drive_connected, this.name + ": missing master device", LOG_DISK);
-            this.master = ide_interface;
-            this.current_interface = ide_interface;
-        }
-        else
-        {
-            this.slave = ide_interface;
-        }
-        this.interfaces[interface_nr] = ide_interface;
-    }
+    const master_cfg = channel_config ? channel_config[0] : undefined;
+    const slave_cfg = channel_config ? channel_config[1] : undefined;
+    this.master = new IDEInterface(this, 0, master_cfg ? master_cfg.buffer : undefined, master_cfg ? !!master_cfg.is_cdrom : false);
+    this.slave = new IDEInterface(this, 1, slave_cfg ? slave_cfg.buffer : undefined, slave_cfg ? !!slave_cfg.is_cdrom : false);
 
+    this.interfaces = [this.master, this.slave];
+    this.current_interface = this.master;
     this.master.init_interface();
     this.slave.init_interface();
 
@@ -321,51 +374,72 @@ function IDEChannel(controller, channel_nr, channel_config, hw_settings)
 
     cpu.io.register_read(this.command_base | ATA_REG_ERROR, this, function()
     {
-        dbg_log(this.current_interface.name + ": read Error register: " +
-            h(this.current_interface.error_reg & 0xFF), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": read Error register: " +
+                h(this.current_interface.error_reg & 0xFF), LOG_DISK);
+        }
         return this.current_interface.error_reg & 0xFF;
     });
 
     cpu.io.register_read(this.command_base | ATA_REG_SECTOR, this, function()
     {
-        dbg_log(this.current_interface.name + ": read Sector Count register: " +
-            h(this.current_interface.sector_count_reg & 0xFF), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": read Sector Count register: " +
+                h(this.current_interface.sector_count_reg & 0xFF), LOG_DISK);
+        }
         return this.current_interface.sector_count_reg & 0xFF;
     });
 
     cpu.io.register_read(this.command_base | ATA_REG_LBA_LOW, this, function()
     {
-        dbg_log(this.current_interface.name + ": read LBA Low register: " +
-            h(this.current_interface.lba_low_reg & 0xFF), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": read LBA Low register: " +
+                h(this.current_interface.lba_low_reg & 0xFF), LOG_DISK);
+        }
         return this.current_interface.lba_low_reg & 0xFF;
     });
 
     cpu.io.register_read(this.command_base | ATA_REG_LBA_MID, this, function()
     {
-        dbg_log(this.current_interface.name + ": read LBA Mid register: " +
-            h(this.current_interface.lba_mid_reg & 0xFF), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": read LBA Mid register: " +
+                h(this.current_interface.lba_mid_reg & 0xFF), LOG_DISK);
+        }
         return this.current_interface.lba_mid_reg & 0xFF;
     });
 
     cpu.io.register_read(this.command_base | ATA_REG_LBA_HIGH, this, function()
     {
-        dbg_log(this.current_interface.name + ": read LBA High register: " +
-            h(this.current_interface.lba_high_reg & 0xFF), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": read LBA High register: " +
+                h(this.current_interface.lba_high_reg & 0xFF), LOG_DISK);
+        }
         return this.current_interface.lba_high_reg & 0xFF;
     });
 
     cpu.io.register_read(this.command_base | ATA_REG_DEVICE, this, function()
     {
-        dbg_log(this.current_interface.name + ": read Device register", LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": read Device register", LOG_DISK);
+        }
         return this.current_interface.device_reg & 0xFF;
     });
 
     cpu.io.register_read(this.command_base | ATA_REG_STATUS, this, function()
     {
-        dbg_log(this.current_interface.name + ": read Status register", LOG_DISK);
-        dbg_log(this.current_interface.name + ": lower IRQ " + this.irq, LOG_DISK);
+        const status = this.read_status();
+        if(LOG_DETAILS & (LOG_DETAIL_REG_IO | LOG_DETAIL_IRQ))
+        {
+            dbg_log(`${this.current_interface.name}: read Status register: ${h(status, 2)} (lower IRQ ${this.irq})`, LOG_DISK);
+        }
         this.cpu.device_lower_irq(this.irq);
-        return this.read_status();
+        return status;
     });
 
     cpu.io.register_write(this.command_base | ATA_REG_DATA, this, function(data)
@@ -381,38 +455,56 @@ function IDEChannel(controller, channel_nr, channel_config, hw_settings)
 
     cpu.io.register_write(this.command_base | ATA_REG_FEATURES, this, function(data)
     {
-        dbg_log(this.current_interface.name + ": write Features register: " + h(data), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": write Features register: " + h(data), LOG_DISK);
+        }
         this.current_interface.features_reg = (this.current_interface.features_reg << 8 | data) & 0xFFFF;
     });
 
     cpu.io.register_write(this.command_base | ATA_REG_SECTOR, this, function(data)
     {
-        dbg_log(this.current_interface.name + ": write Sector Count register: " + h(data), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": write Sector Count register: " + h(data), LOG_DISK);
+        }
         this.current_interface.sector_count_reg = (this.current_interface.sector_count_reg << 8 | data) & 0xFFFF;
     });
 
     cpu.io.register_write(this.command_base | ATA_REG_LBA_LOW, this, function(data)
     {
-        dbg_log(this.current_interface.name + ": write LBA Low register: " + h(data), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": write LBA Low register: " + h(data), LOG_DISK);
+        }
         this.current_interface.lba_low_reg = (this.current_interface.lba_low_reg << 8 | data) & 0xFFFF;
     });
 
     cpu.io.register_write(this.command_base | ATA_REG_LBA_MID, this, function(data)
     {
-        dbg_log(this.current_interface.name + ": write LBA Mid register: " + h(data), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": write LBA Mid register: " + h(data), LOG_DISK);
+        }
         this.current_interface.lba_mid_reg = (this.current_interface.lba_mid_reg << 8 | data) & 0xFFFF;
     });
 
     cpu.io.register_write(this.command_base | ATA_REG_LBA_HIGH, this, function(data)
     {
-        dbg_log(this.current_interface.name + ": write LBA High register: " + h(data), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": write LBA High register: " + h(data), LOG_DISK);
+        }
         this.current_interface.lba_high_reg = (this.current_interface.lba_high_reg << 8 | data) & 0xFFFF;
     });
 
     cpu.io.register_write(this.command_base | ATA_REG_DEVICE, this, function(data)
     {
         const select_slave = data & ATA_DR_DEV;
-        dbg_log(this.current_interface.name + ": write Device register: " + h(data, 2), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": write Device register: " + h(data, 2), LOG_DISK);
+        }
         if((select_slave && this.current_interface === this.master) || (!select_slave && this.current_interface === this.slave))
         {
             if(select_slave)
@@ -433,10 +525,16 @@ function IDEChannel(controller, channel_nr, channel_config, hw_settings)
 
     cpu.io.register_write(this.command_base | ATA_REG_COMMAND, this, function(data)
     {
-        dbg_log(this.current_interface.name + ": write Command register", LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_REG_IO)
+        {
+            dbg_log(this.current_interface.name + ": write Command register", LOG_DISK);
+        }
         this.current_interface.status_reg &= ~(ATA_SR_ERR | 0x20);  // 0x20: command dependent, used to be Drive Write Fault (DF)
         this.current_interface.ata_command(data);
-        dbg_log(this.current_interface.name + ": lower IRQ " + this.irq, LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_IRQ)
+        {
+            dbg_log(this.current_interface.name + ": lower IRQ " + this.irq, LOG_DISK);
+        }
         this.cpu.device_lower_irq(this.irq);
     });
 
@@ -480,19 +578,19 @@ function IDEChannel(controller, channel_nr, channel_config, hw_settings)
 
 IDEChannel.prototype.read_status = function()
 {
-    const ret = this.current_interface.drive_connected ? this.current_interface.status_reg : 0;
-    dbg_log(this.current_interface.name + ": ATA read status: " + h(ret, 2), LOG_DISK);
-    return ret;
+    return this.current_interface.drive_connected ? this.current_interface.status_reg : 0;
 };
 
 IDEChannel.prototype.write_control = function(data)
 {
-    dbg_log(this.current_interface.name + ": write Device Control register: " +
-        h(data, 2) + " interrupts " + ((data & ATA_CR_nIEN) ? "disabled" : "enabled"), LOG_DISK);
+    if(LOG_DETAILS & (LOG_DETAIL_REG_IO | LOG_DETAIL_IRQ))
+    {
+        dbg_log(this.current_interface.name + ": write Device Control register: " +
+            h(data, 2) + " interrupts " + ((data & ATA_CR_nIEN) ? "disabled" : "enabled"), LOG_DISK);
+    }
     if(data & ATA_CR_SRST)
     {
-        dbg_log(this.current_interface.name + ": soft reset via control port", LOG_DISK);
-        dbg_log(this.current_interface.name + ": lower IRQ " + this.irq, LOG_DISK);
+        dbg_log(`${this.current_interface.name}: soft reset via control port (lower IRQ ${this.irq})`, LOG_DISK);
         this.cpu.device_lower_irq(this.irq);
         this.master.device_reset();
         this.slave.device_reset();
@@ -502,25 +600,37 @@ IDEChannel.prototype.write_control = function(data)
 
 IDEChannel.prototype.dma_read_addr = function()
 {
-    //dbg_log(this.current_interface.name + ": DMA get address: " + h(this.prdt_addr, 8), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.current_interface.name + ": DMA get address: " + h(this.prdt_addr, 8), LOG_DISK);
+    }
     return this.prdt_addr;
 };
 
 IDEChannel.prototype.dma_set_addr = function(data)
 {
-    //dbg_log(this.current_interface.name + ": DMA set address: " + h(data, 8), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.current_interface.name + ": DMA set address: " + h(data, 8), LOG_DISK);
+    }
     this.prdt_addr = data;
 };
 
 IDEChannel.prototype.dma_read_status = function()
 {
-    dbg_log(this.current_interface.name + ": DMA read status: " + h(this.dma_status), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.current_interface.name + ": DMA read status: " + h(this.dma_status), LOG_DISK);
+    }
     return this.dma_status;
 };
 
 IDEChannel.prototype.dma_write_status = function(value)
 {
-    dbg_log(this.current_interface.name + ": DMA write status: " + h(value), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.current_interface.name + ": DMA write status: " + h(value), LOG_DISK);
+    }
     this.dma_status &= ~(value & 6);
 };
 
@@ -531,20 +641,29 @@ IDEChannel.prototype.dma_read_command = function()
 
 IDEChannel.prototype.dma_read_command8 = function()
 {
-    //dbg_log(this.current_interface.name + ": DMA read command: " + h(this.dma_command), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.current_interface.name + ": DMA read command: " + h(this.dma_command), LOG_DISK);
+    }
     return this.dma_command;
 };
 
 IDEChannel.prototype.dma_write_command = function(value)
 {
-    //dbg_log(this.current_interface.name + ": DMA write command: " + h(value), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.current_interface.name + ": DMA write command: " + h(value), LOG_DISK);
+    }
     this.dma_write_command8(value & 0xFF);
     this.dma_write_status(value >> 16 & 0xFF);
 };
 
 IDEChannel.prototype.dma_write_command8 = function(value)
 {
-    //dbg_log(this.current_interface.name + ": DMA write command8: " + h(value), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.current_interface.name + ": DMA write command8: " + h(value), LOG_DISK);
+    }
 
     const old_command = this.dma_command;
     this.dma_command = value & 0x09;
@@ -590,7 +709,10 @@ IDEChannel.prototype.push_irq = function()
 {
     if((this.device_control_reg & ATA_CR_nIEN) === 0)
     {
-        dbg_log(this.current_interface.name + ": push IRQ " + this.irq, LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_IRQ)
+        {
+            dbg_log(this.current_interface.name + ": push IRQ " + this.irq, LOG_DISK);
+        }
         this.dma_status |= 4;
         this.cpu.device_raise_irq(this.irq);
     }
@@ -646,16 +768,10 @@ function IDEInterface(channel, interface_nr, buffer, is_cd)
     /** @const @type {BusConnector} */
     this.bus = channel.bus;
 
-    /**
-     * @const
-     * @type {number}
-     */
+    /** @const @type {number} */
     this.channel_nr = channel.channel_nr;
 
-    /**
-     * @const
-     * @type {number}
-     */
+    /** @const @type {number} */
     this.interface_nr = interface_nr;
 
     /** @const @type {CPU} */
@@ -763,6 +879,11 @@ IDEInterface.prototype.init_interface = function()
     this.set_disk_buffer(this.inital_buffer);
     delete this.inital_buffer;
     Object.seal(this);
+
+    if(this.drive_connected)
+    {
+        dbg_log(`${this.name}: ${this.is_atapi ? "ATAPI CD-ROM" : "ATA HD"} device ready`, LOG_DISK);
+    }
 };
 
 IDEInterface.prototype.eject = function()
@@ -803,7 +924,7 @@ IDEInterface.prototype.set_disk_buffer = function(buffer)
 
     if(this.sector_count !== (this.sector_count | 0))
     {
-        dbg_log(this.name + ": Warning: disk size not aligned with sector size", LOG_DISK);
+        dbg_log(this.name + ": warning: disk size not aligned with sector size", LOG_DISK);
         this.sector_count = Math.ceil(this.sector_count);
     }
 
@@ -825,7 +946,7 @@ IDEInterface.prototype.set_disk_buffer = function(buffer)
 
     if(this.cylinder_count !== (this.cylinder_count | 0))
     {
-        dbg_log(this.name + ": Warning: rounding up cylinder count, choose different head number", LOG_DISK);
+        dbg_log(this.name + ": warning: rounding up cylinder count, choose different head number", LOG_DISK);
         this.cylinder_count = Math.floor(this.cylinder_count);
     }
 
@@ -892,21 +1013,29 @@ IDEInterface.prototype.push_irq = function()
 
 IDEInterface.prototype.ata_abort_command = function()
 {
-    dbg_log(this.name + ": ATA Command " + h(this.current_command) + " aborted", LOG_DISK);
     this.error_reg = ATA_ER_ABRT;
     this.status_reg = ATA_SR_DRDY|ATA_SR_ERR;
     this.push_irq();
 };
 
+IDEInterface.prototype.capture_regs = function()
+{
+    return `ST=${h(this.status_reg)} ER=${h(this.error_reg)} ` +
+        `SC=${h(this.sector_count_reg)} LL=${h(this.lba_low_reg)} ` +
+        `LM=${h(this.lba_mid_reg)} LH=${h(this.lba_high_reg)} ` +
+        `FE=${h(this.features_reg)} DE=${h(this.device_reg)}`;
+};
+
 IDEInterface.prototype.ata_command = function(cmd)
 {
-    dbg_log(this.name + ": ATA Command: " + h(cmd), LOG_DISK);
-
     if(!this.drive_connected && cmd !== ATA_CMD_EXECUTE_DEVICE_DIAGNOSTIC)
     {
-        dbg_log(this.name + ": ATA command " + h(cmd) + " ignored: No slave drive connected", LOG_DISK);
+        dbg_log(`${this.name}: ATA command ${ATA_CMD_NAME[cmd]} (${h(cmd)}) ignored: no slave drive connected`, LOG_DISK);
         return;
     }
+
+    const regs_pre = DEBUG ? this.capture_regs() : undefined;
+    let do_dbg_log = DEBUG;
 
     this.current_command = cmd;
     this.error_reg = 0;
@@ -914,7 +1043,6 @@ IDEInterface.prototype.ata_command = function(cmd)
     switch(cmd)
     {
         case ATA_CMD_DEVICE_RESET:
-            dbg_log(this.name + ": ATA device reset", LOG_DISK);
             this.data_pointer = 0;
             this.data_end = 0;
             this.data_length = 0;
@@ -923,14 +1051,12 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case ATA_CMD_10h:
-            dbg_log(this.name + ": ATA calibrate drive", LOG_DISK);
             this.lba_mid_reg = 0;
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             this.push_irq();
             break;
 
         case ATA_CMD_READ_NATIVE_MAX_ADDRESS:
-            dbg_log(this.name + ": ATA read native max address", LOG_DISK);
             var last_sector = this.sector_count - 1;
             this.lba_low_reg = last_sector & 0xFF;
             this.lba_mid_reg = last_sector >> 8 & 0xFF;
@@ -941,7 +1067,6 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case ATA_CMD_READ_NATIVE_MAX_ADDRESS_EXT:
-            dbg_log(this.name + ": ATA read native max address ext", LOG_DISK);
             var last_sector = this.sector_count - 1;
             if(this.channel.device_control_reg & ATA_CR_HOB === 0)
             {
@@ -963,6 +1088,7 @@ IDEInterface.prototype.ata_command = function(cmd)
         case ATA_CMD_READ_SECTORS_EXT:
         case ATA_CMD_READ_MULTIPLE:
         case ATA_CMD_READ_MULTIPLE_EXT:
+            do_dbg_log = LOG_DETAILS & LOG_DETAIL_RW;
             if(this.is_atapi)
             {
                 this.ata_abort_command();
@@ -977,6 +1103,7 @@ IDEInterface.prototype.ata_command = function(cmd)
         case ATA_CMD_WRITE_SECTORS_EXT:
         case ATA_CMD_WRITE_MULTIPLE:
         case ATA_CMD_WRITE_MULTIPLE_EXT:
+            do_dbg_log = LOG_DETAILS & LOG_DETAIL_RW;
             if(this.is_atapi)
             {
                 this.ata_abort_command();
@@ -988,7 +1115,6 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case ATA_CMD_EXECUTE_DEVICE_DIAGNOSTIC:
-            dbg_log(this.name + ": ATA execute device diagnostic", LOG_DISK);
             // the behaviour of this command is independent of the selected device
             this.channel.master.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             this.channel.master.error_reg = 0x01;    // Master drive passed, slave drive passed or not present
@@ -1009,16 +1135,20 @@ IDEInterface.prototype.ata_command = function(cmd)
         case ATA_CMD_PACKET:
             if(this.is_atapi)
             {
+                do_dbg_log = false;
                 this.data_allocate(12);
                 this.data_end = 12;
                 this.sector_count_reg = 0x01;                           // 0x01: indicates transfer of a command packet (C/D)
                 this.status_reg = ATA_SR_DRDY|ATA_SR_DSC|ATA_SR_DRQ;    // 0x10: another command is ready to be serviced (SERV)
                 this.push_irq();
             }
+            else
+            {
+                this.ata_abort_command();
+            }
             break;
 
         case ATA_CMD_IDENTIFY_PACKET_DEVICE:
-            dbg_log(this.name + ": ATA identify packet device", LOG_DISK);
             if(this.is_atapi)
             {
                 this.create_identify_packet();
@@ -1032,7 +1162,6 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case ATA_CMD_SET_MULTIPLE_MODE:
-            dbg_log(this.name + ": ATA set multiple mode", LOG_DISK);
             // Logical sectors per DRQ Block in word 1
             dbg_log(this.name + ": logical sectors per DRQ Block: " + h(this.sector_count_reg & 0xFF), LOG_DISK);
             this.sectors_per_drq = this.sector_count_reg & 0xFF;
@@ -1042,23 +1171,23 @@ IDEInterface.prototype.ata_command = function(cmd)
 
         case ATA_CMD_READ_DMA:
         case ATA_CMD_READ_DMA_EXT:
+            do_dbg_log = LOG_DETAILS & LOG_DETAIL_RW_DMA;
             this.ata_read_sectors_dma(cmd);
             break;
 
         case ATA_CMD_WRITE_DMA:
         case ATA_CMD_WRITE_DMA_EXT:
+            do_dbg_log = LOG_DETAILS & LOG_DETAIL_RW_DMA;
             this.ata_write_sectors_dma(cmd);
             break;
 
         case ATA_CMD_READ_VERIFY_SECTORS:
-            dbg_log(this.name + ": ATA read verify sector(s)", LOG_DISK);
             // TODO: check that lba_low/mid/high and sector_count regs are within the bounds of the disk's size
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             this.push_irq();
             break;
 
         case ATA_CMD_GET_MEDIA_STATUS:
-            dbg_log(this.name + ": ATA get media status", LOG_DISK);
             if(this.is_atapi)
             {
                 if(!this.buffer)
@@ -1077,31 +1206,26 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case ATA_CMD_STANDBY_IMMEDIATE:
-            dbg_log(this.name + ": ATA standby immediate", LOG_DISK);
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             this.push_irq();
             break;
 
         case ATA_CMD_IDLE_IMMEDIATE:
-            dbg_log(this.name + ": ATA idle immediate", LOG_DISK);
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             this.push_irq();
             break;
 
         case ATA_CMD_FLUSH_CACHE:
-            dbg_log(this.name + ": ATA flush cache", LOG_DISK);
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             this.push_irq();
             break;
 
         case ATA_CMD_FLUSH_CACHE_EXT:
-            dbg_log(this.name + ": ATA flush cache ext", LOG_DISK);
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             this.push_irq();
             break;
 
         case ATA_CMD_IDENTIFY_DEVICE:
-            dbg_log(this.name + ": ATA identify device", LOG_DISK);
             if(this.is_atapi)
             {
                 this.ata_abort_command();
@@ -1115,68 +1239,77 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case ATA_CMD_SET_FEATURES:
-            dbg_log(this.name + ": ATA set features: " + h(this.sector_count_reg & 0xFF), LOG_DISK);
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             this.push_irq();
             break;
 
         case ATA_CMD_MEDIA_LOCK:
-            dbg_log(this.name + ": ATA media lock", LOG_DISK);
             this.status_reg = ATA_SR_DRDY;
             this.push_irq();
             break;
 
         case ATA_CMD_SECURITY_FREEZE_LOCK:
-            dbg_log(this.name + ": ATA security freeze lock", LOG_DISK);
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             this.push_irq();
             break;
 
         case ATA_CMD_SET_MAX:
-            dbg_log(this.name + ": ATA set max address (unimplemented)", LOG_DISK);
             this.ata_abort_command();
             break;
 
         case ATA_CMD_NOP:
-            dbg_log(this.name + ": ATA nop", LOG_DISK);
             this.ata_abort_command();
             break;
 
         default:
-            dbg_assert(false, this.name + ": unhandled ATA command: " + h(cmd), LOG_DISK);
+            dbg_assert(false, `${this.name}: error: unimplemented ATA command ${h(cmd)}: ABORT [${this.capture_regs()}]`, LOG_DISK);
             this.ata_abort_command();
             break;
+    }
+
+    if(DEBUG && do_dbg_log)
+    {
+        const regs_msg = `[${regs_pre}] -> [${this.capture_regs()}]`;
+        const result = this.status_reg & ATA_SR_ERR ? (this.error_reg & ATA_ER_ABRT ? "ABORT" : "ERROR") : "OK";
+        dbg_log(`${this.name}: ATA command ${ATA_CMD_NAME[cmd]} (${h(cmd)}): ${result} ${regs_msg}`, LOG_DISK);
     }
 };
 
 IDEInterface.prototype.atapi_handle = function()
 {
-    dbg_log(this.name + ": ATAPI Command: " + h(this.data[0]), LOG_DISK);
-    this.data_pointer = 0;
-    this.current_atapi_command = this.data[0];
+    const cmd = this.data[0];
+    const regs_pre = DEBUG ? this.capture_regs() : undefined;
+    let do_dbg_log = DEBUG;
+    let dbg_log_extra;
 
-    if(this.current_atapi_command !== ATAPI_CMD_REQUEST_SENSE)
+    this.data_pointer = 0;
+    this.current_atapi_command = cmd;
+
+    if(cmd !== ATAPI_CMD_REQUEST_SENSE)
     {
         this.atapi_sense_key = 0;
         this.atapi_add_sense = 0;
     }
 
-    if(!this.buffer && (this.current_atapi_command === ATAPI_CMD_READ_CAPACITY ||
-                        this.current_atapi_command === ATAPI_CMD_READ ||
-                        this.current_atapi_command === ATAPI_CMD_READ_SUBCHANNEL ||
-                        this.current_atapi_command === ATAPI_CMD_READ_TOC_PMA_ATIP ||
-                        this.current_atapi_command === ATAPI_CMD_READ_DISK_INFORMATION))
+    if(!this.buffer && (cmd === ATAPI_CMD_READ_CAPACITY ||
+                        cmd === ATAPI_CMD_READ ||
+                        cmd === ATAPI_CMD_READ_SUBCHANNEL ||
+                        cmd === ATAPI_CMD_READ_TOC_PMA_ATIP ||
+                        cmd === ATAPI_CMD_READ_DISK_INFORMATION))
     {
-        dbg_log(this.name + ": CD read-related action: no buffer", LOG_DISK);
         this.atapi_check_condition_response(ATAPI_SK_NOT_READY, ATAPI_ASC_MEDIUM_NOT_PRESENT);
         this.push_irq();
+        if(DEBUG)
+        {
+            const result = this.status_reg & ATA_SR_ERR ? (this.error_reg & ATA_ER_ABRT ? "ABORT" : "ERROR") : "OK";
+            dbg_log(`${this.name}: ATAPI command ${ATAPI_CMD_NAME[cmd]} (${h(cmd)}) without medium: ${result} [${regs_pre}]`, LOG_DISK);
+        }
         return;
     }
 
-    switch(this.current_atapi_command)
+    switch(cmd)
     {
         case ATAPI_CMD_TEST_UNIT_READY:
-            dbg_log(this.name + ": ATAPI test unit ready", LOG_DISK);
             if(this.buffer)
             {
                 this.data_allocate(0);
@@ -1190,7 +1323,6 @@ IDEInterface.prototype.atapi_handle = function()
             break;
 
         case ATAPI_CMD_REQUEST_SENSE:
-            dbg_log(this.name + ": ATAPI request sense", LOG_DISK);
             this.data_allocate(this.data[4]);
             this.data_end = this.data_length;
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC|ATA_SR_DRQ;
@@ -1205,7 +1337,7 @@ IDEInterface.prototype.atapi_handle = function()
         case ATAPI_CMD_INQUIRY:
             var length = this.data[4];
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC|ATA_SR_DRQ;
-            dbg_log(this.name + ": ATAPI inquiry: " + h(this.data[1], 2) + " length=" + length, LOG_DISK);
+            dbg_log_extra = h(this.data[1], 2) + " length=" + length;
             // for data layout see [CD-SCSI-2] "INQUIRY Command"
             this.data.set([
                 // 0: Device-type, Removable, ANSI-Version, Response Format
@@ -1227,21 +1359,18 @@ IDEInterface.prototype.atapi_handle = function()
             break;
 
         case ATAPI_CMD_MODE_SENSE_6:
-            dbg_log(this.name + ": ATAPI mode sense (6)", LOG_DISK);
             this.data_allocate(this.data[4]);
             this.data_end = this.data_length;
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC|ATA_SR_DRQ;
             break;
 
         case ATAPI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
-            dbg_log(this.name + ": ATAPI prevent allow medium removal", LOG_DISK);
             this.data_allocate(0);
             this.data_end = this.data_length;
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             break;
 
         case ATAPI_CMD_READ_CAPACITY:
-            dbg_log(this.name + ": ATAPI read capacity", LOG_DISK);
             var count = this.sector_count - 1;
             this.data_set(new Uint8Array([
                 count >> 24 & 0xFF,
@@ -1260,17 +1389,19 @@ IDEInterface.prototype.atapi_handle = function()
         case ATAPI_CMD_READ:
             if(this.features_reg & 1)
             {
+                do_dbg_log = LOG_DETAILS & LOG_DETAIL_RW_DMA;
                 this.atapi_read_dma(this.data);
             }
             else
             {
+                do_dbg_log = LOG_DETAILS & LOG_DETAIL_RW;
                 this.atapi_read(this.data);
             }
             break;
 
         case ATAPI_CMD_READ_SUBCHANNEL:
             var length = this.data[8];
-            dbg_log(this.name + ": ATAPI read subchannel: length=" + length, LOG_DISK);
+            dbg_log_extra = "length=" + length;
             this.data_allocate(Math.min(8, length));
             this.data_end = this.data_length;
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC|ATA_SR_DRQ;
@@ -1279,14 +1410,10 @@ IDEInterface.prototype.atapi_handle = function()
         case ATAPI_CMD_READ_TOC_PMA_ATIP:
             var length = this.data[8] | this.data[7] << 8;
             var format = this.data[9] >> 6;
+            dbg_log_extra = `${h(format, 2)} length=${length} ${!!(this.data[1] & 2)} ${h(this.data[6])}`;
 
             this.data_allocate(length);
             this.data_end = this.data_length;
-            dbg_log(this.name + ": ATAPI read toc/pma/atip: " + h(format, 2) +
-                    " length=" + length +
-                    " " + (this.data[1] & 2) +
-                    " " + h(this.data[6]), LOG_DISK);
-
             if(format === 0)
             {
                 const sector_count = this.sector_count;
@@ -1323,7 +1450,7 @@ IDEInterface.prototype.atapi_handle = function()
             }
             else
             {
-                dbg_assert(false, this.name + ": unimplemented format: " + format);
+                dbg_assert(false, this.name + ": error: unimplemented format: " + format);
             }
 
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC|ATA_SR_DRQ;
@@ -1331,7 +1458,7 @@ IDEInterface.prototype.atapi_handle = function()
 
         case ATAPI_CMD_GET_CONFIGURATION:
             var length = Math.min(this.data[8] | this.data[7] << 8, 32);
-            dbg_log(this.name + ": ATAPI get configuration: length=" + length, LOG_DISK);
+            dbg_log_extra = "length=" + length;
             this.data_allocate(length);
             this.data_end = this.data_length;
             this.data[0] = length - 4 >> 24 & 0xFF;
@@ -1344,21 +1471,20 @@ IDEInterface.prototype.atapi_handle = function()
             break;
 
         case ATAPI_CMD_READ_DISK_INFORMATION:
-            dbg_log(this.name + ": ATAPI read disk information", LOG_DISK);
             this.data_allocate(0);
             this.data_end = this.data_length;
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             break;
 
         case ATAPI_CMD_READ_TRACK_INFORMATION:
-            dbg_log(this.name + ": ATAPI read track information (unimplemented)", LOG_DISK);
+            dbg_log_extra = "unimplemented";
             this.atapi_check_condition_response(ATAPI_SK_ILLEGAL_REQUEST, ATAPI_ASC_INV_FIELD_IN_CMD_PACKET);
             break;
 
         case ATAPI_CMD_MODE_SENSE_10:
             var length = this.data[8] | this.data[7] << 8;
             var page_code = this.data[2];
-            dbg_log(this.name + ": ATAPI mode sense (10): page_code=" + h(page_code) + " length=" + length, LOG_DISK);
+            dbg_log_extra = "page_code=" + h(page_code) + " length=" + length;
             if(page_code === 0x2A)
             {
                 this.data_allocate(Math.min(30, length));
@@ -1368,7 +1494,6 @@ IDEInterface.prototype.atapi_handle = function()
             break;
 
         case ATAPI_CMD_MECHANISM_STATUS:
-            dbg_log(this.name + ": ATAPI mechanism status", LOG_DISK);
             this.data_allocate(this.data[9] | this.data[8] << 8);
             this.data_end = this.data_length;
             this.data[5] = 1;
@@ -1376,21 +1501,21 @@ IDEInterface.prototype.atapi_handle = function()
             break;
 
         case ATAPI_CMD_GET_EVENT_STATUS_NOTIFICATION:
-            dbg_log(this.name + ": ATAPI get event status notification (unimplemented)", LOG_DISK);
+            dbg_log_extra = "unimplemented";
             this.atapi_check_condition_response(ATAPI_SK_ILLEGAL_REQUEST, ATAPI_ASC_INV_FIELD_IN_CMD_PACKET);
             break;
 
         case ATAPI_CMD_READ_CD:
-            dbg_log(this.name + ": ATAPI read cd (unimplemented)", LOG_DISK);
+            dbg_log_extra = "unimplemented";
             this.data_allocate(0);
             this.data_end = this.data_length;
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
             break;
 
         default:
+            dbg_assert(false, `${this.name}: error: unimplemented ATAPI command ${h(this.data[0])}`, LOG_DISK);
             this.atapi_check_condition_response(ATAPI_SK_ILLEGAL_REQUEST, ATAPI_ASC_INV_FIELD_IN_CMD_PACKET);
-            dbg_log(this.name + ": unimplemented ATAPI command: " + h(this.data[0]), LOG_DISK);
-            dbg_assert(false);
+            break;
     }
 
     this.sector_count_reg = this.sector_count_reg & ~7 | 2;
@@ -1404,6 +1529,14 @@ IDEInterface.prototype.atapi_handle = function()
     {
         this.sector_count_reg |= 1;
         this.status_reg &= ~ATA_SR_DRQ;
+    }
+
+    if(DEBUG && do_dbg_log)
+    {
+        const regs_msg = `[${regs_pre}] -> [${this.capture_regs()}]`;
+        const result = this.status_reg & ATA_SR_ERR ? (this.error_reg & ATA_ER_ABRT ? "ABORT" : "ERROR") : "OK";
+        dbg_log_extra = dbg_log_extra ? ` ${dbg_log_extra}:` : "";
+        dbg_log(`${this.name}: ATAPI command ${ATAPI_CMD_NAME[cmd]} (${h(cmd)}):${dbg_log_extra} ${result} ${regs_msg}`, LOG_DISK);
     }
 };
 
@@ -1499,7 +1632,6 @@ IDEInterface.prototype.atapi_read = function(cmd)
 
         this.read_buffer(start, byte_count, (data) =>
         {
-            //setTimeout(() => {
             dbg_log(this.name + ": CD read: data arrived", LOG_DISK);
             this.data_set(data);
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC|ATA_SR_DRQ;
@@ -1518,7 +1650,6 @@ IDEInterface.prototype.atapi_read = function(cmd)
             this.lba_high_reg = this.data_end >> 8 & 0xFF;
 
             this.report_read_end(byte_count);
-            //}, 10);
         });
     }
 };
@@ -1577,7 +1708,10 @@ IDEInterface.prototype.do_atapi_dma = function()
         return;
     }
 
-    dbg_log(this.name + ": ATAPI DMA transfer len=" + this.data_length, LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.name + ": ATAPI DMA transfer len=" + this.data_length, LOG_DISK);
+    }
 
     var prdt_start = this.channel.prdt_addr;
     var offset = 0;
@@ -1594,7 +1728,10 @@ IDEInterface.prototype.do_atapi_dma = function()
             count = 0x10000;
         }
 
-        dbg_log(this.name + ": DMA read dest=" + h(addr) + " count=" + h(count) + " datalen=" + h(this.data_length), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+        {
+            dbg_log(this.name + ": DMA read dest=" + h(addr) + " count=" + h(count) + " datalen=" + h(this.data_length), LOG_DISK);
+        }
         this.cpu.write_blob(data.subarray(offset, Math.min(offset + count, this.data_length)), addr);
 
         offset += count;
@@ -1602,16 +1739,22 @@ IDEInterface.prototype.do_atapi_dma = function()
 
         if(offset >= this.data_length && !end)
         {
-            dbg_log(this.name + ": leave early end=" + (+end) +
-                    " offset=" + h(offset) +
-                    " data_length=" + h(this.data_length) +
-                    " cmd=" + h(this.current_command), LOG_DISK);
+            if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+            {
+                dbg_log(this.name + ": leave early end=" + (+end) +
+                        " offset=" + h(offset) +
+                        " data_length=" + h(this.data_length) +
+                        " cmd=" + h(this.current_command), LOG_DISK);
+            }
             break;
         }
     }
     while(!end);
 
-    dbg_log(this.name + ": end offset=" + offset, LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.name + ": end offset=" + offset, LOG_DISK);
+    }
 
     this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
     this.channel.dma_status &= ~1;
@@ -1642,11 +1785,15 @@ IDEInterface.prototype.read_data = function(length)
         this.data_pointer += length;
 
         var align = (this.data_end & 0xFFF) === 0 ? 0xFFF : 0xFF;
-        if((this.data_pointer & align) === 0)
+
+        if(LOG_DETAILS & LOG_DETAIL_RW)
         {
-            dbg_log(this.name + ": read 1F0: " + h(this.data[this.data_pointer], 2) +
-                        " cur=" + h(this.data_pointer) +
-                        " cnt=" + h(this.data_length), LOG_DISK);
+            if((this.data_pointer & align) === 0)
+            {
+                dbg_log(this.name + ": read 1F0: " + h(this.data[this.data_pointer], 2) +
+                            " cur=" + h(this.data_pointer) +
+                            " cnt=" + h(this.data_length), LOG_DISK);
+            }
         }
 
         if(this.data_pointer >= this.data_end)
@@ -1658,8 +1805,10 @@ IDEInterface.prototype.read_data = function(length)
     }
     else
     {
-        dbg_log(this.name + ": read 1F0: empty", LOG_DISK);
-
+        if(LOG_DETAILS & LOG_DETAIL_RW)
+        {
+            dbg_log(this.name + ": read 1F0: empty", LOG_DISK);
+        }
         this.data_pointer += length;
         return 0;
     }
@@ -1667,9 +1816,12 @@ IDEInterface.prototype.read_data = function(length)
 
 IDEInterface.prototype.read_end = function()
 {
-    dbg_log(this.name + ": read_end cmd=" + h(this.current_command) +
-            " data_pointer=" + h(this.data_pointer) + " end=" + h(this.data_end) +
-            " length=" + h(this.data_length), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW)
+    {
+        dbg_log(this.name + ": read_end cmd=" + h(this.current_command) +
+                " data_pointer=" + h(this.data_pointer) + " end=" + h(this.data_end) +
+                " length=" + h(this.data_length), LOG_DISK);
+    }
 
     if(this.current_command === ATA_CMD_PACKET)
     {
@@ -1696,7 +1848,10 @@ IDEInterface.prototype.read_end = function()
             {
                 this.data_end += byte_count;
             }
-            dbg_log(this.name + ": data_end=" + h(this.data_end), LOG_DISK);
+            if(LOG_DETAILS & LOG_DETAIL_RW)
+            {
+                dbg_log(this.name + ": data_end=" + h(this.data_end), LOG_DISK);
+            }
         }
     }
     else
@@ -1739,10 +1894,13 @@ IDEInterface.prototype.write_data_port = function(data, length)
     else
     {
         var align = (this.data_end & 0xFFF) === 0 ? 0xFFF : 0xFF;
-        if((this.data_pointer + length & align) === 0 || this.data_end < 20)
+        if(LOG_DETAILS & LOG_DETAIL_RW)
         {
-            dbg_log(this.name + ": data port: " + h(data >>> 0) + " count=" +
-                    h(this.data_end) + " cur=" + h(this.data_pointer), LOG_DISK);
+            if((this.data_pointer + length & align) === 0 || this.data_end < 20)
+            {
+                dbg_log(this.name + ": data port: " + h(data >>> 0) + " count=" +
+                        h(this.data_end) + " cur=" + h(this.data_pointer), LOG_DISK);
+            }
         }
 
         if(length === 1)
@@ -1791,8 +1949,11 @@ IDEInterface.prototype.write_end = function()
     }
     else
     {
-        dbg_log(this.name + ": write_end data_pointer=" + h(this.data_pointer) +
+        if(LOG_DETAILS & LOG_DETAIL_RW)
+        {
+            dbg_log(this.name + ": write_end data_pointer=" + h(this.data_pointer) +
                 " data_length=" + h(this.data_length), LOG_DISK);
+        }
 
         if(this.data_pointer >= this.data_length)
         {
@@ -1816,7 +1977,10 @@ IDEInterface.prototype.write_end = function()
 
 IDEInterface.prototype.ata_advance = function(cmd, sectors)
 {
-    dbg_log(this.name + ": advance sectors=" + sectors + " old_sector_count_reg=" + this.sector_count_reg, LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW)
+    {
+        dbg_log(this.name + ": advance sectors=" + sectors + " old_sector_count_reg=" + this.sector_count_reg, LOG_DISK);
+    }
     this.sector_count_reg -= sectors;
 
     if(cmd === ATA_CMD_READ_SECTORS_EXT ||
@@ -1864,11 +2028,14 @@ IDEInterface.prototype.ata_read_sectors = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log(this.name + ": ATA read cmd=" + h(cmd) +
-            " mode=" + (this.is_lba ? "lba" : "chs") +
-            " lba=" + h(lba) +
-            " lbacount=" + h(count) +
-            " bytecount=" + h(byte_count), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW)
+    {
+        dbg_log(this.name + ": ATA read cmd=" + h(cmd) +
+                " mode=" + (this.is_lba ? "lba" : "chs") +
+                " lba=" + h(lba) +
+                " lbacount=" + h(count) +
+                " bytecount=" + h(byte_count), LOG_DISK);
+    }
 
     if(start + byte_count > this.buffer.byteLength)
     {
@@ -1884,8 +2051,10 @@ IDEInterface.prototype.ata_read_sectors = function(cmd)
 
         this.read_buffer(start, byte_count, (data) =>
         {
-            //setTimeout(() => {
-            dbg_log(this.name + ": ata_read: Data arrived", LOG_DISK);
+            if(LOG_DETAILS & LOG_DETAIL_RW)
+            {
+                dbg_log(this.name + ": ata_read: Data arrived", LOG_DISK);
+            }
 
             this.data_set(data);
             this.status_reg = ATA_SR_DRDY|ATA_SR_DSC|ATA_SR_DRQ;
@@ -1894,7 +2063,6 @@ IDEInterface.prototype.ata_read_sectors = function(cmd)
 
             this.push_irq();
             this.report_read_end(byte_count);
-            //}, 10);
         });
     }
 };
@@ -1908,9 +2076,12 @@ IDEInterface.prototype.ata_read_sectors_dma = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log(this.name + ": ATA DMA read lba=" + h(lba) +
-            " lbacount=" + h(count) +
-            " bytecount=" + h(byte_count), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.name + ": ATA DMA read lba=" + h(lba) +
+                " lbacount=" + h(count) +
+                " bytecount=" + h(byte_count), LOG_DISK);
+    }
 
     if(start + byte_count > this.buffer.byteLength)
     {
@@ -1944,8 +2115,10 @@ IDEInterface.prototype.do_ata_read_sectors_dma = function()
 
     this.read_buffer(start, byte_count, (data) =>
     {
-        //setTimeout(function() {
-        dbg_log(this.name + ": do_ata_read_sectors_dma: Data arrived", LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+        {
+            dbg_log(this.name + ": do_ata_read_sectors_dma: Data arrived", LOG_DISK);
+        }
         var prdt_start = this.channel.prdt_addr;
         var offset = 0;
 
@@ -1959,11 +2132,17 @@ IDEInterface.prototype.do_ata_read_sectors_dma = function()
             if(!prd_count)
             {
                 prd_count = 0x10000;
-                dbg_log(this.name + ": DMA: prd count was 0", LOG_DISK);
+                if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+                {
+                    dbg_log(this.name + ": DMA: prd count was 0", LOG_DISK);
+                }
             }
 
-            dbg_log(this.name + ": DMA read transfer dest=" + h(prd_addr) +
+            if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+            {
+                dbg_log(this.name + ": DMA read transfer dest=" + h(prd_addr) +
                     " prd_count=" + h(prd_count), LOG_DISK);
+            }
             this.cpu.write_blob(data.subarray(offset, offset + prd_count), prd_addr);
 
             offset += prd_count;
@@ -1995,10 +2174,13 @@ IDEInterface.prototype.ata_write_sectors = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log(this.name + ": ATA write lba=" + h(lba) +
-            " mode=" + (this.is_lba ? "lba" : "chs") +
-            " lbacount=" + h(count) +
-            " bytecount=" + h(byte_count), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW)
+    {
+        dbg_log(this.name + ": ATA write lba=" + h(lba) +
+                " mode=" + (this.is_lba ? "lba" : "chs") +
+                " lbacount=" + h(count) +
+                " bytecount=" + h(byte_count), LOG_DISK);
+    }
 
     if(start + byte_count > this.buffer.byteLength)
     {
@@ -2025,9 +2207,12 @@ IDEInterface.prototype.ata_write_sectors_dma = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log(this.name + ": ATA DMA write lba=" + h(lba) +
-            " lbacount=" + h(count) +
-            " bytecount=" + h(byte_count), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.name + ": ATA DMA write lba=" + h(lba) +
+                " lbacount=" + h(count) +
+                " bytecount=" + h(byte_count), LOG_DISK);
+    }
 
     if(start + byte_count > this.buffer.byteLength)
     {
@@ -2056,7 +2241,10 @@ IDEInterface.prototype.do_ata_write_sectors_dma = function()
     var prdt_start = this.channel.prdt_addr;
     var offset = 0;
 
-    dbg_log(this.name + ": prdt addr: " + h(prdt_start, 8), LOG_DISK);
+    if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+    {
+        dbg_log(this.name + ": prdt addr: " + h(prdt_start, 8), LOG_DISK);
+    }
 
     const buffer = new Uint8Array(byte_count);
 
@@ -2071,7 +2259,10 @@ IDEInterface.prototype.do_ata_write_sectors_dma = function()
             dbg_log(this.name + ": DMA: prd count was 0", LOG_DISK);
         }
 
-        dbg_log(this.name + ": DMA write transfer dest=" + h(prd_addr) + " prd_count=" + h(prd_count), LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+        {
+            dbg_log(this.name + ": DMA write transfer dest=" + h(prd_addr) + " prd_count=" + h(prd_count), LOG_DISK);
+        }
 
         var slice = this.cpu.mem8.subarray(prd_addr, prd_addr + prd_count);
         dbg_assert(slice.length === prd_count);
@@ -2092,7 +2283,10 @@ IDEInterface.prototype.do_ata_write_sectors_dma = function()
 
     this.buffer.set(start, buffer, () =>
     {
-        dbg_log(this.name + ": DMA write completed", LOG_DISK);
+        if(LOG_DETAILS & LOG_DETAIL_RW_DMA)
+        {
+            dbg_log(this.name + ": DMA write completed", LOG_DISK);
+        }
         this.ata_advance(this.current_command, count);
         this.status_reg = ATA_SR_DRDY|ATA_SR_DSC;
         this.push_irq();

--- a/src/ide.js
+++ b/src/ide.js
@@ -101,12 +101,12 @@ const ATA_CMD_SET_MAX = 0xF9;                       // see [ATA-6] 8.47
  * @param {CPU} cpu
  * @param {BusConnector} bus
  *
- * ide_config: [ [<primary-master>, <primary-slave>], [<secondary-master>, <secondary-slave>] ]
+ * ide_config: [ [primary-master, primary-slave], [secondary-master, secondary-slave] ]
  *
- *   Each of the four arguments (<primary-master>, <primary-slave>, ...) is
- *   either undefined or an ide_config object of the form:
+ *   Each of the four arguments (primary-master, primary-slave, ...) is either
+ *   undefined or an object of the form:
  *
- *       ide_config := { buffer: Uint8Array, is_cdrom: bool }
+ *       { buffer: Uint8Array, is_cdrom: bool }
  *
  *   If is_cdrom is defined and true:
  *   - If buffer is defined: create an ATAPI CD-ROM device using buffer as inserted disk
@@ -1689,7 +1689,7 @@ IDEInterface.prototype.write_data_port32 = function(data)
 
 IDEInterface.prototype.write_end = function()
 {
-    if(this.current_command === 0xA0)
+    if(this.current_command === ATA_CMD_PACKET)
     {
         this.atapi_handle();
     }
@@ -1704,9 +1704,9 @@ IDEInterface.prototype.write_end = function()
         }
         else
         {
-            dbg_assert(this.current_command === 0x30 ||
-                this.current_command === 0x34 ||
-                this.current_command === 0xC5,
+            dbg_assert(this.current_command === ATA_CMD_WRITE_SECTORS ||
+                this.current_command === ATA_CMD_WRITE_SECTORS_EXT ||
+                this.current_command === ATA_CMD_WRITE_MULTIPLE_EXT,
                 "Unexpected command: " + h(this.current_command));
 
             // XXX: Should advance here, but do_write does all the advancing
@@ -2135,7 +2135,7 @@ IDEInterface.prototype.create_identify_packet = function()
 
         0, 0,
         // 63, dma supported mode, dma selected mode
-        this.current_command === 0xA0 ? 0 : 7, this.current_command === 0xA0 ? 0 : 4,
+        this.current_command === ATA_CMD_PACKET ? 0 : 7, this.current_command === ATA_CMD_PACKET ? 0 : 4,
         //0, 0, // no DMA
 
         0, 0,

--- a/src/ide.js
+++ b/src/ide.js
@@ -597,10 +597,8 @@ function IDEInterface(device, cpu, buffer, is_cd, device_nr, interface_nr, bus)
     this.in_progress_io_ids = new Set();
     this.cancelled_io_ids = new Set();
 
-    if(buffer)
-    {
-        this.set_cdrom(buffer);
-    }
+    // set optional buffer for both ATA and ATAPI
+    this.set_cdrom(buffer);
 
     Object.seal(this);
 }
@@ -620,12 +618,11 @@ IDEInterface.prototype.set_cdrom = function(buffer)
 {
     if(!buffer)
     {
-        this.eject();
         return;
     }
 
     this.buffer = buffer;
-    if(this.is_atapi)   /// TODO: redundant here in set_cdrom()? is_atapi === is_cd === true
+    if(this.is_atapi)
     {
         this.status = 0x59;
         this.error = 0x60;
@@ -638,13 +635,13 @@ IDEInterface.prototype.set_cdrom = function(buffer)
         this.sector_count = Math.ceil(this.sector_count);
     }
 
-    if(this.is_atapi)   /// TODO: redundant here in set_cdrom()? is_atapi === is_cd === true
+    if(this.is_atapi)
     {
         // default values: 1/2048
         this.head_count = 1;
         this.sectors_per_track = 2048;
     }
-    else                /// TODO: dead code?
+    else
     {
         // "default" values: 16/63
         // common: 255, 63

--- a/src/ide.js
+++ b/src/ide.js
@@ -37,6 +37,7 @@ export function IDEPCIAdapter(cpu, bus, adapter_config)
     this.bus = bus;
     this.primary = undefined;
     this.secondary = undefined;
+    this.channels = [undefined, undefined];
 
     const has_primary = adapter_config && adapter_config[0][0];
     const has_secondary = adapter_config && adapter_config[1][0];
@@ -44,7 +45,6 @@ export function IDEPCIAdapter(cpu, bus, adapter_config)
         DEBUG && Object.seal(this);
         return;
     }
-
     if(has_primary) {
         this.primary = new IDEDevice(this, adapter_config, 0, pri);
     }
@@ -52,6 +52,7 @@ export function IDEPCIAdapter(cpu, bus, adapter_config)
     if(has_secondary) {
         this.secondary = new IDEDevice(this, adapter_config, 1, sec);
     }
+    this.channels = [this.primary, this.secondary];
 
     const vendor_id = 0x8086;    // Intel Corporation
     const device_id = 0x7010;    // 82371SB PIIX3 IDE [Natoma/Triton II]
@@ -116,7 +117,7 @@ export function IDEPCIAdapter(cpu, bus, adapter_config)
  * @param {IDEPCIAdapter} adapter
  * @param {number} channel_nr
  * */
-function IDEDevice(adapter, adapter_config, channel_nr, channel_config)
+function IDEDevice(adapter, adapter_config, channel_nr, channel_config)     // TODO: rename this class to IDEChannel
 {
     this.adapter = adapter;
     this.cpu = adapter.cpu;
@@ -135,6 +136,7 @@ function IDEDevice(adapter, adapter_config, channel_nr, channel_config)
 
     this.master = create_interface(0);
     this.slave = create_interface(1);
+    this.interfaces = [this.master, this.slave];
     this.current_interface = this.master;
 
     this.name = "ide" + channel_nr;

--- a/src/ide.js
+++ b/src/ide.js
@@ -132,6 +132,7 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
     this.ata_port = channel_config.ata_port;
     this.ata_port_high = channel_config.ata_port_high;
     this.irq = channel_config.irq;
+    this.name = "ide" + channel_nr;
 
     const create_interface = interface_nr => {
         const config = adapter_config && adapter_config[channel_nr] ?
@@ -146,7 +147,8 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
     this.interfaces = [this.master, this.slave];
     this.current_interface = this.master;
 
-    this.name = "ide" + channel_nr;
+    this.master.init_interface();
+    this.slave.init_interface();
 
     /** @type {number} */
     this.device_control = 2;
@@ -178,57 +180,55 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
         return this.current_interface.read_data(4);
     });
 
-    // read Error register
     cpu.io.register_read(this.ata_port | 1, this, function()
     {
-        dbg_log("Read error: " + h(this.current_interface.error & 0xFF) +
-                " slave=" + (this.current_interface === this.slave), LOG_DISK);
+        dbg_log(this.current_interface.name + ": read Error register: " +
+            h(this.current_interface.error & 0xFF) + " slave=" +
+            (this.current_interface === this.slave), LOG_DISK);
         return this.current_interface.error & 0xFF;
     });
 
-    // read Sector Count register
     cpu.io.register_read(this.ata_port | 2, this, function()
     {
-        dbg_log("Read bytecount: " + h(this.current_interface.bytecount & 0xFF), LOG_DISK);
+        dbg_log(this.current_interface.name + ": read Sector Count register: " +
+            h(this.current_interface.bytecount & 0xFF), LOG_DISK);
         return this.current_interface.bytecount & 0xFF;
     });
 
-    // read LBA Low register
     cpu.io.register_read(this.ata_port | 3, this, function()
     {
-        dbg_log("Read sector: " + h(this.current_interface.sector & 0xFF), LOG_DISK);
+        dbg_log(this.current_interface.name + ": read LBA Low register: " +
+            h(this.current_interface.sector & 0xFF), LOG_DISK);
         return this.current_interface.sector & 0xFF;
     });
 
-    // read LBA Mid register
     cpu.io.register_read(this.ata_port | 4, this, function()
     {
-        dbg_log("Read 1F4: " + h(this.current_interface.cylinder_low & 0xFF), LOG_DISK);
+        dbg_log(this.current_interface.name + ": read LBA Mid register: " +
+            h(this.current_interface.cylinder_low & 0xFF), LOG_DISK);
         return this.current_interface.cylinder_low & 0xFF;
     });
 
-    // read LBA High register
     cpu.io.register_read(this.ata_port | 5, this, function()
     {
-        dbg_log("Read 1F5: " + h(this.current_interface.cylinder_high & 0xFF), LOG_DISK);
+        dbg_log(this.current_interface.name + ": read LBA High register: " +
+            h(this.current_interface.cylinder_high & 0xFF), LOG_DISK);
         return this.current_interface.cylinder_high & 0xFF;
     });
 
-    // read Device register
     cpu.io.register_read(this.ata_port | 6, this, function()
     {
-        dbg_log("Read 1F6", LOG_DISK);
+        dbg_log(this.current_interface.name + ": read Device register", LOG_DISK);
         return this.current_interface.drive_head & 0xFF;
     });
 
-    // read Status register
     cpu.io.register_read(this.ata_port | 7, this, function() {
-        dbg_log("lower irq", LOG_DISK);
+        dbg_log(this.current_interface.name + ": read Status register", LOG_DISK);
+        dbg_log(this.current_interface.name + ": lower IRQ " + this.irq, LOG_DISK);
         this.cpu.device_lower_irq(this.irq);
         return this.read_status();
     });
 
-    // write Data register
     cpu.io.register_write(this.ata_port | 0, this, function(data)
     {
         this.current_interface.write_data_port8(data);
@@ -240,10 +240,9 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
         this.current_interface.write_data_port32(data);
     });
 
-    // write Features register
     cpu.io.register_write(this.ata_port | 1, this, function(data)
     {
-        dbg_log("1F1/lba_count: " + h(data), LOG_DISK);
+        dbg_log(this.current_interface.name + ": write Features register: " + h(data), LOG_DISK);
 /***
  *      this.master.lba_count = (this.master.lba_count << 8 | data) & 0xFFFF;
  *      this.slave.lba_count = (this.slave.lba_count << 8 | data) & 0xFFFF;
@@ -251,10 +250,9 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
         this.current_interface.lba_count = (this.current_interface.lba_count << 8 | data) & 0xFFFF;
     });
 
-    // write Sector Count register
     cpu.io.register_write(this.ata_port | 2, this, function(data)
     {
-        dbg_log("1F2/bytecount: " + h(data), LOG_DISK);
+        dbg_log(this.current_interface.name + ": write Sector Count register: " + h(data), LOG_DISK);
 /***
  *      this.master.bytecount = (this.master.bytecount << 8 | data) & 0xFFFF;
  *      if(slave_buffer)
@@ -265,10 +263,9 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
         this.current_interface.bytecount = (this.current_interface.bytecount << 8 | data) & 0xFFFF;
     });
 
-    // write LBA Low register
     cpu.io.register_write(this.ata_port | 3, this, function(data)
     {
-        dbg_log("1F3/sector: " + h(data), LOG_DISK);
+        dbg_log(this.current_interface.name + ": write LBA Low register: " + h(data), LOG_DISK);
 /***
  *      this.master.sector = (this.master.sector << 8 | data) & 0xFFFF;
  *      if(slave_buffer)
@@ -279,10 +276,9 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
         this.current_interface.sector = (this.current_interface.sector << 8 | data) & 0xFFFF;
     });
 
-    // write LBA Mid register
     cpu.io.register_write(this.ata_port | 4, this, function(data)
     {
-        dbg_log("1F4/sector low: " + h(data), LOG_DISK);
+        dbg_log(this.current_interface.name + ": write LBA Mid register: " + h(data), LOG_DISK);
 /***
  *      this.master.cylinder_low = (this.master.cylinder_low << 8 | data) & 0xFFFF;
  *      if(slave_buffer)
@@ -293,10 +289,9 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
         this.current_interface.cylinder_low = (this.current_interface.cylinder_low << 8 | data) & 0xFFFF;
     });
 
-    // write LBA High register
     cpu.io.register_write(this.ata_port | 5, this, function(data)
     {
-        dbg_log("1F5/sector high: " + h(data), LOG_DISK);
+        dbg_log(this.current_interface.name + ": write LBA High register: " + h(data), LOG_DISK);
 /***
  *      this.master.cylinder_high = (this.master.cylinder_high << 8 | data) & 0xFFFF;
  *      if(slave_buffer)
@@ -307,22 +302,24 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
         this.current_interface.cylinder_high = (this.current_interface.cylinder_high << 8 | data) & 0xFFFF;
     });
 
-    // write Device register
     cpu.io.register_write(this.ata_port | 6, this, function(data)
     {
         var slave = data & 0x10;
-        var mode = data & 0xE0;
+        // var mode = data & 0xE0;  // unused
 
-        dbg_log("1F6/drive: " + h(data, 2), LOG_DISK);
-
-        if(slave)
+        dbg_log(this.current_interface.name + ": write Device register: " + h(data, 2), LOG_DISK);
+        if((slave && this.current_interface === this.master) || (!slave && this.current_interface === this.slave))
         {
-            dbg_log("Slave", LOG_DISK);
-            this.current_interface = this.slave;
-        }
-        else
-        {
-            this.current_interface = this.master;
+            if(slave)
+            {
+                dbg_log(this.current_interface.name + ": select slave device", LOG_DISK);
+                this.current_interface = this.slave;
+            }
+            else
+            {
+                dbg_log(this.current_interface.name + ": select master device", LOG_DISK);
+                this.current_interface = this.master;
+            }
         }
 /***
  *      this.master.drive_head = data;
@@ -335,10 +332,10 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
         this.current_interface.head = data & 0xF;
     });
 
-    // write Command register
     cpu.io.register_write(this.ata_port | 7, this, function(data)
     {
-        dbg_log("lower irq", LOG_DISK);
+        dbg_log(this.current_interface.name + ": write Command register", LOG_DISK);
+        dbg_log(this.current_interface.name + ": lower IRQ " + this.irq, LOG_DISK);
         this.cpu.device_lower_irq(this.irq);
         // clear error and DF bits
         this.current_interface.status &= ~(1 | (1 << 5));
@@ -378,19 +375,19 @@ function IDEChannel(adapter, adapter_config, channel_nr, channel_config)
 IDEChannel.prototype.read_status = function()
 {
     const ret = this.current_interface.drive_connected ? this.current_interface.status : 0;
-    dbg_log("dev "+this.name+" ATA read status: " + h(ret, 2), LOG_DISK);
+    dbg_log(this.current_interface.name + ": ATA read status: " + h(ret, 2), LOG_DISK);
     return ret;
 };
 
 IDEChannel.prototype.write_control = function(data)
 {
-    dbg_log("set device control: " + h(data, 2) + " interrupts " +
-            ((data & 2) ? "disabled" : "enabled"), LOG_DISK);
+    dbg_log(this.current_interface.name + ": write Device control register: " +
+        h(data, 2) + " interrupts " + ((data & 2) ? "disabled" : "enabled"), LOG_DISK);
 
     if(data & 0x04)
     {
-        dbg_log("Reset via control port", LOG_DISK);
-
+        dbg_log(this.current_interface.name + ": reset via control port", LOG_DISK);
+        dbg_log(this.current_interface.name + ": lower IRQ " + this.irq, LOG_DISK);
         this.cpu.device_lower_irq(this.irq);
 
         this.master.device_reset();
@@ -402,25 +399,25 @@ IDEChannel.prototype.write_control = function(data)
 
 IDEChannel.prototype.dma_read_addr = function()
 {
-    dbg_log("dma get address: " + h(this.prdt_addr, 8), LOG_DISK);
+    dbg_log(this.current_interface.name + ": DMA get address: " + h(this.prdt_addr, 8), LOG_DISK);
     return this.prdt_addr;
 };
 
 IDEChannel.prototype.dma_set_addr = function(data)
 {
-    dbg_log("dma set address: " + h(data, 8), LOG_DISK);
+    dbg_log(this.current_interface.name + ": DMA set address: " + h(data, 8), LOG_DISK);
     this.prdt_addr = data;
 };
 
 IDEChannel.prototype.dma_read_status = function()
 {
-    dbg_log("DMA read status: " + h(this.dma_status), LOG_DISK);
+    dbg_log(this.current_interface.name + ": DMA read status: " + h(this.dma_status), LOG_DISK);
     return this.dma_status;
 };
 
 IDEChannel.prototype.dma_write_status = function(value)
 {
-    dbg_log("DMA set status: " + h(value), LOG_DISK);
+    dbg_log(this.current_interface.name + ": DMA write status: " + h(value), LOG_DISK);
     this.dma_status &= ~(value & 6);
 };
 
@@ -431,13 +428,13 @@ IDEChannel.prototype.dma_read_command = function()
 
 IDEChannel.prototype.dma_read_command8 = function()
 {
-    dbg_log("DMA read command: " + h(this.dma_command), LOG_DISK);
+    dbg_log(this.current_interface.name + ": DMA read command: " + h(this.dma_command), LOG_DISK);
     return this.dma_command;
 };
 
 IDEChannel.prototype.dma_write_command = function(value)
 {
-    dbg_log("DMA write command: " + h(value), LOG_DISK);
+    dbg_log(this.current_interface.name + ": DMA write command: " + h(value), LOG_DISK);
 
     this.dma_write_command8(value & 0xFF);
     this.dma_write_status(value >> 16 & 0xFF);
@@ -445,7 +442,7 @@ IDEChannel.prototype.dma_write_command = function(value)
 
 IDEChannel.prototype.dma_write_command8 = function(value)
 {
-    dbg_log("DMA write command8: " + h(value), LOG_DISK);
+    dbg_log(this.current_interface.name + ": DMA write command8: " + h(value), LOG_DISK);
 
     const old_command = this.dma_command;
     this.dma_command = value & 0x09;
@@ -480,9 +477,9 @@ IDEChannel.prototype.dma_write_command8 = function(value)
             break;
 
         default:
-            dbg_log("Spurious dma command write, current command: " +
+            dbg_log(this.current_interface.name + ": spurious DMA command write, current command: " +
                     h(this.current_interface.current_command), LOG_DISK);
-            dbg_log("dev "+this.name+" DMA clear status 1 bit, set status 2 bit", LOG_DISK);
+            dbg_log(this.current_interface.name + ": DMA clear status 1 bit, set status 2 bit", LOG_DISK);
             this.dma_status &= ~1;
             this.dma_status |= 2;
             this.push_irq();
@@ -494,7 +491,7 @@ IDEChannel.prototype.push_irq = function()
 {
     if((this.device_control & 2) === 0)
     {
-        dbg_log("push irq", LOG_DISK);
+        dbg_log(this.current_interface.name + ": push IRQ " + this.irq, LOG_DISK);
         this.dma_status |= 4;
         this.cpu.device_raise_irq(this.irq);
     }
@@ -536,14 +533,13 @@ IDEChannel.prototype.set_state = function(state)
     this.dma_command = state[12];
 };
 
-
 /**
  * @constructor
  */
 function IDEInterface(channel, cpu, buffer, is_cd, channel_nr, interface_nr, bus)
 {
     this.channel = channel;
-    this.name = channel.name + ":" + interface_nr;
+    this.name = channel.name + "." + interface_nr;
 
     /** @const @type {BusConnector} */
     this.bus = bus;
@@ -649,11 +645,16 @@ function IDEInterface(channel, cpu, buffer, is_cd, channel_nr, interface_nr, bus
     this.in_progress_io_ids = new Set();
     this.cancelled_io_ids = new Set();
 
-    this.set_cdrom(buffer);
-    this.media_changed = false;
-
-    Object.seal(this);
+    // caller must call this.init_interface() to complete object initialization
+    this.inital_buffer = buffer;
 }
+
+IDEInterface.prototype.init_interface = function()
+{
+    this.set_disk_buffer(this.inital_buffer);
+    delete this.inital_buffer;
+    Object.seal(this);
+};
 
 IDEInterface.prototype.eject = function()
 {
@@ -669,12 +670,20 @@ IDEInterface.prototype.eject = function()
 
 IDEInterface.prototype.set_cdrom = function(buffer)
 {
+    if(this.is_atapi && buffer)
+    {
+        this.set_disk_buffer(buffer);
+        this.media_changed = true;
+    }
+};
+
+IDEInterface.prototype.set_disk_buffer = function(buffer)
+{
     if(!buffer)
     {
         return;
     }
 
-    this.media_changed = true;
     this.buffer = buffer;
     if(this.is_atapi)
     {
@@ -685,7 +694,7 @@ IDEInterface.prototype.set_cdrom = function(buffer)
 
     if(this.sector_count !== (this.sector_count | 0))
     {
-        dbg_log("Warning: Disk size not aligned with sector size", LOG_DISK);
+        dbg_log(this.name + ": Warning: disk size not aligned with sector size", LOG_DISK);
         this.sector_count = Math.ceil(this.sector_count);
     }
 
@@ -707,7 +716,7 @@ IDEInterface.prototype.set_cdrom = function(buffer)
 
     if(this.cylinder_count !== (this.cylinder_count | 0))
     {
-        dbg_log("Warning: Rounding up cylinder count. Choose different head number", LOG_DISK);
+        dbg_log(this.name + ": Warning: rounding up cylinder count, choose different head number", LOG_DISK);
         this.cylinder_count = Math.floor(this.cylinder_count);
     }
 
@@ -766,11 +775,11 @@ IDEInterface.prototype.push_irq = function()
 
 IDEInterface.prototype.ata_command = function(cmd)
 {
-    dbg_log("ATA Command: " + h(cmd) + " slave=" + (this.drive_head >> 4 & 1), LOG_DISK);
+    dbg_log(this.name + ": ATA Command: " + h(cmd) + " slave=" + (this.drive_head >> 4 & 1), LOG_DISK);
 
     if(!this.drive_connected && cmd !== 0x90)
     {
-        dbg_log("ignored: No slave drive connected", LOG_DISK);
+        dbg_log(this.name + ": ATA command ignored: No slave drive connected", LOG_DISK);
         return;
     }
 
@@ -780,7 +789,7 @@ IDEInterface.prototype.ata_command = function(cmd)
     switch(cmd)
     {
         case 0x08:
-            dbg_log("ATA device reset", LOG_DISK);
+            dbg_log(this.name + ": ATA device reset", LOG_DISK);
             this.data_pointer = 0;
             this.data_end = 0;
             this.data_length = 0;
@@ -789,14 +798,14 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case 0x10:
-            // calibrate drive
+            dbg_log(this.name + ": ATA calibrate drive", LOG_DISK);     // ATA/ATAPI-6: obsolete
             this.status = 0x50;
             this.cylinder_low = 0;
             this.push_irq();
             break;
 
         case 0xF8:
-            // read native max address
+            dbg_log(this.name + ": ATA read native max address", LOG_DISK);
             this.status = 0x50;
             var last_sector = this.sector_count - 1;
             this.sector = last_sector & 0xFF;
@@ -807,7 +816,7 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case 0x27:
-            // read native max address ext
+            dbg_log(this.name + ": ATA read native max address ext", LOG_DISK);
             this.status = 0x50;
             var last_sector = this.sector_count - 1;
             this.sector = last_sector & 0xFF;
@@ -840,7 +849,7 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case 0x90:
-            // execute device diagnostic
+            dbg_log(this.name + ": ATA execute device diagnostic", LOG_DISK);
             // assign diagnostics code (used to be 0x101?) to error register
             if(this.interface_nr === 0) {
                 // master drive is currently selected
@@ -864,7 +873,7 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case 0x91:
-            // initialize device parameters
+            // initialize device parameters (not mentioned in ATA/ATAPI-6)
             this.status = 0x50;
             this.push_irq();
             break;
@@ -882,8 +891,7 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case 0xA1:
-            dbg_log("ATA identify packet device", LOG_DISK);
-
+            dbg_log(this.name + ": ATA identify packet device", LOG_DISK);
             if(this.is_atapi)
             {
                 this.create_identify_packet();
@@ -902,9 +910,9 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case 0xC6:
-            // set multiple mode
+            dbg_log(this.name + ": ATA set multiple mode", LOG_DISK);
             // Logical sectors per DRQ Block in word 1
-            dbg_log("Logical sectors per DRQ Block: " + h(this.bytecount & 0xFF), LOG_DISK);
+            dbg_log(this.name + ": logical sectors per DRQ Block: " + h(this.bytecount & 0xFF), LOG_DISK);
             this.sectors_per_drq = this.bytecount & 0xFF;
             this.status = 0x50;
             this.push_irq();
@@ -921,13 +929,13 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case 0x40:
-            dbg_log("read verify sectors", LOG_DISK);
+            dbg_log(this.name + ": ATA read verify sector(s)", LOG_DISK);
             this.status = 0x50;
             this.push_irq();
             break;
 
         case 0xDA:
-            dbg_log("ATA get media status", LOG_DISK);
+            dbg_log(this.name + ": ATA get media status", LOG_DISK);
             this.status = 0x50;
             this.error = 0;
             if(this.is_atapi) {
@@ -944,25 +952,25 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case 0xE0:
-            dbg_log("ATA standby immediate", LOG_DISK);
+            dbg_log(this.name + ": ATA standby immediate", LOG_DISK);
             this.status = 0x50;
             this.push_irq();
             break;
 
         case 0xE1:
-            dbg_log("ATA idle immediate", LOG_DISK);
+            dbg_log(this.name + ": ATA idle immediate", LOG_DISK);
             this.status = 0x50;
             this.push_irq();
             break;
 
         case 0xE7:
-            dbg_log("ATA flush cache", LOG_DISK);
+            dbg_log(this.name + ": ATA flush cache", LOG_DISK);
             this.status = 0x50;
             this.push_irq();
             break;
 
         case 0xEC:
-            dbg_log("ATA identify device", LOG_DISK);
+            dbg_log(this.name + ": ATA identify device", LOG_DISK);
 
             if(this.is_atapi)
             {
@@ -979,37 +987,37 @@ IDEInterface.prototype.ata_command = function(cmd)
             break;
 
         case 0xEA:
-            dbg_log("flush cache ext", LOG_DISK);
+            dbg_log(this.name + ": ATA flush cache ext", LOG_DISK);
             this.status = 0x50;
             this.push_irq();
             break;
 
         case 0xEF:
-            dbg_log("set features: " + h(this.bytecount & 0xFF), LOG_DISK);
+            dbg_log(this.name + ": ATA set features: " + h(this.bytecount & 0xFF), LOG_DISK);
             this.status = 0x50;
             this.push_irq();
             break;
 
         case 0xDE:
-            // obsolete
+            dbg_log(this.name + ": ATA media lock", LOG_DISK);
             this.status = 0x50;
             this.push_irq();
             break;
 
         case 0xF5:
-            dbg_log("security freeze lock", LOG_DISK);
+            dbg_log(this.name + ": ATA security freeze lock", LOG_DISK);
             this.status = 0x50;
             this.push_irq();
             break;
 
         case 0xF9:
-            dbg_log("Unimplemented: set max address", LOG_DISK);
+            dbg_log(this.name + ": ATA set max address (unimplemented)", LOG_DISK);
             this.status = 0x41;
             this.error = 4;
             break;
 
         default:
-            dbg_assert(false, "New ATA cmd on 1F7: " + h(cmd), LOG_DISK);
+            dbg_assert(false, this.name + ": unhandled ATA command: " + h(cmd), LOG_DISK);
 
             this.status = 0x41;
             // abort bit set
@@ -1019,7 +1027,7 @@ IDEInterface.prototype.ata_command = function(cmd)
 
 IDEInterface.prototype.atapi_handle = function()
 {
-    dbg_log("ATAPI Command: " + h(this.data[0]) +
+    dbg_log(this.name + ": ATAPI Command: " + h(this.data[0]) +
             " slave=" + (this.drive_head >> 4 & 1), LOG_DISK);
 
     this.data_pointer = 0;
@@ -1030,7 +1038,7 @@ IDEInterface.prototype.atapi_handle = function()
                         this.current_atapi_command === 0x43 ||
                         this.current_atapi_command === 0x51))
     {
-        dbg_log("dev "+this.channel.name+" CD read-related action: no buffer", LOG_DISK);
+        dbg_log(this.name + ": CD read-related action: no buffer", LOG_DISK);
         this.status = 0x51;
         this.error = 0x21;
         this.data_allocate(0);
@@ -1043,7 +1051,7 @@ IDEInterface.prototype.atapi_handle = function()
     switch(this.current_atapi_command)
     {
         case 0x00:
-            dbg_log("test unit ready", LOG_DISK);
+            dbg_log(this.name + ": test unit ready", LOG_DISK);
             // test unit ready
             this.data_allocate(0);
             this.data_end = this.data_length;
@@ -1066,7 +1074,7 @@ IDEInterface.prototype.atapi_handle = function()
             var length = this.data[4];
             this.status = 0x58;
 
-            dbg_log("inquiry: " + h(this.data[1], 2) + " length=" + length, LOG_DISK);
+            dbg_log(this.name + ": inquiry: " + h(this.data[1], 2) + " length=" + length, LOG_DISK);
 
             // http://www.t10.org/ftp/x3t9.2/document.87/87-106r0.txt
             //this.data_allocate(36);
@@ -1139,7 +1147,7 @@ IDEInterface.prototype.atapi_handle = function()
             var length = this.data[8];
             this.data_allocate(Math.min(8, length));
             this.data_end = this.data_length;
-            dbg_log("read q subcode: length=" + length, LOG_DISK);
+            dbg_log(this.name + ": read q subcode: length=" + length, LOG_DISK);
             this.status = 0x58;
             break;
 
@@ -1150,7 +1158,7 @@ IDEInterface.prototype.atapi_handle = function()
 
             this.data_allocate(length);
             this.data_end = this.data_length;
-            dbg_log("read toc: " + h(format, 2) +
+            dbg_log(this.name + ": read toc: " + h(format, 2) +
                     " length=" + length +
                     " " + (this.data[1] & 2) +
                     " " + h(this.data[6]), LOG_DISK);
@@ -1191,7 +1199,7 @@ IDEInterface.prototype.atapi_handle = function()
             }
             else
             {
-                dbg_assert(false, "Unimplemented format: " + format);
+                dbg_assert(false, this.name + ": Unimplemented format: " + format);
             }
 
             this.status = 0x58;
@@ -1220,7 +1228,7 @@ IDEInterface.prototype.atapi_handle = function()
             break;
 
         case 0x52:
-            dbg_log("Unimplemented ATAPI command: " + h(this.data[0]), LOG_DISK);
+            dbg_log(this.name + ": unimplemented ATAPI command: " + h(this.data[0]), LOG_DISK);
             this.status = 0x51;
             this.data_length = 0;
             this.error = 5 << 4;
@@ -1230,7 +1238,7 @@ IDEInterface.prototype.atapi_handle = function()
             // mode sense
             var length = this.data[8] | this.data[7] << 8;
             var page_code = this.data[2];
-            dbg_log("mode sense: " + h(page_code) + " length=" + length, LOG_DISK);
+            dbg_log(this.name + ": mode sense: " + h(page_code) + " length=" + length, LOG_DISK);
             if(page_code === 0x2A)
             {
                 this.data_allocate(Math.min(30, length));
@@ -1251,12 +1259,12 @@ IDEInterface.prototype.atapi_handle = function()
             this.status = 0x51;
             this.data_length = 0;
             this.error = 5 << 4;
-            dbg_log("Unimplemented ATAPI command: " + h(this.data[0]), LOG_DISK);
+            dbg_log(this.name + ": unimplemented ATAPI command: " + h(this.data[0]), LOG_DISK);
             break;
 
         case 0xBE:
             // Hiren's boot CD
-            dbg_log("Unimplemented ATAPI command: " + h(this.data[0]), LOG_DISK);
+            dbg_log(this.name + ": unimplemented ATAPI command: " + h(this.data[0]), LOG_DISK);
             this.data_allocate(0);
             this.data_end = this.data_length;
             this.status = 0x50;
@@ -1266,7 +1274,7 @@ IDEInterface.prototype.atapi_handle = function()
             this.status = 0x51;
             this.data_length = 0;
             this.error = 5 << 4;
-            dbg_log("Unimplemented ATAPI command: " + h(this.data[0]), LOG_DISK);
+            dbg_log(this.name + ": unimplemented ATAPI command: " + h(this.data[0]), LOG_DISK);
             dbg_assert(false);
     }
 
@@ -1312,14 +1320,14 @@ IDEInterface.prototype.atapi_read = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log("CD read lba=" + h(lba) +
+    dbg_log(this.name + ": CD read lba=" + h(lba) +
             " lbacount=" + h(count) +
             " bytecount=" + h(byte_count) +
             " flags=" + h(flags), LOG_DISK);
 
     this.data_length = 0;
     var req_length = this.cylinder_high << 8 & 0xFF00 | this.cylinder_low & 0xFF;
-    dbg_log(h(this.cylinder_high, 2) + " " + h(this.cylinder_low, 2), LOG_DISK);
+    dbg_log(this.name + ": " + h(this.cylinder_high, 2) + " " + h(this.cylinder_low, 2), LOG_DISK);
     this.cylinder_low = this.cylinder_high = 0; // oak technology driver (windows 3.0)
 
     if(req_length === 0xFFFF)
@@ -1332,14 +1340,14 @@ IDEInterface.prototype.atapi_read = function(cmd)
 
     if(!this.buffer)
     {
-        dbg_assert(false, "dev "+this.channel.name+" CD read: no buffer", LOG_DISK);
+        dbg_assert(false, this.name + ": CD read: no buffer", LOG_DISK);
         this.status = 0xFF;
         this.error = 0x41;
         this.push_irq();
     }
     else if(start >= this.buffer.byteLength)
     {
-        dbg_assert(false, "dev "+this.channel.name+" CD read: Outside of disk  end=" + h(start + byte_count) +
+        dbg_assert(false, this.name + ": CD read: Outside of disk  end=" + h(start + byte_count) +
                           " size=" + h(this.buffer.byteLength), LOG_DISK);
 
         this.status = 0xFF;
@@ -1361,7 +1369,7 @@ IDEInterface.prototype.atapi_read = function(cmd)
         this.read_buffer(start, byte_count, (data) =>
         {
             //setTimeout(() => {
-            dbg_log("cd read: data arrived", LOG_DISK);
+            dbg_log(this.name + ": CD read: data arrived", LOG_DISK);
             this.data_set(data);
             this.status = 0x58;
             this.bytecount = this.bytecount & ~7 | 2;
@@ -1393,14 +1401,14 @@ IDEInterface.prototype.atapi_read_dma = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log("CD read DMA lba=" + h(lba) +
+    dbg_log(this.name + ": CD read DMA lba=" + h(lba) +
             " lbacount=" + h(count) +
             " bytecount=" + h(byte_count) +
             " flags=" + h(flags), LOG_DISK);
 
     if(start >= this.buffer.byteLength)
     {
-        dbg_assert(false, "CD read: Outside of disk  end=" + h(start + byte_count) +
+        dbg_assert(false, this.name + ": CD read: Outside of disk  end=" + h(start + byte_count) +
                           " size=" + h(this.buffer.byteLength), LOG_DISK);
 
         this.status = 0xFF;
@@ -1413,7 +1421,7 @@ IDEInterface.prototype.atapi_read_dma = function(cmd)
 
         this.read_buffer(start, byte_count, (data) =>
         {
-            dbg_log("atapi_read_dma: Data arrived");
+            dbg_log(this.name + ": atapi_read_dma: Data arrived");
             this.report_read_end(byte_count);
             this.status = 0x58;
             this.bytecount = this.bytecount & ~7 | 2;
@@ -1428,17 +1436,17 @@ IDEInterface.prototype.do_atapi_dma = function()
 {
     if((this.channel.dma_status & 1) === 0)
     {
-        dbg_log("do_atapi_dma: Status not set", LOG_DISK);
+        dbg_log(this.name + ": do_atapi_dma: Status not set", LOG_DISK);
         return;
     }
 
     if((this.status & 0x8) === 0)
     {
-        dbg_log("do_atapi_dma: DRQ not set", LOG_DISK);
+        dbg_log(this.name + ": do_atapi_dma: DRQ not set", LOG_DISK);
         return;
     }
 
-    dbg_log("atapi dma transfer len=" + this.data_length, LOG_DISK);
+    dbg_log(this.name + ": ATAPI DMA transfer len=" + this.data_length, LOG_DISK);
 
     var prdt_start = this.channel.prdt_addr;
     var offset = 0;
@@ -1455,7 +1463,7 @@ IDEInterface.prototype.do_atapi_dma = function()
             count = 0x10000;
         }
 
-        dbg_log("dma read dest=" + h(addr) + " count=" + h(count) + " datalen=" + h(this.data_length), LOG_DISK);
+        dbg_log(this.name + ": DMA read dest=" + h(addr) + " count=" + h(count) + " datalen=" + h(this.data_length), LOG_DISK);
         this.cpu.write_blob(data.subarray(offset, Math.min(offset + count, this.data_length)), addr);
 
         offset += count;
@@ -1463,7 +1471,7 @@ IDEInterface.prototype.do_atapi_dma = function()
 
         if(offset >= this.data_length && !end)
         {
-            dbg_log("leave early end=" + (+end) +
+            dbg_log(this.name + ": leave early end=" + (+end) +
                     " offset=" + h(offset) +
                     " data_length=" + h(this.data_length) +
                     " cmd=" + h(this.current_command), LOG_DISK);
@@ -1472,7 +1480,7 @@ IDEInterface.prototype.do_atapi_dma = function()
     }
     while(!end);
 
-    dbg_log("end offset=" + offset, LOG_DISK);
+    dbg_log(this.name + ": end offset=" + offset, LOG_DISK);
 
     this.status = 0x50;
     this.channel.dma_status &= ~1;
@@ -1505,7 +1513,7 @@ IDEInterface.prototype.read_data = function(length)
         var align = (this.data_end & 0xFFF) === 0 ? 0xFFF : 0xFF;
         if((this.data_pointer & align) === 0)
         {
-            dbg_log("Read 1F0: " + h(this.data[this.data_pointer], 2) +
+            dbg_log(this.name + ": read 1F0: " + h(this.data[this.data_pointer], 2) +
                         " cur=" + h(this.data_pointer) +
                         " cnt=" + h(this.data_length), LOG_DISK);
         }
@@ -1519,7 +1527,7 @@ IDEInterface.prototype.read_data = function(length)
     }
     else
     {
-        dbg_log("Read 1F0: empty", LOG_DISK);
+        dbg_log(this.name + ": read 1F0: empty", LOG_DISK);
 
         this.data_pointer += length;
         return 0;
@@ -1528,8 +1536,9 @@ IDEInterface.prototype.read_data = function(length)
 
 IDEInterface.prototype.read_end = function()
 {
-    dbg_log("read_end cmd=" + h(this.current_command) + " data_pointer=" + h(this.data_pointer) +
-            " end=" + h(this.data_end) + " length=" + h(this.data_length), LOG_DISK);
+    dbg_log(this.name + ": read_end cmd=" + h(this.current_command) +
+            " data_pointer=" + h(this.data_pointer) + " end=" + h(this.data_end) +
+            " length=" + h(this.data_length), LOG_DISK);
 
     if(this.current_command === 0xA0)
     {
@@ -1556,7 +1565,7 @@ IDEInterface.prototype.read_end = function()
             {
                 this.data_end += byte_count;
             }
-            dbg_log("data_end=" + h(this.data_end), LOG_DISK);
+            dbg_log(this.name + ": data_end=" + h(this.data_end), LOG_DISK);
         }
     }
     else
@@ -1593,16 +1602,16 @@ IDEInterface.prototype.write_data_port = function(data, length)
 
     if(this.data_pointer >= this.data_end)
     {
-        dbg_log("Redundant write to data port: " + h(data) + " count=" + h(this.data_end) +
-                " cur=" + h(this.data_pointer), LOG_DISK);
+        dbg_log(this.name + ": redundant write to data port: " + h(data) + " count=" +
+                h(this.data_end) + " cur=" + h(this.data_pointer), LOG_DISK);
     }
     else
     {
         var align = (this.data_end & 0xFFF) === 0 ? 0xFFF : 0xFF;
         if((this.data_pointer + length & align) === 0 || this.data_end < 20)
         {
-            dbg_log("Data port: " + h(data >>> 0) + " count=" + h(this.data_end) +
-                    " cur=" + h(this.data_pointer), LOG_DISK);
+            dbg_log(this.name + ": data port: " + h(data >>> 0) + " count=" +
+                    h(this.data_end) + " cur=" + h(this.data_pointer), LOG_DISK);
         }
 
         if(length === 1)
@@ -1651,7 +1660,7 @@ IDEInterface.prototype.write_end = function()
     }
     else
     {
-        dbg_log("write_end data_pointer=" + h(this.data_pointer) +
+        dbg_log(this.name + ": write_end data_pointer=" + h(this.data_pointer) +
                 " data_length=" + h(this.data_length), LOG_DISK);
 
         if(this.data_pointer >= this.data_length)
@@ -1676,7 +1685,7 @@ IDEInterface.prototype.write_end = function()
 
 IDEInterface.prototype.ata_advance = function(cmd, sectors)
 {
-    dbg_log("Advance sectors=" + sectors + " old_bytecount=" + this.bytecount, LOG_DISK);
+    dbg_log(this.name + ": advance sectors=" + sectors + " old_bytecount=" + this.bytecount, LOG_DISK);
     this.bytecount -= sectors;
 
     if(cmd === 0x24 || cmd === 0x29 || cmd === 0x34 || cmd === 0x39 ||
@@ -1720,7 +1729,7 @@ IDEInterface.prototype.ata_read_sectors = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log("ATA read cmd=" + h(cmd) +
+    dbg_log(this.name + ": ATA read cmd=" + h(cmd) +
             " mode=" + (this.is_lba ? "lba" : "chs") +
             " lba=" + h(lba) +
             " lbacount=" + h(count) +
@@ -1728,7 +1737,7 @@ IDEInterface.prototype.ata_read_sectors = function(cmd)
 
     if(start + byte_count > this.buffer.byteLength)
     {
-        dbg_assert(false, "ATA read: Outside of disk", LOG_DISK);
+        dbg_assert(false, this.name + ": ATA read: Outside of disk", LOG_DISK);
 
         this.status = 0xFF;
         this.push_irq();
@@ -1741,7 +1750,7 @@ IDEInterface.prototype.ata_read_sectors = function(cmd)
         this.read_buffer(start, byte_count, (data) =>
         {
             //setTimeout(() => {
-            dbg_log("ata_read: Data arrived", LOG_DISK);
+            dbg_log(this.name + ": ata_read: Data arrived", LOG_DISK);
 
             this.data_set(data);
             this.status = 0x58;
@@ -1764,13 +1773,13 @@ IDEInterface.prototype.ata_read_sectors_dma = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log("ATA DMA read lba=" + h(lba) +
+    dbg_log(this.name + ": ATA DMA read lba=" + h(lba) +
             " lbacount=" + h(count) +
             " bytecount=" + h(byte_count), LOG_DISK);
 
     if(start + byte_count > this.buffer.byteLength)
     {
-        dbg_assert(false, "ATA read: Outside of disk", LOG_DISK);
+        dbg_assert(false, this.name + ": ATA read: Outside of disk", LOG_DISK);
 
         this.status = 0xFF;
         this.push_irq();
@@ -1801,7 +1810,7 @@ IDEInterface.prototype.do_ata_read_sectors_dma = function()
     this.read_buffer(start, byte_count, (data) =>
     {
         //setTimeout(function() {
-        dbg_log("do_ata_read_sectors_dma: Data arrived", LOG_DISK);
+        dbg_log(this.name + ": do_ata_read_sectors_dma: Data arrived", LOG_DISK);
         var prdt_start = this.channel.prdt_addr;
         var offset = 0;
 
@@ -1815,10 +1824,10 @@ IDEInterface.prototype.do_ata_read_sectors_dma = function()
             if(!prd_count)
             {
                 prd_count = 0x10000;
-                dbg_log("dma: prd count was 0", LOG_DISK);
+                dbg_log(this.name + ": DMA: prd count was 0", LOG_DISK);
             }
 
-            dbg_log("dma read transfer dest=" + h(prd_addr) +
+            dbg_log(this.name + ": DMA read transfer dest=" + h(prd_addr) +
                     " prd_count=" + h(prd_count), LOG_DISK);
             this.cpu.write_blob(data.subarray(offset, offset + prd_count), prd_addr);
 
@@ -1851,14 +1860,14 @@ IDEInterface.prototype.ata_write_sectors = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log("ATA write lba=" + h(lba) +
+    dbg_log(this.name + ": ATA write lba=" + h(lba) +
             " mode=" + (this.is_lba ? "lba" : "chs") +
             " lbacount=" + h(count) +
             " bytecount=" + h(byte_count), LOG_DISK);
 
     if(start + byte_count > this.buffer.byteLength)
     {
-        dbg_assert(false, "ATA write: Outside of disk", LOG_DISK);
+        dbg_assert(false, this.name + ": ATA write: Outside of disk", LOG_DISK);
 
         this.status = 0xFF;
         this.push_irq();
@@ -1881,13 +1890,13 @@ IDEInterface.prototype.ata_write_sectors_dma = function(cmd)
     var byte_count = count * this.sector_size;
     var start = lba * this.sector_size;
 
-    dbg_log("ATA DMA write lba=" + h(lba) +
+    dbg_log(this.name + ": ATA DMA write lba=" + h(lba) +
             " lbacount=" + h(count) +
             " bytecount=" + h(byte_count), LOG_DISK);
 
     if(start + byte_count > this.buffer.byteLength)
     {
-        dbg_assert(false, "ATA DMA write: Outside of disk", LOG_DISK);
+        dbg_assert(false, this.name + ": ATA DMA write: Outside of disk", LOG_DISK);
 
         this.status = 0xFF;
         this.push_irq();
@@ -1912,7 +1921,7 @@ IDEInterface.prototype.do_ata_write_sectors_dma = function()
     var prdt_start = this.channel.prdt_addr;
     var offset = 0;
 
-    dbg_log("prdt addr: " + h(prdt_start, 8), LOG_DISK);
+    dbg_log(this.name + ": prdt addr: " + h(prdt_start, 8), LOG_DISK);
 
     const buffer = new Uint8Array(byte_count);
 
@@ -1924,10 +1933,10 @@ IDEInterface.prototype.do_ata_write_sectors_dma = function()
         if(!prd_count)
         {
             prd_count = 0x10000;
-            dbg_log("dma: prd count was 0", LOG_DISK);
+            dbg_log(this.name + ": DMA: prd count was 0", LOG_DISK);
         }
 
-        dbg_log("dma write transfer dest=" + h(prd_addr) + " prd_count=" + h(prd_count), LOG_DISK);
+        dbg_log(this.name + ": DMA write transfer dest=" + h(prd_addr) + " prd_count=" + h(prd_count), LOG_DISK);
 
         var slice = this.cpu.mem8.subarray(prd_addr, prd_addr + prd_count);
         dbg_assert(slice.length === prd_count);
@@ -1948,7 +1957,7 @@ IDEInterface.prototype.do_ata_write_sectors_dma = function()
 
     this.buffer.set(start, buffer, () =>
     {
-        dbg_log("dma write completed", LOG_DISK);
+        dbg_log(this.name + ": DMA write completed", LOG_DISK);
         this.ata_advance(this.current_command, count);
         this.status = 0x50;
         this.push_irq();
@@ -1965,7 +1974,7 @@ IDEInterface.prototype.get_chs = function()
     var h = this.head;
     var s = this.sector & 0xFF;
 
-    dbg_log("get_chs: c=" + c + " h=" + h + " s=" + s, LOG_DISK);
+    dbg_log(this.name + ": get_chs: c=" + c + " h=" + h + " s=" + s, LOG_DISK);
 
     return (c * this.head_count + h) * this.sectors_per_track + s - 1;
 };

--- a/src/ide.js
+++ b/src/ide.js
@@ -184,6 +184,7 @@ const ATAPI_CF_NONE = 0x00;         // no flags
 const ATAPI_CF_NEEDS_DISK = 0x01;   // command needs inserted disk
 const ATAPI_CF_UNIT_ATTN = 0x02;    // bounce command if unit attention condition is active
 
+// ATAPI commands, for flags see [MMC-3] 4.2.6
 const ATAPI_CMD =
 {
     [ATAPI_CMD_GET_CONFIGURATION]:             {name: "GET CONFIGURATION",             flags: ATAPI_CF_NONE},
@@ -192,17 +193,17 @@ const ATAPI_CMD =
     [ATAPI_CMD_MECHANISM_STATUS]:              {name: "MECHANISM STATUS",              flags: ATAPI_CF_NONE},
     [ATAPI_CMD_MODE_SENSE_6]:                  {name: "MODE SENSE (6)",                flags: ATAPI_CF_NONE},
     [ATAPI_CMD_MODE_SENSE_10]:                 {name: "MODE SENSE (10)",               flags: ATAPI_CF_NONE},
-    [ATAPI_CMD_PAUSE]:                         {name: "PAUSE",                         flags: ATAPI_CF_NONE},
+    [ATAPI_CMD_PAUSE]:                         {name: "PAUSE",                         flags: ATAPI_CF_NEEDS_DISK},
     [ATAPI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL]:  {name: "PREVENT ALLOW MEDIUM REMOVAL",  flags: ATAPI_CF_NONE},
     [ATAPI_CMD_READ]:                          {name: "READ",                          flags: ATAPI_CF_NEEDS_DISK},
     [ATAPI_CMD_READ_CAPACITY]:                 {name: "READ CAPACITY",                 flags: ATAPI_CF_NEEDS_DISK},
-    [ATAPI_CMD_READ_CD]:                       {name: "READ CD",                       flags: ATAPI_CF_NONE},
+    [ATAPI_CMD_READ_CD]:                       {name: "READ CD",                       flags: ATAPI_CF_NEEDS_DISK},
     [ATAPI_CMD_READ_DISK_INFORMATION]:         {name: "READ DISK INFORMATION",         flags: ATAPI_CF_NEEDS_DISK},
     [ATAPI_CMD_READ_SUBCHANNEL]:               {name: "READ SUBCHANNEL",               flags: ATAPI_CF_NEEDS_DISK},
     [ATAPI_CMD_READ_TOC_PMA_ATIP]:             {name: "READ TOC PMA ATIP",             flags: ATAPI_CF_NEEDS_DISK},
-    [ATAPI_CMD_READ_TRACK_INFORMATION]:        {name: "READ TRACK INFORMATION",        flags: ATAPI_CF_NONE},
+    [ATAPI_CMD_READ_TRACK_INFORMATION]:        {name: "READ TRACK INFORMATION",        flags: ATAPI_CF_NEEDS_DISK},
     [ATAPI_CMD_REQUEST_SENSE]:                 {name: "REQUEST SENSE",                 flags: ATAPI_CF_NONE},
-    [ATAPI_CMD_TEST_UNIT_READY]:               {name: "TEST UNIT READY",               flags: ATAPI_CF_NONE},
+    [ATAPI_CMD_TEST_UNIT_READY]:               {name: "TEST UNIT READY",               flags: ATAPI_CF_NEEDS_DISK},
 };
 
 // ATAPI device signature

--- a/src/ide.js
+++ b/src/ide.js
@@ -1106,6 +1106,8 @@ IDEInterface.prototype.ata_command = function(cmd)
             do_dbg_log = false;
             if(this.is_atapi)
             {
+                this.lba_mid_reg = ATAPI_SIGNATURE_LO;  // see [ATA8-ACS] 4.3
+                this.lba_high_reg = ATAPI_SIGNATURE_HI;
                 this.ata_abort_command();
             }
             else
@@ -1257,6 +1259,8 @@ IDEInterface.prototype.ata_command = function(cmd)
         case ATA_CMD_IDENTIFY_DEVICE:
             if(this.is_atapi)
             {
+                this.lba_mid_reg = ATAPI_SIGNATURE_LO;  // see [ATA8-ACS] 4.3
+                this.lba_high_reg = ATAPI_SIGNATURE_HI;
                 this.ata_abort_command();
             }
             else

--- a/src/ide.js
+++ b/src/ide.js
@@ -44,7 +44,7 @@ const HD_SECTOR_SIZE = 512;
 // Read-only registers:
 const ATA_REG_ERROR      = 0x01;  // Error register, see [ATA-6] 7.9
 const ATA_REG_STATUS     = 0x07;  // Status register, see [ATA-6] 7.15
-const ATA_REG_ALT_STATUS = 0x02;  // (*1*) Alternate Status register, see [ATA-6] 7.3
+const ATA_REG_ALT_STATUS = 0x00;  // (*1*) Alternate Status register, see [ATA-6] 7.3
 // Read-/writable registers:
 const ATA_REG_DATA       = 0x00;  // Data register, see [ATA-6] 7.6
 const ATA_REG_SECTOR     = 0x02;  // Sector Count register, see [ATA-6] 7.14
@@ -55,7 +55,7 @@ const ATA_REG_DEVICE     = 0x06;  // Device register, see [ATA-6] 7.7
 // Write-only registers:
 const ATA_REG_FEATURES   = 0x01;  // Features register, see [ATA-6] 7.10
 const ATA_REG_COMMAND    = 0x07;  // Command register, see [ATA-6] 7.4
-const ATA_REG_CONTROL    = 0x02;  // (*1*) Device Control register, see [ATA-6] 7.8
+const ATA_REG_CONTROL    = 0x00;  // (*1*) Device Control register, see [ATA-6] 7.8
 
 // Per-channel Bus Master IDE register offsets (BAR4), see [BMI-1] 2.0
 // these are the primary channel's offsets, add 8 for secondary
@@ -278,14 +278,14 @@ export function IDEController(cpu, bus, ide_config)
         if(has_primary)
         {
             this.primary = new IDEChannel(this, 0, ide_config[0], {
-                command_base: 0x1f0, control_base: 0x3f4, bus_master_base: bus_master_base, irq: 14
+                command_base: 0x1f0, control_base: 0x3f6, bus_master_base: bus_master_base, irq: 14
             });
             this.channels[0] = this.primary;
         }
         if(has_secondary)
         {
             this.secondary = new IDEChannel(this, 1, ide_config[1], {
-                command_base: 0x170, control_base: 0x374, bus_master_base: bus_master_base, irq: 15
+                command_base: 0x170, control_base: 0x376, bus_master_base: bus_master_base, irq: 15
             });
             this.channels[1] = this.secondary;
         }
@@ -332,9 +332,9 @@ export function IDEController(cpu, bus, ide_config)
         ];
         this.pci_bars = [
             has_primary ? { size: 8 } : undefined,   // BAR0: Command block register address of primary channel
-            has_primary ? { size: 4 } : undefined,   // BAR1: Control block register address of primary channel
+            has_primary ? { size: 1 } : undefined,   // BAR1: Control block register address of primary channel
             has_secondary ? { size: 8 } : undefined, // BAR2: Command block register address of secondary channel
-            has_secondary ? { size: 4 } : undefined, // BAR3: Control block register address of secondary channel
+            has_secondary ? { size: 1 } : undefined, // BAR3: Control block register address of secondary channel
             { size: 16 }                             // BAR4: Bus Master I/O register address of both channels (8+8)
         ];
         cpu.devices.pci.register_device(this);
@@ -565,7 +565,7 @@ function IDEChannel(controller, channel_nr, channel_config, hw_settings)
     });
 
     //
-    // Control Block Register: control_base + 0...3 (BAR1: 3F4h, BAR3: 374h)
+    // Control Block Register: control_base (BAR1: 3F6h, BAR3: 376h)
     //
 
     // read Alternate Status register

--- a/src/ide.js
+++ b/src/ide.js
@@ -338,7 +338,9 @@ function IDEDevice(adapter, adapter_config, channel_nr, channel_config)     // T
 
 IDEDevice.prototype.read_status = function()
 {
-    const ret = this.current_interface.status;
+    /// temporary hack to indicate missing slave drive to host
+    /// const ret = this.current_interface.status;
+    const ret = this.current_interface.is_atapi || this.current_interface.buffer ? this.current_interface.status : 0;
     dbg_log("dev "+this.name+" ATA read status: " + h(ret, 2), LOG_DISK);
     return ret;
 };

--- a/src/pci.js
+++ b/src/pci.js
@@ -394,7 +394,7 @@ PCI.prototype.pci_write32 = function(address, written)
         var bar_nr = addr - 0x10 >> 2;
         var bar = device.pci_bars[bar_nr];
 
-        dbg_log("BAR" + bar_nr + " exists=" + (bar ? "y" : "n") + " changed to " +
+        dbg_log("BAR" + bar_nr + " exists=" + (bar ? "y" : "n") + " changed from " + h(space[addr >> 2]) + " to " +
                 h(written >>> 0) + " dev=" + h(bdf >> 3, 2) + " (" + device.name + ") ", LOG_PCI);
 
         if(bar)
@@ -518,6 +518,7 @@ PCI.prototype.register_device = function(device)
 
         var bar_base = bar_space[i];
         var type = bar_base & 1;
+        dbg_log("device "+ device.name +" register bar of size "+bar.size +" at " + h(bar_base), LOG_PCI);
 
         bar.original_bar = bar_base;
         bar.entries = [];
@@ -565,6 +566,9 @@ PCI.prototype.set_io_bars = function(bar, from, to)
            old_entry.write32 === this.io.empty_port_write)
         {
             // happens when a device doesn't register its full range (currently ne2k and virtio)
+            // but it also happens when aligned reads/writes are set up,
+            // e.g. a 16-bit read registered at 0xB400 will show up as
+            // no source mapping at 0xB401.
             dbg_log("Warning: Bad IO bar: Source not mapped, port=" + h(from + i, 4), LOG_PCI);
         }
 
@@ -577,16 +581,16 @@ PCI.prototype.set_io_bars = function(bar, from, to)
             ports[to + i] = entry;
         }
 
-        if(empty_entry.read8 === this.io.empty_port_read8 ||
-            empty_entry.read16 === this.io.empty_port_read16 ||
-            empty_entry.read32 === this.io.empty_port_read32 ||
-            empty_entry.write8 === this.io.empty_port_write ||
-            empty_entry.write16 === this.io.empty_port_write ||
-            empty_entry.write32 === this.io.empty_port_write)
+        if(empty_entry.read8 !== this.io.empty_port_read8 ||
+            empty_entry.read16 !== this.io.empty_port_read16 ||
+            empty_entry.read32 !== this.io.empty_port_read32 ||
+            empty_entry.write8 !== this.io.empty_port_write ||
+            empty_entry.write16 !== this.io.empty_port_write ||
+            empty_entry.write32 !== this.io.empty_port_write)
         {
             // These can fail if the os maps an io port in multiple bars (indicating a bug)
             // XXX: Fails during restore_state
-            dbg_log("Warning: Bad IO bar: Target already mapped, port=" + h(to + i, 4), LOG_PCI);
+            dbg_log("Warning: Bad IO bar: Target already mapped, port=" + h(to + i, 4)+" from device "+entry.device.name+" to device "+empty_entry.device.name, LOG_PCI);
         }
     }
 };

--- a/src/pci.js
+++ b/src/pci.js
@@ -558,20 +558,6 @@ PCI.prototype.set_io_bars = function(bar, from, to)
             ports[from + i] = this.io.create_empty_entry();
         }
 
-        if(old_entry.read8 === this.io.empty_port_read8 &&
-           old_entry.read16 === this.io.empty_port_read16 &&
-           old_entry.read32 === this.io.empty_port_read32 &&
-           old_entry.write8 === this.io.empty_port_write &&
-           old_entry.write16 === this.io.empty_port_write &&
-           old_entry.write32 === this.io.empty_port_write)
-        {
-            // happens when a device doesn't register its full range (currently ne2k and virtio)
-            // but it also happens when aligned reads/writes are set up,
-            // e.g. a 16-bit read registered at 0xB400 will show up as
-            // no source mapping at 0xB401.
-            dbg_log("Warning: Bad IO bar: Source not mapped, port=" + h(from + i, 4), LOG_PCI);
-        }
-
         var entry = bar.entries[i];
         var empty_entry = ports[to + i];
         dbg_assert(entry && empty_entry);
@@ -579,18 +565,6 @@ PCI.prototype.set_io_bars = function(bar, from, to)
         if(to + i >= 0x1000)
         {
             ports[to + i] = entry;
-        }
-
-        if(empty_entry.read8 !== this.io.empty_port_read8 ||
-            empty_entry.read16 !== this.io.empty_port_read16 ||
-            empty_entry.read32 !== this.io.empty_port_read32 ||
-            empty_entry.write8 !== this.io.empty_port_write ||
-            empty_entry.write16 !== this.io.empty_port_write ||
-            empty_entry.write32 !== this.io.empty_port_write)
-        {
-            // These can fail if the os maps an io port in multiple bars (indicating a bug)
-            // XXX: Fails during restore_state
-            dbg_log("Warning: Bad IO bar: Target already mapped, port=" + h(to + i, 4)+" from device "+entry.device.name+" to device "+empty_entry.device.name, LOG_PCI);
         }
     }
 };


### PR DESCRIPTION
This PR improves on PR #901 "Fix booting from cd while hda present, booting from hda while cd present", please see [my comment there](https://github.com/copy/v86/pull/901#issuecomment-2848666992) and also issue #1323 "ATA/ATAPI PCI adapter" for more details if you like.

SeaBIOS now properly boots with both a HDA and a CD-ROM device configured, the CD-ROM may or may not be empty. Tested under FreeDOS 1.3, FreeDOS 1.4, Debian 12, FreeBSD 12, Windows 3.1, Windows 95, Syllable-0.6.7-1 and more. A CD-ROM disk can be inserted after booting with an empty CD drive, and ejecting a disk mostly works.

Boch's BIOS shows the same problems with or without this PR, when booting FreeDOS fails to find or activate the NE2K network card, and Debian fails to find any IDE drive (neither HDA nor CD-ROM). However, it does boot with this dual IDE configuration (HD and CD) which it doesn't without this PR.

Technically, this implementation should support any combination of up to 4 ATA-HDD and/or ATAPI-CD-ROM devices (tested with three devices `hda`, `hdb` and  `cdrom`), though this would cause some serious headache in the web UI setup.

Major fixes and improvements in this PR:

* fixed PCI device layout of the IDE controller
* fixed ATAPI responses for ejected media
* added several ATA/ATAPI commands
* improved ATA responses for missing IDE slave devices
* improved code readabilty with named constants
* improved debug log output

This code attempts to implement a sufficient subset of the latest revisions of the IDE-related standards (that is: ATA/ATAPI-8 and MMC-3). However, some deprecated commands from older revisions are also supported for guest OSes that make still use of them.

References that this IDE code is based on:

- **[ATA/ATAPI-8 Command Set - 3 (ACS-3)](https://read.seas.harvard.edu/cs161/2019/pdf/ata-atapi-8.pdf)** (Rev. 5, Oct. 28, 2013)
- **[AT Attachment with Packet Interface - 6 (ATA/ATAPI-6)](https://technion-csl.github.io/ose/readings/hardware/ATA-d1410r3a.pdf)** (Rev. 3a, Dec. 14, 2001)
- **[AT Attachment Interface for Disk Drives](https://dn790009.ca.archive.org/0/items/SCSISpecificationDocumentsATAATAPI/ATA_ATAPI/AT%20Attachment%20Interface%20for%20Disk%20Drives%20Revision%204c.pdf)** (Rev. 4c, 1994)
- **[SCSI Architecture Model - 3 (SAM-3)](https://dn790004.ca.archive.org/0/items/SCSISpecificationDocumentsSCSIDocuments/SCSI%20Architecture%20Model/SCSI%20Architecture%20Model%203%20rev%2014.pdf)** (Sep. 21, 2004)
- **[SCSI Primary Commands - 3 (SPC-3)](https://www.t10.org/ftp/t10/document.08/08-309r0.pdf)** (July 20, 2008)
- **[SCSI Multimedia Commands - 3 (MMC-3)](https://ia902808.us.archive.org/33/items/mmc3r10g/mmc3r10g.pdf)** (Rev. 10g, Nov. 12, 2001)
- **[Packet Commands for C/DVD Devices (MMC-2)](https://www.t10.org/ftp/t10/document.97/97-108r0.pdf)** (1997)
- **[Proposal for CD-ROM in SCSI-2](https://www.t10.org/ftp/x3t9.2/document.87/87-106r0.txt)** (1987)
- **[Programming Interface for Bus Master IDE Controller](https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/u9proj/idems100.pdf)** (Rev. 1.0, May 16, 1994)

Other related reading material:

- [ATA/ATAPI Host Adapters Standard (ATA – Adapter)](https://ia800207.us.archive.org/28/items/SCSISpecificationDocumentsATAATAPI/ATA_ATAPI/ATA_ATAPI%20Host%20Adapters%20Standard%20%28ATA%20-%20Adapter%29%20Revision%201.0.pdf) (Jan. 2003)
- [Intel 2371FB (PIIX) AND 82371SB (PIIX3) PCI ISA IDE XCELERATOR](https://theretroweb.com/chip/documentation/82371sb-intelcorporation-62f8fda6daac0627455529.pdf) (Apr. 1997)
- [ATA Packet Interface for CD-ROMs](https://web.archive.org/web/20221214054146/https://inst.eecs.berkeley.edu/~cs150/fa01/labs/project/ATAPI_Spec.pdf)
- https://wiki.osdev.org/ATA/ATAPI_using_DMA
- https://wiki.osdev.org/ATA_PIO_Mode
- https://wiki.osdev.org/ATAPI
- https://wiki.osdev.org/PCI_IDE_Controller
- http://www.psism.com/SiliconDrivePCCard-1.pdf
