### PR TITLE
Add missing MULTIBOOT_INFO_MODS flag

### DIFF
--- a/src/cpu.js
+++ b/src/cpu.js
@@ -1302,6 +1302,7 @@ CPU.prototype.load_multiboot_option_rom = function(buffer, initrd, cmdline)
     const MULTIBOOT_SEARCH_BYTES = 8192;
     const MULTIBOOT_INFO_STRUCT_LEN = 116;
     const MULTIBOOT_INFO_CMDLINE = 0x4;
+    const MULTIBOOT_INFO_MODS = 0x8;
     const MULTIBOOT_INFO_MEM_MAP = 0x40;
 
     if(buffer.byteLength < MULTIBOOT_SEARCH_BYTES)
@@ -1396,8 +1397,6 @@ CPU.prototype.load_multiboot_option_rom = function(buffer, initrd, cmdline)
                 dbg_assert (!was_memory, "top of 4GB shouldn't have memory");
                 cpu.write32(multiboot_info_addr + 44, multiboot_mmap_count);
             }
-
-            cpu.write32(multiboot_info_addr, info);
 
             let entrypoint = 0;
             let top_of_load = 0;
@@ -1508,6 +1507,8 @@ CPU.prototype.load_multiboot_option_rom = function(buffer, initrd, cmdline)
 
             if(initrd)
             {
+                info |= MULTIBOOT_INFO_MODS;
+
                 cpu.write32(multiboot_info_addr + 20, 1); // mods_count
                 cpu.write32(multiboot_info_addr + 24, multiboot_data); // mods_addr;
 
@@ -1529,6 +1530,8 @@ CPU.prototype.load_multiboot_option_rom = function(buffer, initrd, cmdline)
 
                 cpu.write_blob(new Uint8Array(initrd), ramdisk_address);
             }
+
+            cpu.write32(multiboot_info_addr, info);
 
             // set state for multiboot
 


### PR DESCRIPTION
`MULTIBOOT_INFO_MODS` flag should be set when a module is present.