### PR TITLE
Attempting to add NX bit

### DIFF
--- a/src/rust/cpu/global_pointers.rs
+++ b/src/rust/cpu/global_pointers.rs
@@ -76,6 +76,8 @@ pub const sse_scratch_register: *mut reg128 = 1136 as *mut reg128;
 
 pub const fpu_st: *mut F80 = 1152 as *mut F80;
 
+pub const efer: *mut i32 = 1280 as *mut i32;
+
 pub fn get_reg32_offset(r: u32) -> u32 {
     dbg_assert!(r < 8);
     (unsafe { reg32.offset(r as isize) }) as u32


### PR DESCRIPTION
Thanks to the comment https://github.com/copy/v86/issues/845#issuecomment-2061179271 I tried adding the NX-bit, but I ran into the definition of read for execution and read for data. Can you give any implementation tips?

When starting an OS that requires NX-bit (Windows 8/10), I see a message in the logs about enabling the NX bit, but the result is the same as before.

1. I understand that this is a difficult task, but the number of function calls to read from memory is too large. Can this be simplified?
2. Am I doing the right thing by storing the nx flag in tlb?
3. I also don't quite understand how the implementation of the nx bit can improve OS support, since this flag is only needed for security.
4. I don't know how to test this. I couldn't run any kvm tests other than realmode.flat.