### PR TITLE
fix PIT single byte access modes

### DIFF
--- a/src/pit.js
+++ b/src/pit.js
@@ -308,13 +308,13 @@ PIT.prototype.port43_write = function(reg_byte)
 
     if(read_mode === 1)
     {
-        // msb
-        this.counter_next_low[i] = 0;
+        // lsb
+        this.counter_next_low[i] = 1;
     }
     else if(read_mode === 2)
     {
-        // lsb
-        this.counter_next_low[i] = 1;
+        // msb
+        this.counter_next_low[i] = 0;
     }
     else
     {


### PR DESCRIPTION
Using single byte access mode on PIT had flipped low and high byte access modes. 1 is supposed to be low and 2 high, this is what the specification says should happen and what [qemu](https://github.com/qemu/qemu/blob/e82989544e38062beeeaad88c175afbeed0400f8/hw/timer/i8254.c#L35-L36) does.

I guess this feature isn't really used by operating systems so it hasn't been a problem before(?).