### PR TITLE
Fix serial not handling end of line properly

### DIFF
--- a/src/browser/serial.js
+++ b/src/browser/serial.js
@@ -230,6 +230,7 @@ export function SerialAdapterXtermJS(element, bus)
 
     var term = this.term = new window["Terminal"]({
         "logLevel": "off",
+        "convertEol": "true",
     });
     term.write("This is the serial console. Whatever you type or paste here will be sent to COM1");
 


### PR DESCRIPTION
Fixed a weird issue with the serial terminal not handling end of line characters correctly. For example, on ToaruOS, the serial output is displayed sporadically and the stream does not proceed to the next line. See image:

![toaruOSbefore](https://github.com/user-attachments/assets/6ef8a022-46ed-4850-a2e3-399a5c0a74a8)

Adding the convertEol option to the xterm initialization results in this output: 

![toaruOSafter](https://github.com/user-attachments/assets/d3dab994-08e0-4f98-83aa-1a94ba952ed0)

Based on my limited testing on FreeDOS, ToaruOS with serial debug on and my own simple kernel, this does not affect the other functionalities of the serial monitor, but it's possible.
Let me know if it can be done better or if it affects any other functionality.
Cheers.

