### PR TITLE
Fix HDA and HDB always being set to 1 MB and fix HDB to buffer to be created to the proper value

### DIFF
--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -2170,7 +2170,7 @@ function start_emulation(profile, query_args)
         if(hdb_empty_size)
         {
             const size = Math.max(1, Math.min(MAX_ARRAY_BUFFER_SIZE_MB, hdb_empty_size)) * 1024 * 1024;
-            settings.hdb = { buffer: new ArrayBuffer(hdb_empty_size) };
+            settings.hdb = { buffer: new ArrayBuffer(size) };
             new_query_args.set("hdb.empty", String(size));
         }
         const multiboot = $("multiboot_image")?.files[0];


### PR DESCRIPTION
This is towards #1427. This PR fixes an issue where the math performed on the target size of either HDA or HDB would always return 1 MB in size.