### PR TITLE
add support for custom 9p request handler

### DIFF
--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -1,9 +1,9 @@
 A 9p filesystem is supported by v86, using a virtio transport. There are several
-ways it can be set up. 
+ways it can be set up.
 
 ### Guest mount
 
-In all cases, the filesystem is mounted in the guest system using the `9p` 
+In all cases, the filesystem is mounted in the guest system using the `9p`
 filesystem type and the `host9p` device tag. Typically you want to be specific
 with the version and transport options:
 
@@ -17,7 +17,7 @@ Here are kernel arguments you can use to boot directly off the 9p filesystem:
 rw root=host9p rootfstype=9p rootflags=trans=virtio,version=9p2000.L
 ```
 
-The `aname` option can be used to pick the directory from 9p to mount. The `rw` 
+The `aname` option can be used to pick the directory from 9p to mount. The `rw`
 argument makes this a read-write root filesystem.
 
 
@@ -25,7 +25,7 @@ argument makes this a read-write root filesystem.
 
 This is the standard way to setup the 9p filesystem. It loads files over
 HTTP on-demand into an in-memory filesystem in JS. This allows files to be
-exchanged with the guest OS. See `create_file` and `read_file` in 
+exchanged with the guest OS. See `create_file` and `read_file` in
 [`starter.js`](https://github.com/copy/v86/blob/master/src/browser/starter.js).
 
 This mode is enabled by passing the following options to `V86`:
@@ -41,7 +41,7 @@ Here, `basefs` is a json file created using
 [fs2json](https://github.com/copy/fs2json). The base url is the prefix of a url
 from which the files are available. For instance, if the 9p filesystem has a
 file `/bin/sh`, that file must be accessible from
-`http://localhost/9p/base/bin/sh`. 
+`http://localhost/9p/base/bin/sh`.
 
 If `basefs` and `baseurl` are omitted, an empty 9p filesystem is created. Unless
 you configure one of the alternative modes.
@@ -84,13 +84,13 @@ Simlar to using `handle9p`, this filesystem will not be available in JS and
 will need to be re-mounted after restoring state.
 
 The WS proxy just needs to hand off messages with a connection to a normal 9p
-server. Each binary WebSocket message is the full buffer of a request or a 
-reply. 
+server. Each binary WebSocket message is the full buffer of a request or a
+reply.
 
-To implement, request message bytes can just be sent directly to the 9p 
+To implement, request message bytes can just be sent directly to the 9p
 connection, but the 9p reply stream needs to be buffered into a single binary
-WebSocket message. The proxy must at least parse the first 4 bytes to get the 
-message size and use it to buffer a full message before sending over WebSocket. 
+WebSocket message. The proxy must at least parse the first 4 bytes to get the
+message size and use it to buffer a full message before sending over WebSocket.
 
 The [wanix](https://github.com/tractordev/wanix) CLI has a `serve` command that
 not only serves a directory over HTTP, but also over 9P via WebSocket. You can

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -1,7 +1,34 @@
-A 9p filesystem is supported by v86, using a virtio transport. Using
-it, files can be exchanged with the guest OS, see `create_file` and `read_file`
-in [`starter.js`](https://github.com/copy/v86/blob/master/src/browser/starter.js).
-It can be enabled by passing the following options to `V86`:
+A 9p filesystem is supported by v86, using a virtio transport. There are several
+ways it can be set up. 
+
+### Guest mount
+
+In all cases, the filesystem is mounted in the guest system using the `9p` 
+filesystem type and the `host9p` device tag. Typically you want to be specific
+with the version and transport options:
+
+```sh
+mount -t 9p -o trans=virtio,version=9p2000.L host9p /mnt/9p/
+```
+
+Here are kernel arguments you can use to boot directly off the 9p filesystem:
+
+```
+rw root=host9p rootfstype=9p rootflags=trans=virtio,version=9p2000.L
+```
+
+The `aname` option can be used to pick the directory from 9p to mount. The `rw` 
+argument makes this a read-write root filesystem.
+
+
+### JSON/HTTP Filesystem
+
+This is the standard way to setup the 9p filesystem. It loads files over
+HTTP on-demand into an in-memory filesystem in JS. This allows files to be
+exchanged with the guest OS. See `create_file` and `read_file` in 
+[`starter.js`](https://github.com/copy/v86/blob/master/src/browser/starter.js).
+
+This mode is enabled by passing the following options to `V86`:
 
 ```javascript
 filesystem: {
@@ -14,12 +41,59 @@ Here, `basefs` is a json file created using
 [fs2json](https://github.com/copy/fs2json). The base url is the prefix of a url
 from which the files are available. For instance, if the 9p filesystem has a
 file `/bin/sh`, that file must be accessible from
-`http://localhost/9p/base/bin/sh`. If `basefs` and `baseurl` are omitted, an
-empty 9p filesystem is created.
+`http://localhost/9p/base/bin/sh`. 
 
-The `mount_tag` of the 9p device is `host9p`. In order to mount it in the
-guest, use:
+If `basefs` and `baseurl` are omitted, an empty 9p filesystem is created. Unless
+you configure one of the alternative modes.
 
-```sh
-mount -t 9p host9p /mnt/9p/
+
+### Function Handler
+
+You can handle 9p messages directly in JavaScript yourself by providing a
+function as `handle9p` under `filesystem`:
+
+```javascript
+filesystem: {
+    handle9p: async (reqBuf, reply) => {
+        // reqBuf is a Uint8Array of the entire request frame.
+        // you can parse these bytes using a library or reading the 9p spec.
+        // once you formulate a response, you send the reply frame as a
+        // Uint8Array by passing it to reply: reply(respBuf)
+    }
+}
 ```
+
+This allows you to implement a 9p server or custom proxy in JS. However, this
+filesystem will not be cached (unless cached in the guest OS), functions like
+`create_file` and `read_file` will not be available, and you will be responsible
+for keeping its state in sync with any machine save states.
+
+
+### WebSocket Proxy
+
+You can also back the 9p virtio filesystem with a 9p server over WebSocket by
+providing a WS proxy URL:
+
+```javascript
+filesystem: {
+    proxy_url: "ws://localhost:8080/"
+}
+```
+
+Simlar to using `handle9p`, this filesystem will not be available in JS and
+will need to be re-mounted after restoring state.
+
+The WS proxy just needs to hand off messages with a connection to a normal 9p
+server. Each binary WebSocket message is the full buffer of a request or a 
+reply. 
+
+To implement, request message bytes can just be sent directly to the 9p 
+connection, but the 9p reply stream needs to be buffered into a single binary
+WebSocket message. The proxy must at least parse the first 4 bytes to get the 
+message size and use it to buffer a full message before sending over WebSocket. 
+
+The [wanix](https://github.com/tractordev/wanix) CLI has a `serve` command that
+not only serves a directory over HTTP, but also over 9P via WebSocket. You can
+see how it [implements a proxy][1] in Go.
+
+[1]: https://github.com/tractordev/wanix/blob/main/cmd/wanix/serve.go#L117-L177

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -38,10 +38,8 @@ filesystem: {
 ```
 
 Here, `basefs` is a json file created using
-[fs2json](https://github.com/copy/fs2json). The base url is the prefix of a url
-from which the files are available. For instance, if the 9p filesystem has a
-file `/bin/sh`, that file must be accessible from
-`http://localhost/9p/base/bin/sh`.
+[fs2json.py](tools/fs2json.py) and the `baseurl` directory is created using
+[copy-to-sha256.py](tools/copy-to-sha256.py).
 
 If `basefs` and `baseurl` are omitted, an empty 9p filesystem is created. Unless
 you configure one of the alternative modes.

--- a/lib/9p.js
+++ b/lib/9p.js
@@ -87,15 +87,24 @@ function range(size)
     return Array.from(Array(size).keys());
 }
 
+/** @typedef {function(!Uint8Array, function(!Uint8Array):void):void} */
+export let P9RequestHandler;
+
 /**
  * @constructor
  *
- * @param {FS} filesystem
+ * @param {(!FS|!P9RequestHandler)} fs_or_handler
  * @param {CPU} cpu
  */
-export function Virtio9p(filesystem, cpu, bus) {
-    /** @type {FS} */
-    this.fs = filesystem;
+export function Virtio9p(fs_or_handler, cpu, bus) {
+    if (typeof fs_or_handler === "function") {
+        /** @type {(Function|undefined)} */
+        this.handle_fn = fs_or_handler;
+        this.tag_bufchain = new Map();
+    } else {
+        /** @type {(FS|undefined)} */
+        this.fs = fs_or_handler;
+    }
 
     /** @const @type {BusConnector} */
     this.bus = bus;
@@ -224,7 +233,9 @@ Virtio9p.prototype.set_state = function(state)
     {
         return { inodeid: f[0], type: f[1], uid: f[2], dbg_name: f[3] };
     });
-    this.fs.set_state(state[9]);
+    if (this.fs) {
+        this.fs.set_state(state[9]);
+    }
 };
 
 // Note: dbg_name is only used for debugging messages and may not be the same as the filename,
@@ -285,6 +296,34 @@ Virtio9p.prototype.ReceiveRequest = async function (bufchain) {
     var tag = header[2];
     //dbg_log("size:" + size + " id:" + id + " tag:" + tag, LOG_9P);
 
+    // if a 9p request handler was given
+    if (this.handle_fn) {
+        this.tag_bufchain.set(tag, bufchain);
+        this.handle_fn(buffer, (replybuf) => {
+            var reply_header = marshall.Unmarshall(["w", "b", "h"], replybuf, { offset: 0 });
+            var reply_tag = reply_header[2];
+
+            // Create a new buffer for each response instead of reusing the same one
+            this.replybuffer = new Uint8Array(replybuf.byteLength);
+            this.replybuffer.set(replybuf);
+            this.replybuffersize = replybuf.byteLength;
+
+            const bufchain = this.tag_bufchain.get(reply_tag);
+            if (!bufchain) {
+                console.error("No bufchain found for tag: " + reply_tag);
+                return;
+            }
+
+            bufchain.set_next_blob(replybuf);
+            this.virtqueue.push_reply(bufchain);
+            this.virtqueue.flush_replies();
+
+            this.tag_bufchain.delete(reply_tag);
+        });
+        return;
+    }
+
+    // otherwise, if a filesystem was given
     switch(id)
     {
         case 8: // statfs

--- a/lib/9p.js
+++ b/lib/9p.js
@@ -88,19 +88,12 @@ function range(size)
 }
 
 /**
- * @constructor
- *
  * @param {CPU} cpu
  * @param {Function} receive
  */
-function Virtio9pDevice(cpu, receive) {
-    //this.configspace = [0x0, 0x4, 0x68, 0x6F, 0x73, 0x74]; // length of string and "host" string
-    //this.configspace = [0x0, 0x9, 0x2F, 0x64, 0x65, 0x76, 0x2F, 0x72, 0x6F, 0x6F, 0x74 ]; // length of string and "/dev/root" string
-    this.configspace_tagname = [0x68, 0x6F, 0x73, 0x74, 0x39, 0x70]; // "host9p" string
-    this.configspace_taglen = this.configspace_tagname.length; // num bytes
-
-    /** @type {VirtIO} */
-    this.virtio = new VirtIO(cpu,
+function init_virtio(cpu, configspace_taglen, configspace_tagname, receive)
+{
+    const virtio = new VirtIO(cpu,
     {
         name: "virtio-9p",
         pci_id: 0x06 << 3,
@@ -139,12 +132,13 @@ function Virtio9pDevice(cpu, receive) {
                             " (expected queue_id of 0)");
                         return;
                     }
-                    while(this.virtqueue.has_request())
+                    const virtqueue = virtio.queues[0];
+                    while(virtqueue.has_request())
                     {
-                        const bufchain = this.virtqueue.pop_request();
+                        const bufchain = virtqueue.pop_request();
                         receive(bufchain);
                     }
-                    this.virtqueue.notify_me_after(0);
+                    virtqueue.notify_me_after(0);
                     // Don't flush replies here: async replies are not completed yet.
                 },
             ],
@@ -161,7 +155,7 @@ function Virtio9pDevice(cpu, receive) {
                 {
                     bytes: 2,
                     name: "mount tag length",
-                    read: () => this.configspace_taglen,
+                    read: () => configspace_taglen,
                     write: data => { /* read only */ },
                 },
             ].concat(range(VIRTIO_9P_MAX_TAGLEN).map(index =>
@@ -169,13 +163,13 @@ function Virtio9pDevice(cpu, receive) {
                     bytes: 1,
                     name: "mount tag name " + index,
                     // Note: configspace_tagname may have changed after set_state
-                    read: () => this.configspace_tagname[index] || 0,
+                    read: () => configspace_tagname[index] || 0,
                     write: data => { /* read only */ },
                 })
             )),
         },
     });
-    this.virtqueue = this.virtio.queues[0];
+    return virtio;
 }
 
 /**
@@ -191,24 +185,27 @@ export function Virtio9p(filesystem, cpu, bus) {
     /** @const @type {BusConnector} */
     this.bus = bus;
 
-    
+    this.configspace_tagname = [0x68, 0x6F, 0x73, 0x74, 0x39, 0x70]; // "host9p" string
+    this.configspace_taglen = this.configspace_tagname.length; // num bytes
+
+    this.virtio = init_virtio(cpu, this.configspace_taglen, this.configspace_tagname, this.ReceiveRequest.bind(this));
+    this.virtqueue = this.virtio.queues[0];
+
     this.VERSION = "9P2000.L";
     this.BLOCKSIZE = 8192; // Let's define one page.
     this.msize = 8192; // maximum message size
     this.replybuffer = new Uint8Array(this.msize*2); // Twice the msize to stay on the safe site
     this.replybuffersize = 0;
     this.fids = [];
-
-    this.device = new Virtio9pDevice(cpu, this.ReceiveRequest.bind(this));
 }
 
 Virtio9p.prototype.get_state = function()
 {
     var state = [];
 
-    state[0] = this.device.configspace_tagname;
-    state[1] = this.device.configspace_taglen;
-    state[2] = this.device.virtio;
+    state[0] = this.configspace_tagname;
+    state[1] = this.configspace_taglen;
+    state[2] = this.virtio;
     state[3] = this.VERSION;
     state[4] = this.BLOCKSIZE;
     state[5] = this.msize;
@@ -222,10 +219,10 @@ Virtio9p.prototype.get_state = function()
 
 Virtio9p.prototype.set_state = function(state)
 {
-    this.device.configspace_tagname = state[0];
-    this.device.configspace_taglen = state[1];
-    this.device.virtio.set_state(state[2]);
-    this.device.virtqueue = this.device.virtio.queues[0];
+    this.configspace_tagname = state[0];
+    this.configspace_taglen = state[1];
+    this.virtio.set_state(state[2]);
+    this.virtqueue = this.virtio.queues[0];
     this.VERSION = state[3];
     this.BLOCKSIZE = state[4];
     this.msize = state[5];
@@ -254,11 +251,11 @@ Virtio9p.prototype.update_dbg_name = function(idx, newname)
     }
 };
 
-Virtio9p.prototype.reset = function() {
+Virtio9p.prototype.reset = function()
+{
     this.fids = [];
-    this.device.virtio.reset();
+    this.virtio.reset();
 };
-
 
 Virtio9p.prototype.BuildReply = function(id, tag, payloadsize) {
     dbg_assert(payloadsize >= 0, "9P: Negative payload size");
@@ -280,8 +277,8 @@ Virtio9p.prototype.SendError = function (tag, errormsg, errorcode) {
 Virtio9p.prototype.SendReply = function (bufchain) {
     dbg_assert(this.replybuffersize >= 0, "9P: Negative replybuffersize");
     bufchain.set_next_blob(this.replybuffer.subarray(0, this.replybuffersize));
-    this.device.virtqueue.push_reply(bufchain);
-    this.device.virtqueue.flush_replies();
+    this.virtqueue.push_reply(bufchain);
+    this.virtqueue.flush_replies();
 };
 
 Virtio9p.prototype.ReceiveRequest = async function (bufchain) {
@@ -894,7 +891,7 @@ Virtio9p.prototype.ReceiveRequest = async function (bufchain) {
 };
 
 /** @typedef {function(Uint8Array, function(Uint8Array):void):void} */
-export let P9Handler;
+let P9Handler;
 
 /**
  * @constructor
@@ -906,41 +903,52 @@ export function Virtio9pHandler(handle_fn, cpu) {
     /** @type {P9Handler} */
     this.handle_fn = handle_fn;
     this.tag_bufchain = new Map();
-    this.device = new Virtio9pDevice(cpu, async (bufchain) => {
-        // TODO: split into header + data blobs to avoid unnecessary copying.
-        const reqbuf = new Uint8Array(bufchain.length_readable);
-        bufchain.get_next_blob(reqbuf);
-    
-        var reqheader = marshall.Unmarshall(["w", "b", "h"], reqbuf, { offset : 0 });
-        var reqtag = reqheader[2];
-        
-        this.tag_bufchain.set(reqtag, bufchain);
-        this.handle_fn(reqbuf, (replybuf) => {
-            var replyheader = marshall.Unmarshall(["w", "b", "h"], replybuf, { offset: 0 });
-            var replytag = replyheader[2];
-    
-            const bufchain = this.tag_bufchain.get(replytag);
-            if (!bufchain) {
-                console.error("No bufchain found for tag: " + replytag);
-                return;
-            }
-    
-            bufchain.set_next_blob(replybuf);
-            this.device.virtqueue.push_reply(bufchain);
-            this.device.virtqueue.flush_replies();
-    
-            this.tag_bufchain.delete(replytag);
-        });
-    });
+
+    this.configspace_tagname = [0x68, 0x6F, 0x73, 0x74, 0x39, 0x70]; // "host9p" string
+    this.configspace_taglen = this.configspace_tagname.length; // num bytes
+
+    this.virtio = init_virtio(
+        cpu,
+        this.configspace_taglen,
+        this.configspace_tagname,
+        async (bufchain) => {
+            // TODO: split into header + data blobs to avoid unnecessary copying.
+            const reqbuf = new Uint8Array(bufchain.length_readable);
+            bufchain.get_next_blob(reqbuf);
+
+            var reqheader = marshall.Unmarshall(["w", "b", "h"], reqbuf, { offset : 0 });
+            var reqtag = reqheader[2];
+
+            this.tag_bufchain.set(reqtag, bufchain);
+            this.handle_fn(reqbuf, (replybuf) => {
+                var replyheader = marshall.Unmarshall(["w", "b", "h"], replybuf, { offset: 0 });
+                var replytag = replyheader[2];
+
+                const bufchain = this.tag_bufchain.get(replytag);
+                if(!bufchain)
+                {
+                    console.error("No bufchain found for tag: " + replytag);
+                    return;
+                }
+
+                bufchain.set_next_blob(replybuf);
+                this.virtqueue.push_reply(bufchain);
+                this.virtqueue.flush_replies();
+
+                this.tag_bufchain.delete(replytag);
+            });
+        }
+    );
+    this.virtqueue = this.virtio.queues[0];
 }
 
 Virtio9pHandler.prototype.get_state = function()
 {
     var state = [];
 
-    state[0] = this.device.configspace_tagname;
-    state[1] = this.device.configspace_taglen;
-    state[2] = this.device.virtio;
+    state[0] = this.configspace_tagname;
+    state[1] = this.configspace_taglen;
+    state[2] = this.virtio;
     state[3] = this.tag_bufchain;
 
     return state;
@@ -948,16 +956,17 @@ Virtio9pHandler.prototype.get_state = function()
 
 Virtio9pHandler.prototype.set_state = function(state)
 {
-    this.device.configspace_tagname = state[0];
-    this.device.configspace_taglen = state[1];
-    this.device.virtio.set_state(state[2]);
-    this.device.virtqueue = this.device.virtio.queues[0];
+    this.configspace_tagname = state[0];
+    this.configspace_taglen = state[1];
+    this.virtio.set_state(state[2]);
+    this.virtqueue = this.virtio.queues[0];
     this.tag_bufchain = state[3];
 };
 
 
-Virtio9pHandler.prototype.reset = function() {
-    this.device.virtio.reset();
+Virtio9pHandler.prototype.reset = function()
+{
+    this.virtio.reset();
 };
 
 
@@ -982,26 +991,36 @@ export function Virtio9pProxy(url, cpu)
     this.destroyed = false;
 
     this.tag_bufchain = new Map();
-    this.device = new Virtio9pDevice(cpu, async (bufchain) => {
-        // TODO: split into header + data blobs to avoid unnecessary copying.
-        const reqbuf = new Uint8Array(bufchain.length_readable);
-        bufchain.get_next_blob(reqbuf);
-    
-        const reqheader = marshall.Unmarshall(["w", "b", "h"], reqbuf, { offset : 0 });
-        const reqtag = reqheader[2];
-        
-        this.tag_bufchain.set(reqtag, bufchain);
-        this.send(reqbuf);
-    });
+
+    this.configspace_tagname = [0x68, 0x6F, 0x73, 0x74, 0x39, 0x70]; // "host9p" string
+    this.configspace_taglen = this.configspace_tagname.length; // num bytes
+
+    this.virtio = init_virtio(
+        cpu,
+        this.configspace_taglen,
+        this.configspace_tagname,
+        async (bufchain) => {
+            // TODO: split into header + data blobs to avoid unnecessary copying.
+            const reqbuf = new Uint8Array(bufchain.length_readable);
+            bufchain.get_next_blob(reqbuf);
+
+            const reqheader = marshall.Unmarshall(["w", "b", "h"], reqbuf, { offset : 0 });
+            const reqtag = reqheader[2];
+
+            this.tag_bufchain.set(reqtag, bufchain);
+            this.send(reqbuf);
+        }
+    );
+    this.virtqueue = this.virtio.queues[0];
 }
 
 Virtio9pProxy.prototype.get_state = function()
 {
     var state = [];
 
-    state[0] = this.device.configspace_tagname;
-    state[1] = this.device.configspace_taglen;
-    state[2] = this.device.virtio;
+    state[0] = this.configspace_tagname;
+    state[1] = this.configspace_taglen;
+    state[2] = this.virtio;
     state[3] = this.tag_bufchain;
 
     return state;
@@ -1009,16 +1028,15 @@ Virtio9pProxy.prototype.get_state = function()
 
 Virtio9pProxy.prototype.set_state = function(state)
 {
-    this.device.configspace_tagname = state[0];
-    this.device.configspace_taglen = state[1];
-    this.device.virtio.set_state(state[2]);
-    this.device.virtqueue = this.device.virtio.queues[0];
+    this.configspace_tagname = state[0];
+    this.configspace_taglen = state[1];
+    this.virtio.set_state(state[2]);
+    this.virtqueue = this.virtio.queues[0];
     this.tag_bufchain = state[3];
 };
 
-
 Virtio9pProxy.prototype.reset = function() {
-    this.device.virtio.reset();
+    this.virtio.reset();
 };
 
 Virtio9pProxy.prototype.handle_message = function(e)
@@ -1028,14 +1046,15 @@ Virtio9pProxy.prototype.handle_message = function(e)
     const replytag = replyheader[2];
 
     const bufchain = this.tag_bufchain.get(replytag);
-    if (!bufchain) {
+    if(!bufchain)
+    {
         console.error("Virtio9pProxy: No bufchain found for tag: " + replytag);
         return;
     }
 
     bufchain.set_next_blob(replybuf);
-    this.device.virtqueue.push_reply(bufchain);
-    this.device.virtqueue.flush_replies();
+    this.virtqueue.push_reply(bufchain);
+    this.virtqueue.flush_replies();
 
     this.tag_bufchain.delete(replytag);
 };

--- a/lib/9p.js
+++ b/lib/9p.js
@@ -87,39 +87,17 @@ function range(size)
     return Array.from(Array(size).keys());
 }
 
-/** @typedef {function(!Uint8Array, function(!Uint8Array):void):void} */
-export let P9RequestHandler;
-
 /**
  * @constructor
  *
- * @param {(!FS|!P9RequestHandler)} fs_or_handler
  * @param {CPU} cpu
+ * @param {Function} receive
  */
-export function Virtio9p(fs_or_handler, cpu, bus) {
-    if (typeof fs_or_handler === "function") {
-        /** @type {(Function|undefined)} */
-        this.handle_fn = fs_or_handler;
-        this.tag_bufchain = new Map();
-    } else {
-        /** @type {(FS|undefined)} */
-        this.fs = fs_or_handler;
-    }
-
-    /** @const @type {BusConnector} */
-    this.bus = bus;
-
+function Virtio9pDevice(cpu, receive) {
     //this.configspace = [0x0, 0x4, 0x68, 0x6F, 0x73, 0x74]; // length of string and "host" string
     //this.configspace = [0x0, 0x9, 0x2F, 0x64, 0x65, 0x76, 0x2F, 0x72, 0x6F, 0x6F, 0x74 ]; // length of string and "/dev/root" string
     this.configspace_tagname = [0x68, 0x6F, 0x73, 0x74, 0x39, 0x70]; // "host9p" string
     this.configspace_taglen = this.configspace_tagname.length; // num bytes
-    this.VERSION = "9P2000.L";
-    this.BLOCKSIZE = 8192; // Let's define one page.
-    this.msize = 8192; // maximum message size
-    this.replybuffer = new Uint8Array(this.msize*2); // Twice the msize to stay on the safe site
-    this.replybuffersize = 0;
-
-    this.fids = [];
 
     /** @type {VirtIO} */
     this.virtio = new VirtIO(cpu,
@@ -164,7 +142,7 @@ export function Virtio9p(fs_or_handler, cpu, bus) {
                     while(this.virtqueue.has_request())
                     {
                         const bufchain = this.virtqueue.pop_request();
-                        this.ReceiveRequest(bufchain);
+                        receive(bufchain);
                     }
                     this.virtqueue.notify_me_after(0);
                     // Don't flush replies here: async replies are not completed yet.
@@ -200,13 +178,37 @@ export function Virtio9p(fs_or_handler, cpu, bus) {
     this.virtqueue = this.virtio.queues[0];
 }
 
+/**
+ * @constructor
+ *
+ * @param {FS} filesystem
+ * @param {CPU} cpu
+ */
+export function Virtio9p(filesystem, cpu, bus) {
+    /** @type {FS} */
+    this.fs = filesystem;
+
+    /** @const @type {BusConnector} */
+    this.bus = bus;
+
+    
+    this.VERSION = "9P2000.L";
+    this.BLOCKSIZE = 8192; // Let's define one page.
+    this.msize = 8192; // maximum message size
+    this.replybuffer = new Uint8Array(this.msize*2); // Twice the msize to stay on the safe site
+    this.replybuffersize = 0;
+    this.fids = [];
+
+    this.device = new Virtio9pDevice(cpu, this.ReceiveRequest.bind(this));
+}
+
 Virtio9p.prototype.get_state = function()
 {
     var state = [];
 
-    state[0] = this.configspace_tagname;
-    state[1] = this.configspace_taglen;
-    state[2] = this.virtio;
+    state[0] = this.device.configspace_tagname;
+    state[1] = this.device.configspace_taglen;
+    state[2] = this.device.virtio;
     state[3] = this.VERSION;
     state[4] = this.BLOCKSIZE;
     state[5] = this.msize;
@@ -220,10 +222,10 @@ Virtio9p.prototype.get_state = function()
 
 Virtio9p.prototype.set_state = function(state)
 {
-    this.configspace_tagname = state[0];
-    this.configspace_taglen = state[1];
-    this.virtio.set_state(state[2]);
-    this.virtqueue = this.virtio.queues[0];
+    this.device.configspace_tagname = state[0];
+    this.device.configspace_taglen = state[1];
+    this.device.virtio.set_state(state[2]);
+    this.device.virtqueue = this.device.virtio.queues[0];
     this.VERSION = state[3];
     this.BLOCKSIZE = state[4];
     this.msize = state[5];
@@ -233,9 +235,7 @@ Virtio9p.prototype.set_state = function(state)
     {
         return { inodeid: f[0], type: f[1], uid: f[2], dbg_name: f[3] };
     });
-    if (this.fs) {
-        this.fs.set_state(state[9]);
-    }
+    this.fs.set_state(state[9]);
 };
 
 // Note: dbg_name is only used for debugging messages and may not be the same as the filename,
@@ -256,7 +256,7 @@ Virtio9p.prototype.update_dbg_name = function(idx, newname)
 
 Virtio9p.prototype.reset = function() {
     this.fids = [];
-    this.virtio.reset();
+    this.device.virtio.reset();
 };
 
 
@@ -280,8 +280,8 @@ Virtio9p.prototype.SendError = function (tag, errormsg, errorcode) {
 Virtio9p.prototype.SendReply = function (bufchain) {
     dbg_assert(this.replybuffersize >= 0, "9P: Negative replybuffersize");
     bufchain.set_next_blob(this.replybuffer.subarray(0, this.replybuffersize));
-    this.virtqueue.push_reply(bufchain);
-    this.virtqueue.flush_replies();
+    this.device.virtqueue.push_reply(bufchain);
+    this.device.virtqueue.flush_replies();
 };
 
 Virtio9p.prototype.ReceiveRequest = async function (bufchain) {
@@ -296,34 +296,6 @@ Virtio9p.prototype.ReceiveRequest = async function (bufchain) {
     var tag = header[2];
     //dbg_log("size:" + size + " id:" + id + " tag:" + tag, LOG_9P);
 
-    // if a 9p request handler was given
-    if (this.handle_fn) {
-        this.tag_bufchain.set(tag, bufchain);
-        this.handle_fn(buffer, (replybuf) => {
-            var reply_header = marshall.Unmarshall(["w", "b", "h"], replybuf, { offset: 0 });
-            var reply_tag = reply_header[2];
-
-            // Create a new buffer for each response instead of reusing the same one
-            this.replybuffer = new Uint8Array(replybuf.byteLength);
-            this.replybuffer.set(replybuf);
-            this.replybuffersize = replybuf.byteLength;
-
-            const bufchain = this.tag_bufchain.get(reply_tag);
-            if (!bufchain) {
-                console.error("No bufchain found for tag: " + reply_tag);
-                return;
-            }
-
-            bufchain.set_next_blob(replybuf);
-            this.virtqueue.push_reply(bufchain);
-            this.virtqueue.flush_replies();
-
-            this.tag_bufchain.delete(reply_tag);
-        });
-        return;
-    }
-
-    // otherwise, if a filesystem was given
     switch(id)
     {
         case 8: // statfs
@@ -919,4 +891,267 @@ Virtio9p.prototype.ReceiveRequest = async function (bufchain) {
 
     //consistency checks if there are problems with the filesystem
     //this.fs.Check();
+};
+
+/** @typedef {function(Uint8Array, function(Uint8Array):void):void} */
+export let P9Handler;
+
+/**
+ * @constructor
+ *
+ * @param {P9Handler} handle_fn
+ * @param {CPU} cpu
+ */
+export function Virtio9pHandler(handle_fn, cpu) {
+    /** @type {P9Handler} */
+    this.handle_fn = handle_fn;
+    this.tag_bufchain = new Map();
+    this.device = new Virtio9pDevice(cpu, async (bufchain) => {
+        // TODO: split into header + data blobs to avoid unnecessary copying.
+        const reqbuf = new Uint8Array(bufchain.length_readable);
+        bufchain.get_next_blob(reqbuf);
+    
+        var reqheader = marshall.Unmarshall(["w", "b", "h"], reqbuf, { offset : 0 });
+        var reqtag = reqheader[2];
+        
+        this.tag_bufchain.set(reqtag, bufchain);
+        this.handle_fn(reqbuf, (replybuf) => {
+            var replyheader = marshall.Unmarshall(["w", "b", "h"], replybuf, { offset: 0 });
+            var replytag = replyheader[2];
+    
+            const bufchain = this.tag_bufchain.get(replytag);
+            if (!bufchain) {
+                console.error("No bufchain found for tag: " + replytag);
+                return;
+            }
+    
+            bufchain.set_next_blob(replybuf);
+            this.device.virtqueue.push_reply(bufchain);
+            this.device.virtqueue.flush_replies();
+    
+            this.tag_bufchain.delete(replytag);
+        });
+    });
+}
+
+Virtio9pHandler.prototype.get_state = function()
+{
+    var state = [];
+
+    state[0] = this.device.configspace_tagname;
+    state[1] = this.device.configspace_taglen;
+    state[2] = this.device.virtio;
+    state[3] = this.tag_bufchain;
+
+    return state;
+};
+
+Virtio9pHandler.prototype.set_state = function(state)
+{
+    this.device.configspace_tagname = state[0];
+    this.device.configspace_taglen = state[1];
+    this.device.virtio.set_state(state[2]);
+    this.device.virtqueue = this.device.virtio.queues[0];
+    this.tag_bufchain = state[3];
+};
+
+
+Virtio9pHandler.prototype.reset = function() {
+    this.device.virtio.reset();
+};
+
+
+/**
+ * @constructor
+ *
+ * @param {string} url
+ * @param {CPU} cpu
+ */
+export function Virtio9pProxy(url, cpu)
+{
+    this.socket = undefined;
+    this.cpu = cpu;
+
+    // TODO: circular buffer?
+    this.send_queue = [];
+    this.url = url;
+
+    this.reconnect_interval = 10000;
+    this.last_connect_attempt = Date.now() - this.reconnect_interval;
+    this.send_queue_limit = 64;
+    this.destroyed = false;
+
+    this.tag_bufchain = new Map();
+    this.device = new Virtio9pDevice(cpu, async (bufchain) => {
+        // TODO: split into header + data blobs to avoid unnecessary copying.
+        const reqbuf = new Uint8Array(bufchain.length_readable);
+        bufchain.get_next_blob(reqbuf);
+    
+        const reqheader = marshall.Unmarshall(["w", "b", "h"], reqbuf, { offset : 0 });
+        const reqtag = reqheader[2];
+        
+        this.tag_bufchain.set(reqtag, bufchain);
+        this.send(reqbuf);
+    });
+}
+
+Virtio9pProxy.prototype.get_state = function()
+{
+    var state = [];
+
+    state[0] = this.device.configspace_tagname;
+    state[1] = this.device.configspace_taglen;
+    state[2] = this.device.virtio;
+    state[3] = this.tag_bufchain;
+
+    return state;
+};
+
+Virtio9pProxy.prototype.set_state = function(state)
+{
+    this.device.configspace_tagname = state[0];
+    this.device.configspace_taglen = state[1];
+    this.device.virtio.set_state(state[2]);
+    this.device.virtqueue = this.device.virtio.queues[0];
+    this.tag_bufchain = state[3];
+};
+
+
+Virtio9pProxy.prototype.reset = function() {
+    this.device.virtio.reset();
+};
+
+Virtio9pProxy.prototype.handle_message = function(e)
+{
+    const replybuf = new Uint8Array(e.data);
+    const replyheader = marshall.Unmarshall(["w", "b", "h"], replybuf, { offset: 0 });
+    const replytag = replyheader[2];
+
+    const bufchain = this.tag_bufchain.get(replytag);
+    if (!bufchain) {
+        console.error("Virtio9pProxy: No bufchain found for tag: " + replytag);
+        return;
+    }
+
+    bufchain.set_next_blob(replybuf);
+    this.device.virtqueue.push_reply(bufchain);
+    this.device.virtqueue.flush_replies();
+
+    this.tag_bufchain.delete(replytag);
+};
+
+Virtio9pProxy.prototype.handle_close = function(e)
+{
+    //console.log("onclose", e);
+
+    if(!this.destroyed)
+    {
+        this.connect();
+        setTimeout(this.connect.bind(this), this.reconnect_interval);
+    }
+};
+
+Virtio9pProxy.prototype.handle_open = function(e)
+{
+    //console.log("open", e);
+
+    for(var i = 0; i < this.send_queue.length; i++)
+    {
+        this.send(this.send_queue[i]);
+    }
+
+    this.send_queue = [];
+};
+
+Virtio9pProxy.prototype.handle_error = function(e)
+{
+    //console.log("onerror", e);
+};
+
+Virtio9pProxy.prototype.destroy = function()
+{
+    this.destroyed = true;
+    if(this.socket)
+    {
+        this.socket.close();
+    }
+};
+
+Virtio9pProxy.prototype.connect = function()
+{
+    if(typeof WebSocket === "undefined")
+    {
+        return;
+    }
+
+    if(this.socket)
+    {
+        var state = this.socket.readyState;
+
+        if(state === 0 || state === 1)
+        {
+            // already or almost there
+            return;
+        }
+    }
+
+    var now = Date.now();
+
+    if(this.last_connect_attempt + this.reconnect_interval > now)
+    {
+        return;
+    }
+
+    this.last_connect_attempt = Date.now();
+
+    try
+    {
+        this.socket = new WebSocket(this.url);
+    }
+    catch(e)
+    {
+        console.error(e);
+        return;
+    }
+
+    this.socket.binaryType = "arraybuffer";
+
+    this.socket.onopen = this.handle_open.bind(this);
+    this.socket.onmessage = this.handle_message.bind(this);
+    this.socket.onclose = this.handle_close.bind(this);
+    this.socket.onerror = this.handle_error.bind(this);
+};
+
+Virtio9pProxy.prototype.send = function(data)
+{
+    //console.log("send", data);
+
+    if(!this.socket || this.socket.readyState !== 1)
+    {
+        this.send_queue.push(data);
+
+        if(this.send_queue.length > 2 * this.send_queue_limit)
+        {
+            this.send_queue = this.send_queue.slice(-this.send_queue_limit);
+        }
+
+        this.connect();
+    }
+    else
+    {
+        this.socket.send(data);
+    }
+};
+
+Virtio9pProxy.prototype.change_proxy = function(url)
+{
+    this.url = url;
+
+    if(this.socket)
+    {
+        this.socket.onclose = function() {};
+        this.socket.onerror = function() {};
+        this.socket.close();
+        this.socket = undefined;
+    }
 };

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -178,8 +178,7 @@ FS.prototype.load_from_json = function(fs)
 
     if(fs["version"] !== JSONFS_VERSION)
     {
-        throw "The filesystem JSON format has changed. " +
-              "Please update your fs2json (https://github.com/copy/fs2json) and recreate the filesystem JSON.";
+        throw "The filesystem JSON format has changed. Please recreate the filesystem JSON.";
     }
 
     var fsroot = fs["fsroot"];

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -427,7 +427,12 @@ V86.prototype.continue_init = async function(emulator, options)
         settings.handle9p = options.filesystem.handle9p;
     }
 
-    if(options.filesystem && !options.filesystem.handle9p)
+    if(options.filesystem && options.filesystem.proxy_url)
+    {
+        settings.proxy9p = options.filesystem.proxy_url;
+    }
+
+    if(options.filesystem && !options.filesystem.handle9p && !options.filesystem.proxy_url)
     {
         var fs_url = options.filesystem.basefs;
         var base_url = options.filesystem.baseurl;

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -426,13 +426,11 @@ V86.prototype.continue_init = async function(emulator, options)
     {
         settings.handle9p = options.filesystem.handle9p;
     }
-
-    if(options.filesystem && options.filesystem.proxy_url)
+    else if(options.filesystem && options.filesystem.proxy_url)
     {
         settings.proxy9p = options.filesystem.proxy_url;
     }
-
-    if(options.filesystem && !options.filesystem.handle9p && !options.filesystem.proxy_url)
+    else if(options.filesystem)
     {
         var fs_url = options.filesystem.basefs;
         var base_url = options.filesystem.baseurl;

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -422,7 +422,12 @@ V86.prototype.continue_init = async function(emulator, options)
     add_file("bzimage", options.bzimage);
     add_file("initrd", options.initrd);
 
-    if(options.filesystem)
+    if(options.filesystem && options.filesystem.handle9p)
+    {
+        settings.handle9p = options.filesystem.handle9p;
+    }
+
+    if(options.filesystem && !options.filesystem.handle9p)
     {
         var fs_url = options.filesystem.basefs;
         var base_url = options.filesystem.baseurl;

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -33,7 +33,7 @@ import { IDEController } from "./ide.js";
 import { VirtioNet } from "./virtio_net.js";
 import { VGAScreen } from "./vga.js";
 import { VirtioBalloon } from "./virtio_balloon.js";
-import { Virtio9p } from "../lib/9p.js";
+import { Virtio9p, Virtio9pHandler, Virtio9pProxy } from "../lib/9p.js";
 
 import { load_kernel } from "./kernel.js";
 
@@ -1162,9 +1162,17 @@ CPU.prototype.init = function(settings, device_bus)
             this.devices.virtio_net = new VirtioNet(this, device_bus, settings.preserve_mac_from_state_image);
         }
 
-        if(settings.fs9p || settings.handle9p)
+        if(settings.fs9p)
         {
-            this.devices.virtio_9p = new Virtio9p(settings.fs9p || settings.handle9p, this, device_bus);
+            this.devices.virtio_9p = new Virtio9p(settings.fs9p, this, device_bus);
+        }
+        else if(settings.handle9p)
+        {
+            this.devices.virtio_9p = new Virtio9pHandler(settings.handle9p, this);
+        }
+        else if(settings.proxy9p)
+        {
+            this.devices.virtio_9p = new Virtio9pProxy(settings.proxy9p, this);
         }
         if(settings.virtio_console)
         {

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -1162,9 +1162,9 @@ CPU.prototype.init = function(settings, device_bus)
             this.devices.virtio_net = new VirtioNet(this, device_bus, settings.preserve_mac_from_state_image);
         }
 
-        if(settings.fs9p)
+        if(settings.fs9p || settings.handle9p)
         {
-            this.devices.virtio_9p = new Virtio9p(settings.fs9p, this, device_bus);
+            this.devices.virtio_9p = new Virtio9p(settings.fs9p || settings.handle9p, this, device_bus);
         }
         if(settings.virtio_console)
         {

--- a/v86.d.ts
+++ b/v86.d.ts
@@ -234,6 +234,13 @@ export interface V86Options {
          * For more details, see docs/filesystem.md
          */
         basefs?: string;
+
+        /**
+         * A function that will be called for each 9p request.
+         * If specified, this will back Virtio9p instead of a filesystem.
+         * Use this to connect Virtio9p to a custom 9p server.
+         */
+        handle9p?: (reqbuf: Uint8Array, reply: (replybuf: Uint8Array) => void) => void;
     };
 
     /**

--- a/v86.d.ts
+++ b/v86.d.ts
@@ -230,7 +230,7 @@ export interface V86Options {
         baseurl?: string;
 
         /**
-         * A directory of 9p files, as created by [fs2json](https://github.com/copy/v86/blob/master/tools/fs2json.py).
+         * A directory of 9p files, as created by [copy-to-sha256.py](https://github.com/copy/v86/blob/master/tools/copy-to-sha256.py).
          * For more details, see docs/filesystem.md
          */
         basefs?: string;

--- a/v86.d.ts
+++ b/v86.d.ts
@@ -238,9 +238,16 @@ export interface V86Options {
         /**
          * A function that will be called for each 9p request.
          * If specified, this will back Virtio9p instead of a filesystem.
-         * Use this to connect Virtio9p to a custom 9p server.
+         * Use this to build or connect to a custom 9p server.
          */
         handle9p?: (reqbuf: Uint8Array, reply: (replybuf: Uint8Array) => void) => void;
+
+        /**
+         * A URL to a websocket proxy for 9p.
+         * If specified, this will back Virtio9p instead of a filesystem.
+         * Use this to connect to a custom 9p server over websocket.
+         */
+        proxy_url?: string;
     };
 
     /**


### PR DESCRIPTION
This is an initial pass at allowing a custom 9P handler function to be provided that would be used by Virtio9p instead of the HTTP backed filesystem. It's based on a working patch used by [Wanix][1]. It compiles but hasn't been thoroughly tested yet. I'd like feedback on implementation/API and how much testing would be appropriate. I can provide an example/test that's based on a Wasm 9P file server written in Go if that would be good. 

It also includes a pre-made WebSocket proxy adapter for using non-browser 9P servers.

This proposes two new fields on V86Option's `filesystem` object:
```typescript
export interface V86Options {
    // ...
    
    filesystem?: {
        // ...
        
        /**
         * A function that will be called for each 9p request.
         * If specified, this will back Virtio9p instead of a filesystem.
         * Use this to connect Virtio9p to a custom 9p server.
         */
        handle9p?: (reqbuf: Uint8Array, reply: (replybuf: Uint8Array) => void) => void;

        /**
         * A URL to a websocket proxy for 9p.
         * If specified, this will back Virtio9p instead of a filesystem.
         * Use this to connect to a custom 9p server over websocket.
         */
        proxy_url?: string;
    };
}
```

This would close #1385 

[1]: https://github.com/tractordev/wanix/blob/main/external/v86/patch/9p.js#L278