### PR TITLE
sb16: OPL2/OPL3 via AudioWorklet, ADPCM, MPU-401 UART, AdLib compat ports, and mixer/DSP fixes

### DIFF
--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -18,8 +18,9 @@ const AUDIOBUFFER_MINIMUM_SAMPLING_RATE = 8000;
 /**
  * @constructor
  * @param {!BusConnector} bus
+ * @param {Object=} options
  */
-export function SpeakerAdapter(bus)
+export function SpeakerAdapter(bus, options)
 {
     if(typeof window === "undefined")
     {
@@ -46,7 +47,7 @@ export function SpeakerAdapter(bus)
 
     this.dac = new SpeakerDAC(bus, this.audio_context, this.mixer);
 
-    this.opl2 = new OPL2Source(bus, this.audio_context, this.mixer);
+    this.opl2 = new OPL2Source(bus, this.audio_context, this.mixer, options && options["opl2_worklet_url"]);
 
     this.pcspeaker.start();
 
@@ -486,8 +487,9 @@ PCSpeaker.prototype.start = function()
  * @param {!BusConnector} bus
  * @param {!AudioContext} audio_context
  * @param {!SpeakerMixer} mixer
+ * @param {string=} worklet_url
  */
-function OPL2Source(bus, audio_context, mixer)
+function OPL2Source(bus, audio_context, mixer, worklet_url)
 {
     var _port = null;
     var _queue = [];
@@ -504,8 +506,6 @@ function OPL2Source(bus, audio_context, mixer)
     var mixer_connection = mixer.add_source(node_output, MIXER_SRC_OPL);
     // OPL output amplitude is ~2/3 of full-scale PCM; scale up to match.
     mixer_connection.set_gain_hidden(1.5);
-
-    var worklet_url = new URL("../opl2-worklet.js", import.meta.url).href;
 
     if(window.AudioWorklet)
     {

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -115,6 +115,20 @@ function SpeakerMixer(bus, audio_context)
     this.node_gain_left = this.audio_context.createGain();
     this.node_gain_right = this.audio_context.createGain();
 
+    // SBPro analogue output filter (mixer 0x0E bit 5, active-low).
+    // Mono cutoff ~3.2 kHz, stereo cutoff ~8 kHz; disabled = Nyquist (passthrough).
+    this.node_sbpro_filter_left = this.audio_context.createBiquadFilter();
+    this.node_sbpro_filter_right = this.audio_context.createBiquadFilter();
+    this.node_sbpro_filter_left.type = "lowpass";
+    this.node_sbpro_filter_right.type = "lowpass";
+    // Default: filter disabled — use Nyquist so the node is transparent.
+    var nyquist = this.audio_context.sampleRate / 2;
+    this.node_sbpro_filter_left.frequency.setValueAtTime(nyquist, this.audio_context.currentTime);
+    this.node_sbpro_filter_right.frequency.setValueAtTime(nyquist, this.audio_context.currentTime);
+    // Q ≈ 0.5 approximates the first-order RC slope of the real hardware filter.
+    this.node_sbpro_filter_left.Q.setValueAtTime(0.5, this.audio_context.currentTime);
+    this.node_sbpro_filter_right.Q.setValueAtTime(0.5, this.audio_context.currentTime);
+
     this.node_merger = this.audio_context.createChannelMerger(2);
 
     // Graph
@@ -124,11 +138,13 @@ function SpeakerMixer(bus, audio_context)
 
     this.node_treble_left.connect(this.node_bass_left);
     this.node_bass_left.connect(this.node_gain_left);
-    this.node_gain_left.connect(this.node_merger, 0, 0);
+    this.node_gain_left.connect(this.node_sbpro_filter_left);
+    this.node_sbpro_filter_left.connect(this.node_merger, 0, 0);
 
     this.node_treble_right.connect(this.node_bass_right);
     this.node_bass_right.connect(this.node_gain_right);
-    this.node_gain_right.connect(this.node_merger, 0, 1);
+    this.node_gain_right.connect(this.node_sbpro_filter_right);
+    this.node_sbpro_filter_right.connect(this.node_merger, 0, 1);
 
     this.node_merger.connect(this.audio_context.destination);
 
@@ -190,6 +206,16 @@ function SpeakerMixer(bus, audio_context)
     bus.register("mixer-treble-right", create_gain_handler(this.node_treble_right), this);
     bus.register("mixer-bass-left", create_gain_handler(this.node_bass_left), this);
     bus.register("mixer-bass-right", create_gain_handler(this.node_bass_right), this);
+
+    bus.register("mixer-sbpro-filter", function(data)
+    {
+        // data[0]: filter enabled (bit 5 = 0), data[1]: stereo
+        var enabled = data[0];
+        var stereo  = data[1];
+        var cutoff  = enabled ? (stereo ? 8000 : 3200) : this.audio_context.sampleRate / 2;
+        this.node_sbpro_filter_left.frequency.setValueAtTime(cutoff, this.audio_context.currentTime);
+        this.node_sbpro_filter_right.frequency.setValueAtTime(cutoff, this.audio_context.currentTime);
+    }, this);
 }
 
 /**

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -1,6 +1,6 @@
 import {
     MIXER_CHANNEL_BOTH, MIXER_CHANNEL_LEFT, MIXER_CHANNEL_RIGHT,
-    MIXER_SRC_PCSPEAKER, MIXER_SRC_DAC, MIXER_SRC_MASTER,
+    MIXER_SRC_PCSPEAKER, MIXER_SRC_DAC, MIXER_SRC_MASTER, MIXER_SRC_OPL,
 } from "../const.js";
 import { dbg_assert, dbg_log } from "../log.js";
 import { OSCILLATOR_FREQ } from "../pit.js";
@@ -45,6 +45,8 @@ export function SpeakerAdapter(bus)
     this.pcspeaker = new PCSpeaker(bus, this.audio_context, this.mixer);
 
     this.dac = new SpeakerDAC(bus, this.audio_context, this.mixer);
+
+    this.opl2 = new OPL2Source(bus, this.audio_context, this.mixer);
 
     this.pcspeaker.start();
 
@@ -393,6 +395,7 @@ SpeakerMixerSource.prototype.set_volume = function(value, channel)
 SpeakerMixerSource.prototype.set_gain_hidden = function(value)
 {
     this.gain_hidden = value;
+    this.update();
 };
 
 /**
@@ -447,6 +450,57 @@ PCSpeaker.prototype.start = function()
 {
     this.node_oscillator.start();
 };
+
+/**
+ * OPL2/OPL3 FM synthesizer source wired through the SpeakerMixer.
+ * Receives OPL register writes from SB16 via the bus and forwards
+ * them to the AudioWorklet running in opl2-worklet.js.
+ *
+ * @constructor
+ * @param {!BusConnector} bus
+ * @param {!AudioContext} audio_context
+ * @param {!SpeakerMixer} mixer
+ */
+function OPL2Source(bus, audio_context, mixer)
+{
+    var _port = null;
+    var _queue = [];
+
+    function send(msg)
+    {
+        if(_port) _port.postMessage(msg);
+        else _queue.push(msg);
+    }
+
+    // Placeholder pass-through node; registered synchronously so mixer-volume
+    // events from mixer_full_update() find the source immediately.
+    var node_output = audio_context.createGain();
+    var mixer_connection = mixer.add_source(node_output, MIXER_SRC_OPL);
+    // OPL output amplitude is ~2/3 of full-scale PCM; scale up to match.
+    mixer_connection.set_gain_hidden(1.5);
+
+    var worklet_url = new URL("../opl2-worklet.js", import.meta.url).href;
+
+    if(window.AudioWorklet)
+    {
+        audio_context.audioWorklet.addModule(worklet_url).then(function()
+        {
+            var node = new AudioWorkletNode(audio_context, "opl2", { outputChannelCount: [2] });
+            node.connect(node_output);
+            _port = node.port;
+            for(var i = 0; i < _queue.length; i++) _port.postMessage(_queue[i]);
+            _queue.length = 0;
+        }).catch(function(e)
+        {
+            console.error("[OPL2] AudioWorklet load failed:", e);
+        });
+    }
+
+    bus.register("opl2-reg-write", function(data)
+    {
+        send({ t: "w", r: data[0], v: data[1] });
+    });
+}
 
 /**
  * @constructor
@@ -809,7 +863,7 @@ function SpeakerWorkletDAC(bus, audio_context, mixer)
     // Interface
 
     this.mixer_connection = mixer.add_source(this.node_output, MIXER_SRC_DAC);
-    this.mixer_connection.set_gain_hidden(3);
+    this.mixer_connection.set_gain_hidden(1);
 
     bus.register("dac-send-data", function(data)
     {
@@ -908,7 +962,7 @@ function SpeakerBufferSourceDAC(bus, audio_context, mixer)
     this.node_output = this.node_lowpass;
 
     this.mixer_connection = mixer.add_source(this.node_output, MIXER_SRC_DAC);
-    this.mixer_connection.set_gain_hidden(3);
+    this.mixer_connection.set_gain_hidden(1);
 
     bus.register("dac-send-data", function(data)
     {

--- a/src/browser/speaker.js
+++ b/src/browser/speaker.js
@@ -507,9 +507,9 @@ function OPL2Source(bus, audio_context, mixer, worklet_url)
     // OPL output amplitude is ~2/3 of full-scale PCM; scale up to match.
     mixer_connection.set_gain_hidden(1.5);
 
-    if(window.AudioWorklet)
+    if(window.AudioWorklet && worklet_url)
     {
-        audio_context.audioWorklet.addModule(worklet_url).then(function()
+        audio_context.audioWorklet.addModule(/** @type{string} */ (worklet_url)).then(function()
         {
             var node = new AudioWorkletNode(audio_context, "opl2", { outputChannelCount: [2] });
             node.connect(node_output);
@@ -525,7 +525,7 @@ function OPL2Source(bus, audio_context, mixer, worklet_url)
     bus.register("opl2-reg-write", function(data)
     {
         send({ t: "w", r: data[0], v: data[1] });
-    });
+    }, null);
 }
 
 /**

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -319,7 +319,7 @@ V86.prototype.continue_init = async function(emulator, options)
 
     if(!options.disable_speaker)
     {
-        this.speaker_adapter = new SpeakerAdapter(this.bus);
+        this.speaker_adapter = new SpeakerAdapter(this.bus, options);
     }
 
     // ugly, but required for closure compiler compilation

--- a/src/const.js
+++ b/src/const.js
@@ -137,3 +137,4 @@ export const MIXER_CHANNEL_BOTH = 2;
 export const MIXER_SRC_MASTER = 0;
 export const MIXER_SRC_PCSPEAKER = 1;
 export const MIXER_SRC_DAC = 2;
+export const MIXER_SRC_OPL = 3;

--- a/src/opl2-worklet.js
+++ b/src/opl2-worklet.js
@@ -1,0 +1,996 @@
+/**
+ * DBOPL OPL2/OPL3 FM Synthesizer — JavaScript port of DOSBox DBOPL (GPL v2+)
+ * DBOPL_WAVE = WAVE_TABLEMUL, no WAVE_PRECISION
+ */
+"use strict";
+
+// ============ Constants ============
+const WAVE_BITS = 10;
+const WAVE_SH = 32 - WAVE_BITS;
+const WAVE_MASK = (1 << WAVE_SH) - 1;
+const LFO_SH = WAVE_SH - 10;
+const LFO_MAX = 256 << LFO_SH;
+const ENV_BITS = 9;
+const ENV_EXTRA = ENV_BITS - 9;
+const ENV_MAX = 511 << ENV_EXTRA;
+const ENV_LIMIT = (12 * 256) >> (3 - ENV_EXTRA);
+const RATE_SH = 24;
+const RATE_MASK = (1 << RATE_SH) - 1;
+const MUL_SH = 16;
+const TREMOLO_TABLE = 52;
+const OPLRATE = 14318180.0 / 288.0;
+const SHIFT_KSLBASE = 16;
+const SHIFT_KEYCODE = 24;
+
+const OFF = 0, RELEASE = 1, SUSTAIN = 2, DECAY = 3, ATTACK = 4;
+const MASK_KSR = 0x10, MASK_SUSTAIN = 0x20, MASK_VIBRATO = 0x40, MASK_TREMOLO = 0x80;
+const sm2AM = 0;
+const sm2FM = 1;
+const sm3AM = 2;
+const sm3FM = 3;
+const sm4Start = 4;
+const sm3FMFM = 5;
+const sm3AMFM = 6;
+const sm3FMAM = 7;
+const sm3AMAM = 8;
+const sm6Start = 9;
+const sm2Percussion = 10;
+const sm3Percussion = 11;
+
+// ============ Static constant tables ============
+const KslCreateTable = [64, 32, 24, 19, 16, 12, 11, 10, 8, 6, 5, 4, 3, 2, 1, 0];
+const FreqCreateTable = [1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 20, 24, 24, 30, 30];
+const AttackSamplesTable = [69, 55, 46, 40, 35, 29, 23, 20, 19, 15, 11, 10, 9];
+const EnvelopeIncreaseTable = [4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28, 32];
+const WaveBaseTable = [0x000, 0x200, 0x200, 0x800, 0xa00, 0xc00, 0x100, 0x400];
+const WaveMaskTable = [1023, 1023, 511, 511, 1023, 1023, 512, 1023];
+const WaveStartTable = [512, 0, 0, 0, 0, 512, 512, 256];
+const VibratoTable = new Int8Array([1, 0, 1, 30, 1 - 128, 0 - 128, 1 - 128, 30 - 128]);
+const KslShiftTable = [31, 1, 2, 0];
+
+// ============ Computed tables (filled by initTables) ============
+const MulTable = new Uint16Array(384);
+const WaveTable = new Int16Array(8 * 512);
+const KslTable = new Uint8Array(8 * 16);
+const TremoloTable = new Uint8Array(TREMOLO_TABLE);
+const chanLookup = new Int8Array(32).fill(-1);
+const opLookup = new Array(64).fill(null);
+
+function envelopeSelect(val) {
+    if (val < 52) return [val & 3, 12 - (val >> 2)];
+    if (val < 60) return [val - 48, 0];
+    return [12, 0];
+}
+
+function initTables() {
+    for (let i = 0; i < 384; i++) {
+        MulTable[i] = 0.5 + Math.pow(2, -1 + (255 - i * 8) / 256) * (1 << MUL_SH);
+    }
+    for (let i = 0; i < 512; i++) {
+        WaveTable[0x200 + i] = Math.trunc(Math.sin((i + 0.5) * Math.PI / 512) * 4084);
+        WaveTable[0x000 + i] = -WaveTable[0x200 + i];
+    }
+    for (let i = 0; i < 256; i++) {
+        WaveTable[0x700 + i] = Math.trunc(0.5 + Math.pow(2, -1 + (255 - i * 8) / 256) * 4085);
+        WaveTable[0x6ff - i] = -WaveTable[0x700 + i];
+    }
+    for (let i = 0; i < 256; i++) {
+        WaveTable[0x400 + i] = WaveTable[0];
+        WaveTable[0x500 + i] = WaveTable[0];
+        WaveTable[0x900 + i] = WaveTable[0];
+        WaveTable[0xc00 + i] = WaveTable[0];
+        WaveTable[0xd00 + i] = WaveTable[0];
+        WaveTable[0x800 + i] = WaveTable[0x200 + i];
+        WaveTable[0xa00 + i] = WaveTable[0x200 + i * 2];
+        WaveTable[0xb00 + i] = WaveTable[0x000 + i * 2];
+        WaveTable[0xe00 + i] = WaveTable[0x200 + i * 2];
+        WaveTable[0xf00 + i] = WaveTable[0x200 + i * 2];
+    }
+    for (let oct = 0; oct < 8; oct++) {
+        const base = oct * 8;
+        for (let i = 0; i < 16; i++) {
+            let val = base - KslCreateTable[i];
+            if (val < 0) val = 0;
+            KslTable[oct * 16 + i] = val * 4;
+        }
+    }
+    for (let i = 0; i < (TREMOLO_TABLE >> 1); i++) {
+        TremoloTable[i] = i << ENV_EXTRA;
+        TremoloTable[TREMOLO_TABLE - 1 - i] = i << ENV_EXTRA;
+    }
+    for (let i = 0; i < 32; i++) {
+        let idx = i & 0xf;
+        if (idx >= 9) { chanLookup[i] = -1; continue; }
+        if (idx < 6) idx = (idx % 3) * 2 + ((idx / 3) | 0);
+        if (i >= 16) idx += 9;
+        chanLookup[i] = idx;
+    }
+    for (let i = 0; i < 64; i++) {
+        if (i % 8 >= 6 || ((i / 8 | 0) % 4 === 3)) { opLookup[i] = null; continue; }
+        let chNum = ((i / 8) | 0) * 3 + (i % 8) % 3;
+        if (chNum >= 12) chNum += 4;
+        const opNum = ((i % 8) / 3) | 0;
+        const chanIdx = chanLookup[chNum];
+        opLookup[i] = chanIdx >= 0 ? [chanIdx, opNum] : null;
+    }
+}
+
+// ============ Operator ============
+class Operator {
+    constructor() {
+        this.waveBaseIdx = 0;
+        this.waveMask = 0;
+        this.waveStart = 0;
+        this.waveIndex = 0;
+        this.waveAdd = 0;
+        this.waveCurrent = 0;
+        this.chanData = 0;
+        this.freqMul = 0;
+        this.vibrato = 0;
+        this.sustainLevel = ENV_MAX;
+        this.totalLevel = ENV_MAX;
+        this.currentLevel = ENV_MAX;
+        this.volume = ENV_MAX;
+        this.attackAdd = 0;
+        this.decayAdd = 0;
+        this.releaseAdd = 0;
+        this.rateIndex = 0;
+        this.rateZero = 1 << OFF;
+        this.keyOn = 0;
+        this.reg20 = 0;
+        this.reg40 = 0;
+        this.reg60 = 0;
+        this.reg80 = 0;
+        this.regE0 = 0;
+        this.state = OFF;
+        this.tremoloMask = 0;
+        this.vibStrength = 0;
+        this.ksr = 0;
+    }
+
+    updateAttack(chip) {
+        const rate = this.reg60 >> 4;
+        if (rate) {
+            this.attackAdd = chip.attackRates[(rate << 2) + this.ksr];
+            this.rateZero &= ~(1 << ATTACK);
+        } else {
+            this.attackAdd = 0;
+            this.rateZero |= 1 << ATTACK;
+        }
+    }
+
+    updateDecay(chip) {
+        const rate = this.reg60 & 0xf;
+        if (rate) {
+            this.decayAdd = chip.linearRates[(rate << 2) + this.ksr];
+            this.rateZero &= ~(1 << DECAY);
+        } else {
+            this.decayAdd = 0;
+            this.rateZero |= 1 << DECAY;
+        }
+    }
+
+    updateRelease(chip) {
+        const rate = this.reg80 & 0xf;
+        if (rate) {
+            this.releaseAdd = chip.linearRates[(rate << 2) + this.ksr];
+            this.rateZero &= ~(1 << RELEASE);
+            if (!(this.reg20 & MASK_SUSTAIN)) this.rateZero &= ~(1 << SUSTAIN);
+        } else {
+            this.releaseAdd = 0;
+            this.rateZero |= 1 << RELEASE;
+            if (!(this.reg20 & MASK_SUSTAIN)) this.rateZero |= 1 << SUSTAIN;
+        }
+    }
+
+    updateAttenuation() {
+        const kslBase = (this.chanData >>> SHIFT_KSLBASE) & 0xff;
+        const tl = this.reg40 & 0x3f;
+        const kslShift = KslShiftTable[this.reg40 >> 6];
+        this.totalLevel = tl << (ENV_BITS - 7);
+        this.totalLevel += (kslBase << ENV_EXTRA) >> kslShift;
+    }
+
+    updateFrequency() {
+        const freq = this.chanData & 0x3ff;
+        const block = (this.chanData >> 10) & 0xff;
+        this.waveAdd = ((freq << block) * this.freqMul) >>> 0;
+        if (this.reg20 & MASK_VIBRATO) {
+            this.vibStrength = (freq >> 7) & 0xff;
+            this.vibrato = ((this.vibStrength << block) * this.freqMul) >>> 0;
+        } else {
+            this.vibStrength = 0;
+            this.vibrato = 0;
+        }
+    }
+
+    updateRates(chip) {
+        let newKsr = (this.chanData >>> SHIFT_KEYCODE) & 0xff;
+        if (!(this.reg20 & MASK_KSR)) newKsr >>= 2;
+        if (this.ksr === newKsr) return;
+        this.ksr = newKsr;
+        this.updateAttack(chip);
+        this.updateDecay(chip);
+        this.updateRelease(chip);
+    }
+
+    rateForward(add) {
+        this.rateIndex += add;
+        const ret = this.rateIndex >>> RATE_SH;
+        this.rateIndex &= RATE_MASK;
+        return ret;
+    }
+
+    templateVolume() {
+        let vol = this.volume;
+        switch (this.state) {
+            case OFF: return ENV_MAX;
+            case ATTACK: {
+                const change = this.rateForward(this.attackAdd);
+                if (!change) return vol;
+                vol += ((~vol) * change) >> 3;
+                if (vol < 0) {
+                    this.volume = 0;
+                    this.rateIndex = 0;
+                    this.state = DECAY;
+                    return 0;
+                }
+                break;
+            }
+            case DECAY:
+                vol += this.rateForward(this.decayAdd);
+                if (vol >= this.sustainLevel) {
+                    if (vol >= ENV_MAX) {
+                        this.volume = ENV_MAX;
+                        this.state = OFF;
+                        return ENV_MAX;
+                    }
+                    this.rateIndex = 0;
+                    this.state = SUSTAIN;
+                }
+                break;
+            case SUSTAIN:
+                if (this.reg20 & MASK_SUSTAIN) return vol;
+                // fall through to release
+            case RELEASE:
+                vol += this.rateForward(this.releaseAdd);
+                if (vol >= ENV_MAX) {
+                    this.volume = ENV_MAX;
+                    this.state = OFF;
+                    return ENV_MAX;
+                }
+                break;
+        }
+        this.volume = vol;
+        return vol;
+    }
+
+    forwardVolume() {
+        return this.currentLevel + this.templateVolume();
+    }
+
+    forwardWave() {
+        this.waveIndex = (this.waveIndex + this.waveCurrent) >>> 0;
+        return this.waveIndex >>> WAVE_SH;
+    }
+
+    getWave(index, vol) {
+        return (WaveTable[this.waveBaseIdx + (index & this.waveMask)] * MulTable[vol]) >> MUL_SH;
+    }
+
+    getSample(modulation) {
+        const vol = this.forwardVolume();
+        if (vol >= ENV_LIMIT) {
+            this.waveIndex = (this.waveIndex + this.waveCurrent) >>> 0;
+            return 0;
+        }
+        const index = this.forwardWave();
+        return this.getWave(index + modulation, vol);
+    }
+
+    silent() {
+        if (this.totalLevel + this.volume < ENV_LIMIT) return false;
+        if (!(this.rateZero & (1 << this.state))) return false;
+        return true;
+    }
+
+    prepare(chip) {
+        this.currentLevel = this.totalLevel + (chip.tremoloValue & this.tremoloMask);
+        this.waveCurrent = this.waveAdd;
+        if ((this.vibStrength >>> chip.vibratoShift) !== 0) {
+            let add = (this.vibrato >>> chip.vibratoShift) | 0;
+            const neg = chip.vibratoSign;
+            add = (add ^ neg) - neg;
+            this.waveCurrent = (this.waveCurrent + add) | 0;
+        }
+    }
+
+    keyOnAction(mask) {
+        if (!this.keyOn) {
+            this.waveIndex = this.waveStart;
+            this.rateIndex = 0;
+            this.state = ATTACK;
+        }
+        this.keyOn |= mask;
+    }
+
+    keyOffAction(mask) {
+        this.keyOn &= ~mask;
+        if (!this.keyOn && this.state !== OFF) {
+            this.state = RELEASE;
+        }
+    }
+
+    write20(chip, val) {
+        const change = this.reg20 ^ val;
+        if (!change) return;
+        this.reg20 = val;
+        this.tremoloMask = (val << 24) >> 31;
+        this.tremoloMask &= ~((1 << ENV_EXTRA) - 1);
+        if (change & MASK_KSR) this.updateRates(chip);
+        if ((this.reg20 & MASK_SUSTAIN) || !this.releaseAdd) {
+            this.rateZero |= 1 << SUSTAIN;
+        } else {
+            this.rateZero &= ~(1 << SUSTAIN);
+        }
+        if (change & (0xf | MASK_VIBRATO)) {
+            this.freqMul = chip.freqMul[val & 0xf];
+            this.updateFrequency();
+        }
+    }
+
+    write40(chip, val) {
+        if (this.reg40 === val) return;
+        this.reg40 = val;
+        this.updateAttenuation();
+    }
+
+    write60(chip, val) {
+        const change = this.reg60 ^ val;
+        this.reg60 = val;
+        if (change & 0x0f) this.updateDecay(chip);
+        if (change & 0xf0) this.updateAttack(chip);
+    }
+
+    write80(chip, val) {
+        const change = this.reg80 ^ val;
+        if (!change) return;
+        this.reg80 = val;
+        let sustain = val >> 4;
+        sustain |= (sustain + 1) & 0x10;
+        this.sustainLevel = sustain << (ENV_BITS - 5);
+        if (change & 0x0f) this.updateRelease(chip);
+    }
+
+    writeE0(chip, val) {
+        if (this.regE0 === val) return;
+        const waveForm = val & ((0x3 & chip.waveFormMask) | (0x7 & chip.opl3Active));
+        this.regE0 = val;
+        this.waveBaseIdx = WaveBaseTable[waveForm];
+        this.waveStart = WaveStartTable[waveForm] << WAVE_SH;
+        this.waveMask = WaveMaskTable[waveForm];
+    }
+}
+
+// ============ Channel ============
+class Channel {
+    constructor(index, chip) {
+        this.index = index;
+        this.chip = chip;
+        this.op = [new Operator(), new Operator()];
+        this.old = [0, 0];
+        this.chanData = 0;
+        this.feedback = 31;
+        this.regB0 = 0;
+        this.regC0 = 0;
+        this.fourMask = 0;
+        this.maskLeft = -1;
+        this.maskRight = -1;
+        this.synthMode = sm2FM;
+    }
+
+    Op(idx) {
+        return this.chip.chan[this.index + (idx >> 1)].op[idx & 1];
+    }
+
+    setChanData(chip, data) {
+        const change = this.chanData ^ data;
+        this.chanData = data;
+        this.op[0].chanData = data;
+        this.op[1].chanData = data;
+        this.op[0].updateFrequency();
+        this.op[1].updateFrequency();
+        if (change & (0xff << SHIFT_KSLBASE)) {
+            this.op[0].updateAttenuation();
+            this.op[1].updateAttenuation();
+        }
+        if (change & (0xff << SHIFT_KEYCODE)) {
+            this.op[0].updateRates(chip);
+            this.op[1].updateRates(chip);
+        }
+    }
+
+    updateFrequency(chip, fourOp) {
+        let data = this.chanData & 0xffff;
+        const kslBase = KslTable[data >> 6];
+        let keyCode = (data & 0x1c00) >> 9;
+        if (chip.reg08 & 0x40) {
+            keyCode |= (data & 0x100) >> 8;
+        } else {
+            keyCode |= (data & 0x200) >> 9;
+        }
+        data |= (keyCode << SHIFT_KEYCODE) | (kslBase << SHIFT_KSLBASE);
+        this.setChanData(chip, data);
+        if (fourOp & 0x3f) {
+            this.chip.chan[this.index + 1].setChanData(chip, data);
+        }
+    }
+
+    writeA0(chip, val) {
+        const fourOp = chip.reg104 & chip.opl3Active & this.fourMask;
+        if (fourOp > 0x80) return;
+        const change = (this.chanData ^ val) & 0xff;
+        if (change) {
+            this.chanData ^= change;
+            this.updateFrequency(chip, fourOp);
+        }
+    }
+
+    writeB0(chip, val) {
+        const fourOp = chip.reg104 & chip.opl3Active & this.fourMask;
+        if (fourOp > 0x80) return;
+        const change = (this.chanData ^ (val << 8)) & 0x1f00;
+        if (change) {
+            this.chanData ^= change;
+            this.updateFrequency(chip, fourOp);
+        }
+        if (!((val ^ this.regB0) & 0x20)) return;
+        this.regB0 = val;
+        if (val & 0x20) {
+            this.op[0].keyOnAction(0x1);
+            this.op[1].keyOnAction(0x1);
+            if (fourOp & 0x3f) {
+                this.chip.chan[this.index + 1].op[0].keyOnAction(1);
+                this.chip.chan[this.index + 1].op[1].keyOnAction(1);
+            }
+        } else {
+            this.op[0].keyOffAction(0x1);
+            this.op[1].keyOffAction(0x1);
+            if (fourOp & 0x3f) {
+                this.chip.chan[this.index + 1].op[0].keyOffAction(1);
+                this.chip.chan[this.index + 1].op[1].keyOffAction(1);
+            }
+        }
+    }
+
+    writeC0(chip, val) {
+        if (!(val ^ this.regC0)) return;
+        this.regC0 = val;
+        this.feedback = (this.regC0 >> 1) & 7;
+        this.feedback = this.feedback ? 9 - this.feedback : 31;
+        this.updateSynth(chip);
+    }
+
+    updateSynth(chip) {
+        if (chip.opl3Active) {
+            if ((chip.reg104 & this.fourMask) & 0x3f) {
+                let chan0, chan1;
+                if (!(this.fourMask & 0x80)) {
+                    chan0 = this;
+                    chan1 = chip.chan[this.index + 1];
+                } else {
+                    chan0 = chip.chan[this.index - 1];
+                    chan1 = this;
+                }
+                const synth = ((chan0.regC0 & 1) << 0) | ((chan1.regC0 & 1) << 1);
+                switch (synth) {
+                case 0: chan0.synthMode = sm3FMFM; break;
+                case 1: chan0.synthMode = sm3AMFM; break;
+                case 2: chan0.synthMode = sm3FMAM; break;
+                case 3: chan0.synthMode = sm3AMAM; break;
+                }
+            } else if ((this.fourMask & 0x40) && (chip.regBD & 0x20)) {
+                // Percussion - don't update
+            } else if (this.regC0 & 1) {
+                this.synthMode = sm3AM;
+            } else {
+                this.synthMode = sm3FM;
+            }
+            this.maskLeft = (this.regC0 & 0x10) ? -1 : 0;
+            this.maskRight = (this.regC0 & 0x20) ? -1 : 0;
+        } else {
+            if ((this.fourMask & 0x40) && (chip.regBD & 0x20)) {
+                // Percussion - don't update
+            } else if (this.regC0 & 1) {
+                this.synthMode = sm2AM;
+            } else {
+                this.synthMode = sm2FM;
+            }
+        }
+    }
+
+    generatePercussion(chip, output, outIdx, opl3Mode) {
+        let mod = (this.old[0] + this.old[1]) >>> this.feedback;
+        this.old[0] = this.old[1];
+        this.old[1] = this.Op(0).getSample(mod);
+
+        if (this.regC0 & 1) { mod = 0; } else { mod = this.old[0]; }
+        let sample = this.Op(1).getSample(mod);
+
+        const noiseBit = chip.forwardNoise() & 0x1;
+        const c2 = this.Op(2).forwardWave();
+        const c5 = this.Op(5).forwardWave();
+        const phaseBit = (((c2 & 0x88) ^ ((c2 << 5) & 0x80)) | ((c5 ^ (c5 << 2)) & 0x20)) ? 0x02 : 0x00;
+
+        const hhVol = this.Op(2).forwardVolume();
+        if (hhVol < ENV_LIMIT) {
+            sample += this.Op(2).getWave((phaseBit << 8) | (0x34 << (phaseBit ^ (noiseBit << 1))), hhVol);
+        }
+        const sdVol = this.Op(3).forwardVolume();
+        if (sdVol < ENV_LIMIT) {
+            sample += this.Op(3).getWave((0x100 + (c2 & 0x100)) ^ (noiseBit << 8), sdVol);
+        }
+        sample += this.Op(4).getSample(0);
+        const tcVol = this.Op(5).forwardVolume();
+        if (tcVol < ENV_LIMIT) {
+            sample += this.Op(5).getWave((1 + phaseBit) << 8, tcVol);
+        }
+
+        sample <<= 1;
+        if (opl3Mode) {
+            output[outIdx] += sample;
+            output[outIdx + 1] += sample;
+        } else {
+            output[outIdx] += sample;
+        }
+    }
+
+    blockTemplate(chip, samples, output, outIdx) {
+        const mode = this.synthMode;
+        switch (mode) {
+        case sm2AM:
+        case sm3AM:
+            if (this.Op(0).silent() && this.Op(1).silent()) {
+                this.old[0] = this.old[1] = 0;
+                return this.index + 1;
+            }
+            break;
+        case sm2FM:
+        case sm3FM:
+            if (this.Op(1).silent()) {
+                this.old[0] = this.old[1] = 0;
+                return this.index + 1;
+            }
+            break;
+        case sm3FMFM:
+            if (this.Op(3).silent()) {
+                this.old[0] = this.old[1] = 0;
+                return this.index + 2;
+            }
+            break;
+        case sm3AMFM:
+            if (this.Op(0).silent() && this.Op(3).silent()) {
+                this.old[0] = this.old[1] = 0;
+                return this.index + 2;
+            }
+            break;
+        case sm3FMAM:
+            if (this.Op(1).silent() && this.Op(3).silent()) {
+                this.old[0] = this.old[1] = 0;
+                return this.index + 2;
+            }
+            break;
+        case sm3AMAM:
+            if (this.Op(0).silent() && this.Op(2).silent() && this.Op(3).silent()) {
+                this.old[0] = this.old[1] = 0;
+                return this.index + 2;
+            }
+            break;
+        }
+
+        this.Op(0).prepare(chip);
+        this.Op(1).prepare(chip);
+        if (mode > sm4Start) {
+            this.Op(2).prepare(chip);
+            this.Op(3).prepare(chip);
+        }
+        if (mode > sm6Start) {
+            this.Op(4).prepare(chip);
+            this.Op(5).prepare(chip);
+        }
+
+        for (let i = 0; i < samples; i++) {
+            if (mode === sm2Percussion) {
+                this.generatePercussion(chip, output, outIdx + i, false);
+                continue;
+            } else if (mode === sm3Percussion) {
+                this.generatePercussion(chip, output, outIdx + i * 2, true);
+                continue;
+            }
+            const mod = (this.old[0] + this.old[1]) >>> this.feedback;
+            this.old[0] = this.old[1];
+            this.old[1] = this.Op(0).getSample(mod);
+            let sample;
+            const out0 = this.old[0];
+
+            if (mode === sm2AM || mode === sm3AM) {
+                sample = out0 + this.Op(1).getSample(0);
+            } else if (mode === sm2FM || mode === sm3FM) {
+                sample = this.Op(1).getSample(out0);
+            } else if (mode === sm3FMFM) {
+                let next = this.Op(1).getSample(out0);
+                next = this.Op(2).getSample(next);
+                sample = this.Op(3).getSample(next);
+            } else if (mode === sm3AMFM) {
+                sample = out0;
+                let next = this.Op(1).getSample(0);
+                next = this.Op(2).getSample(next);
+                sample += this.Op(3).getSample(next);
+            } else if (mode === sm3FMAM) {
+                sample = this.Op(1).getSample(out0);
+                const next = this.Op(2).getSample(0);
+                sample += this.Op(3).getSample(next);
+            } else if (mode === sm3AMAM) {
+                sample = out0;
+                const next = this.Op(1).getSample(0);
+                sample += this.Op(2).getSample(next);
+                sample += this.Op(3).getSample(0);
+            }
+
+            switch (mode) {
+            case sm2AM:
+            case sm2FM:
+                output[outIdx + i] += sample;
+                break;
+            case sm3AM:
+            case sm3FM:
+            case sm3FMFM:
+            case sm3AMFM:
+            case sm3FMAM:
+            case sm3AMAM:
+                output[outIdx + i * 2 + 0] += sample & this.maskLeft;
+                output[outIdx + i * 2 + 1] += sample & this.maskRight;
+                break;
+            }
+        }
+
+        switch (mode) {
+        case sm2AM:
+        case sm2FM:
+        case sm3AM:
+        case sm3FM:
+            return this.index + 1;
+        case sm3FMFM:
+        case sm3AMFM:
+        case sm3FMAM:
+        case sm3AMAM:
+            return this.index + 2;
+        case sm2Percussion:
+        case sm3Percussion:
+            return this.index + 3;
+        }
+        return this.index;
+    }
+}
+
+// ============ Chip ============
+class Chip {
+    constructor() {
+        this.chan = [];
+        for (let i = 0; i < 18; i++) this.chan[i] = new Channel(i, this);
+
+        this.lfoCounter = 0;
+        this.lfoAdd = 0;
+        this.noiseCounter = 0;
+        this.noiseAdd = 0;
+        this.noiseValue = 1;
+
+        this.freqMul = new Uint32Array(16);
+        this.linearRates = new Uint32Array(76);
+        this.attackRates = new Uint32Array(76);
+
+        this.reg104 = 0;
+        this.reg08 = 0;
+        this.reg04 = 0;
+        this.regBD = 0;
+        this.vibratoIndex = 0;
+        this.tremoloIndex = 0;
+        this.vibratoSign = 0;
+        this.vibratoShift = 0;
+        this.tremoloValue = 0;
+        this.vibratoStrength = 0;
+        this.tremoloStrength = 0;
+        this.waveFormMask = 0;
+        this.opl3Active = 0;
+    }
+
+    forwardNoise() {
+        this.noiseCounter += this.noiseAdd;
+        let count = this.noiseCounter >>> LFO_SH;
+        this.noiseCounter &= WAVE_MASK;
+        for (; count > 0; --count) {
+            this.noiseValue ^= 0x800302 & (0 - (this.noiseValue & 1));
+            this.noiseValue >>>= 1;
+        }
+        return this.noiseValue;
+    }
+
+    forwardLFO(samples) {
+        this.vibratoSign = VibratoTable[this.vibratoIndex >> 2] >> 7;
+        this.vibratoShift = (VibratoTable[this.vibratoIndex >> 2] & 7) + this.vibratoStrength;
+        this.tremoloValue = TremoloTable[this.tremoloIndex] >> this.tremoloStrength;
+
+        const todo = LFO_MAX - this.lfoCounter;
+        let count = ((todo + this.lfoAdd - 1) / this.lfoAdd) | 0;
+        if (count > samples) {
+            count = samples;
+            this.lfoCounter += count * this.lfoAdd;
+        } else {
+            this.lfoCounter += count * this.lfoAdd;
+            this.lfoCounter &= LFO_MAX - 1;
+            this.vibratoIndex = (this.vibratoIndex + 1) & 31;
+            if (this.tremoloIndex + 1 < TREMOLO_TABLE) ++this.tremoloIndex;
+            else this.tremoloIndex = 0;
+        }
+        return count;
+    }
+
+    writeBD(val) {
+        const change = this.regBD ^ val;
+        if (!change) return;
+        this.regBD = val;
+        this.vibratoStrength = (val & 0x40) ? 0x00 : 0x01;
+        this.tremoloStrength = (val & 0x80) ? 0x00 : 0x02;
+
+        if (val & 0x20) {
+            if (change & 0x20) {
+                if (this.opl3Active) {
+                    this.chan[6].synthMode = sm3Percussion;
+                } else {
+                    this.chan[6].synthMode = sm2Percussion;
+                }
+            }
+            if (val & 0x10) { this.chan[6].op[0].keyOnAction(0x2); this.chan[6].op[1].keyOnAction(0x2); }
+            else { this.chan[6].op[0].keyOffAction(0x2); this.chan[6].op[1].keyOffAction(0x2); }
+            if (val & 0x01) this.chan[7].op[0].keyOnAction(0x2);
+            else this.chan[7].op[0].keyOffAction(0x2);
+            if (val & 0x08) this.chan[7].op[1].keyOnAction(0x2);
+            else this.chan[7].op[1].keyOffAction(0x2);
+            if (val & 0x04) this.chan[8].op[0].keyOnAction(0x2);
+            else this.chan[8].op[0].keyOffAction(0x2);
+            if (val & 0x02) this.chan[8].op[1].keyOnAction(0x2);
+            else this.chan[8].op[1].keyOffAction(0x2);
+        } else if (change & 0x20) {
+            this.chan[6].updateSynth(this);
+            this.chan[6].op[0].keyOffAction(0x2);
+            this.chan[6].op[1].keyOffAction(0x2);
+            this.chan[7].op[0].keyOffAction(0x2);
+            this.chan[7].op[1].keyOffAction(0x2);
+            this.chan[8].op[0].keyOffAction(0x2);
+            this.chan[8].op[1].keyOffAction(0x2);
+        }
+    }
+
+    updateSynths() {
+        for (let i = 0; i < 18; i++) this.chan[i].updateSynth(this);
+    }
+
+    writeReg(reg, val) {
+        switch ((reg & 0xf0) >> 4) {
+            case 0:
+                if (reg === 0x01) this.waveFormMask = (val & 0x20) ? 0x7 : 0x0;
+                else if (reg === 0x104) {
+                    if (!((this.reg104 ^ val) & 0x3f)) return;
+                    this.reg104 = 0x80 | (val & 0x3f);
+                    this.updateSynths();
+                }
+                else if (reg === 0x105) {
+                    if (!((this.opl3Active ^ val) & 1)) return;
+                    this.opl3Active = (val & 1) ? 0xff : 0;
+                    this.updateSynths();
+                }
+                else if (reg === 0x08) this.reg08 = val;
+                // fall through
+            case 1: break;
+            case 2: case 3: {
+                const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
+                if (e) this.chan[e[0]].op[e[1]].write20(this, val);
+                break;
+            }
+            case 4: case 5: {
+                const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
+                if (e) this.chan[e[0]].op[e[1]].write40(this, val);
+                break;
+            }
+            case 6: case 7: {
+                const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
+                if (e) this.chan[e[0]].op[e[1]].write60(this, val);
+                break;
+            }
+            case 8: case 9: {
+                const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
+                if (e) this.chan[e[0]].op[e[1]].write80(this, val);
+                break;
+            }
+            case 0xa: {
+                const ch = chanLookup[((reg >> 4) & 0x10) | (reg & 0xf)];
+                if (ch >= 0) this.chan[ch].writeA0(this, val);
+                break;
+            }
+            case 0xb:
+                if (reg === 0xbd) this.writeBD(val);
+                else {
+                    const ch = chanLookup[((reg >> 4) & 0x10) | (reg & 0xf)];
+                    if (ch >= 0) this.chan[ch].writeB0(this, val);
+                }
+                break;
+            case 0xc: {
+                const ch = chanLookup[((reg >> 4) & 0x10) | (reg & 0xf)];
+                if (ch >= 0) this.chan[ch].writeC0(this, val);
+                break;
+            }
+            case 0xd: break;
+            case 0xe: case 0xf: {
+                const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
+                if (e) this.chan[e[0]].op[e[1]].writeE0(this, val);
+                break;
+            }
+        }
+    }
+
+    writeAddr(port, val) {
+        switch (port & 3) {
+        case 0:
+            return val;
+        case 2:
+            if (this.opl3Active || (val === 0x05))
+                return 0x100 | val;
+            else
+                return val;
+        }
+        return 0;
+    }
+
+    generateBlock2(total, output) {
+        let outIdx = 0;
+        while (total > 0) {
+            const samples = this.forwardLFO(total);
+            for (let i = outIdx; i < outIdx + samples; i++) output[i] = 0;
+            let chIdx = 0;
+            while (chIdx < 9) {
+                chIdx = this.chan[chIdx].blockTemplate(this, samples, output, outIdx);
+            }
+            total -= samples;
+            outIdx += samples;
+        }
+    }
+
+    generateBlock3(total, output) {
+        let outIdx = 0;
+        while (total > 0) {
+            const samples = this.forwardLFO(total);
+            for (let i = outIdx; i < outIdx + samples * 2; i++) output[i] = 0;
+            let chIdx = 0;
+            while (chIdx < 18) {
+                chIdx = this.chan[chIdx].blockTemplate(this, samples, output, outIdx);
+            }
+            total -= samples;
+            outIdx += samples * 2;
+        }
+    }
+
+    setup(rate) {
+        const scale = OPLRATE / rate;
+
+        this.noiseAdd = Math.round(scale * (1 << LFO_SH));
+        this.noiseCounter = 0;
+        this.noiseValue = 1;
+        this.lfoAdd = Math.round(scale * (1 << LFO_SH));
+        this.lfoCounter = 0;
+        this.vibratoIndex = 0;
+        this.tremoloIndex = 0;
+
+        const freqScale = Math.round(scale * (1 << (WAVE_SH - 1 - 10)));
+        for (let i = 0; i < 16; i++) this.freqMul[i] = freqScale * FreqCreateTable[i];
+
+        for (let i = 0; i < 76; i++) {
+            const [index, shift] = envelopeSelect(i);
+            this.linearRates[i] = Math.trunc(scale * (EnvelopeIncreaseTable[index] << (RATE_SH + ENV_EXTRA - shift - 3)));
+        }
+
+        for (let i = 0; i < 62; i++) {
+            const [index, shift] = envelopeSelect(i);
+            const origSamples = Math.trunc((AttackSamplesTable[index] << shift) / scale);
+            let guessAdd = Math.trunc(scale * (EnvelopeIncreaseTable[index] << (RATE_SH - shift - 3)));
+            let bestAdd = guessAdd, bestDiff = 1 << 30;
+            for (let passes = 0; passes < 16; passes++) {
+                let volume = ENV_MAX, samples = 0, count = 0;
+                while (volume > 0 && samples < origSamples * 2) {
+                    count += guessAdd;
+                    const change = count >> RATE_SH;
+                    count &= RATE_MASK;
+                    if (change) volume += ((~volume) * change) >> 3;
+                    samples++;
+                }
+                const diff = origSamples - samples;
+                const lDiff = Math.abs(diff);
+                if (lDiff < bestDiff) {
+                    bestDiff = lDiff;
+                    bestAdd = guessAdd;
+                    if (!bestDiff) break;
+                }
+                guessAdd = Math.trunc(guessAdd * ((origSamples - diff) / origSamples));
+                if (diff < 0) guessAdd++;
+            }
+            this.attackRates[i] = bestAdd;
+        }
+        for (let i = 62; i < 76; i++) this.attackRates[i] = 8 << RATE_SH;
+
+        this.chan[0].fourMask = 0x00 | (1 << 0);
+        this.chan[1].fourMask = 0x80 | (1 << 0);
+        this.chan[2].fourMask = 0x00 | (1 << 1);
+        this.chan[3].fourMask = 0x80 | (1 << 1);
+        this.chan[4].fourMask = 0x00 | (1 << 2);
+        this.chan[5].fourMask = 0x80 | (1 << 2);
+        this.chan[9].fourMask = 0x00 | (1 << 3);
+        this.chan[10].fourMask = 0x80 | (1 << 3);
+        this.chan[11].fourMask = 0x00 | (1 << 4);
+        this.chan[12].fourMask = 0x80 | (1 << 4);
+        this.chan[13].fourMask = 0x00 | (1 << 5);
+        this.chan[14].fourMask = 0x80 | (1 << 5);
+        this.chan[6].fourMask = 0x40;
+        this.chan[7].fourMask = 0x40;
+        this.chan[8].fourMask = 0x40;
+
+        this.writeReg(0x105, 0x1);
+        for (let i = 0; i < 512; i++) {
+            if (i === 0x105) continue;
+            this.writeReg(i, 0xff);
+            this.writeReg(i, 0x0);
+        }
+        this.writeReg(0x105, 0x0);
+        for (let i = 0; i < 255; i++) {
+            this.writeReg(i, 0xff);
+            this.writeReg(i, 0x0);
+        }
+    }
+}
+
+// ============ AudioWorklet Processor ============
+class OPL2Processor extends AudioWorkletProcessor {
+    constructor() {
+        super();
+        this.chip = new Chip();
+        this.chip.setup(sampleRate);
+        this.buf = new Int32Array(128);
+        this.port.onmessage = (e) => {
+            const msg = e.data;
+            if (msg.t === "w") this.chip.writeReg(msg.r, msg.v);
+        };
+    }
+
+    process(inputs, outputs) {
+        const outL = outputs[0][0];
+        if (!outL) return true;
+        const outR = outputs[0][1];
+        const len = outL.length;
+        if (!this.chip.opl3Active) {
+            if (this.buf.length < len) this.buf = new Int32Array(len);
+            this.chip.generateBlock2(len, this.buf);
+            for (let i = 0; i < len; i++) outL[i] = this.buf[i] / 32768;
+            // OPL2 is mono: copy left to right so both speakers get audio.
+            if (outR) for (let i = 0; i < len; i++) outR[i] = outL[i];
+        } else {
+            if (this.buf.length < len * 2) this.buf = new Int32Array(len * 2);
+            this.chip.generateBlock3(len, this.buf);
+            for (let i = 0; i < len; i++) {
+                outL[i] = this.buf[i * 2] / 32768;
+                if (outR) outR[i] = this.buf[i * 2 + 1] / 32768;
+            }
+        }
+        return true;
+    }
+}
+
+initTables();
+registerProcessor("opl2", OPL2Processor);

--- a/src/opl2-worklet.js
+++ b/src/opl2-worklet.js
@@ -2,7 +2,8 @@
  * DBOPL OPL2/OPL3 FM Synthesizer — JavaScript port of DOSBox DBOPL (GPL v2+)
  * DBOPL_WAVE = WAVE_TABLEMUL, no WAVE_PRECISION
  */
-"use strict";
+/* global sampleRate, registerProcessor, AudioWorkletProcessor */
+
 
 // ============ Constants ============
 const WAVE_BITS = 10;
@@ -57,24 +58,24 @@ const chanLookup = new Int8Array(32).fill(-1);
 const opLookup = new Array(64).fill(null);
 
 function envelopeSelect(val) {
-    if (val < 52) return [val & 3, 12 - (val >> 2)];
-    if (val < 60) return [val - 48, 0];
+    if(val < 52) return [val & 3, 12 - (val >> 2)];
+    if(val < 60) return [val - 48, 0];
     return [12, 0];
 }
 
 function initTables() {
-    for (let i = 0; i < 384; i++) {
+    for(let i = 0; i < 384; i++) {
         MulTable[i] = 0.5 + Math.pow(2, -1 + (255 - i * 8) / 256) * (1 << MUL_SH);
     }
-    for (let i = 0; i < 512; i++) {
+    for(let i = 0; i < 512; i++) {
         WaveTable[0x200 + i] = Math.trunc(Math.sin((i + 0.5) * Math.PI / 512) * 4084);
         WaveTable[0x000 + i] = -WaveTable[0x200 + i];
     }
-    for (let i = 0; i < 256; i++) {
+    for(let i = 0; i < 256; i++) {
         WaveTable[0x700 + i] = Math.trunc(0.5 + Math.pow(2, -1 + (255 - i * 8) / 256) * 4085);
         WaveTable[0x6ff - i] = -WaveTable[0x700 + i];
     }
-    for (let i = 0; i < 256; i++) {
+    for(let i = 0; i < 256; i++) {
         WaveTable[0x400 + i] = WaveTable[0];
         WaveTable[0x500 + i] = WaveTable[0];
         WaveTable[0x900 + i] = WaveTable[0];
@@ -86,29 +87,29 @@ function initTables() {
         WaveTable[0xe00 + i] = WaveTable[0x200 + i * 2];
         WaveTable[0xf00 + i] = WaveTable[0x200 + i * 2];
     }
-    for (let oct = 0; oct < 8; oct++) {
+    for(let oct = 0; oct < 8; oct++) {
         const base = oct * 8;
-        for (let i = 0; i < 16; i++) {
+        for(let i = 0; i < 16; i++) {
             let val = base - KslCreateTable[i];
-            if (val < 0) val = 0;
+            if(val < 0) val = 0;
             KslTable[oct * 16 + i] = val * 4;
         }
     }
-    for (let i = 0; i < (TREMOLO_TABLE >> 1); i++) {
+    for(let i = 0; i < (TREMOLO_TABLE >> 1); i++) {
         TremoloTable[i] = i << ENV_EXTRA;
         TremoloTable[TREMOLO_TABLE - 1 - i] = i << ENV_EXTRA;
     }
-    for (let i = 0; i < 32; i++) {
+    for(let i = 0; i < 32; i++) {
         let idx = i & 0xf;
-        if (idx >= 9) { chanLookup[i] = -1; continue; }
-        if (idx < 6) idx = (idx % 3) * 2 + ((idx / 3) | 0);
-        if (i >= 16) idx += 9;
+        if(idx >= 9) { chanLookup[i] = -1; continue; }
+        if(idx < 6) idx = (idx % 3) * 2 + ((idx / 3) | 0);
+        if(i >= 16) idx += 9;
         chanLookup[i] = idx;
     }
-    for (let i = 0; i < 64; i++) {
-        if (i % 8 >= 6 || ((i / 8 | 0) % 4 === 3)) { opLookup[i] = null; continue; }
+    for(let i = 0; i < 64; i++) {
+        if(i % 8 >= 6 || ((i / 8 | 0) % 4 === 3)) { opLookup[i] = null; continue; }
         let chNum = ((i / 8) | 0) * 3 + (i % 8) % 3;
-        if (chNum >= 12) chNum += 4;
+        if(chNum >= 12) chNum += 4;
         const opNum = ((i % 8) / 3) | 0;
         const chanIdx = chanLookup[chNum];
         opLookup[i] = chanIdx >= 0 ? [chanIdx, opNum] : null;
@@ -150,7 +151,7 @@ class Operator {
 
     updateAttack(chip) {
         const rate = this.reg60 >> 4;
-        if (rate) {
+        if(rate) {
             this.attackAdd = chip.attackRates[(rate << 2) + this.ksr];
             this.rateZero &= ~(1 << ATTACK);
         } else {
@@ -161,7 +162,7 @@ class Operator {
 
     updateDecay(chip) {
         const rate = this.reg60 & 0xf;
-        if (rate) {
+        if(rate) {
             this.decayAdd = chip.linearRates[(rate << 2) + this.ksr];
             this.rateZero &= ~(1 << DECAY);
         } else {
@@ -172,14 +173,14 @@ class Operator {
 
     updateRelease(chip) {
         const rate = this.reg80 & 0xf;
-        if (rate) {
+        if(rate) {
             this.releaseAdd = chip.linearRates[(rate << 2) + this.ksr];
             this.rateZero &= ~(1 << RELEASE);
-            if (!(this.reg20 & MASK_SUSTAIN)) this.rateZero &= ~(1 << SUSTAIN);
+            if(!(this.reg20 & MASK_SUSTAIN)) this.rateZero &= ~(1 << SUSTAIN);
         } else {
             this.releaseAdd = 0;
             this.rateZero |= 1 << RELEASE;
-            if (!(this.reg20 & MASK_SUSTAIN)) this.rateZero |= 1 << SUSTAIN;
+            if(!(this.reg20 & MASK_SUSTAIN)) this.rateZero |= 1 << SUSTAIN;
         }
     }
 
@@ -195,7 +196,7 @@ class Operator {
         const freq = this.chanData & 0x3ff;
         const block = (this.chanData >> 10) & 0xff;
         this.waveAdd = ((freq << block) * this.freqMul) >>> 0;
-        if (this.reg20 & MASK_VIBRATO) {
+        if(this.reg20 & MASK_VIBRATO) {
             this.vibStrength = (freq >> 7) & 0xff;
             this.vibrato = ((this.vibStrength << block) * this.freqMul) >>> 0;
         } else {
@@ -206,8 +207,8 @@ class Operator {
 
     updateRates(chip) {
         let newKsr = (this.chanData >>> SHIFT_KEYCODE) & 0xff;
-        if (!(this.reg20 & MASK_KSR)) newKsr >>= 2;
-        if (this.ksr === newKsr) return;
+        if(!(this.reg20 & MASK_KSR)) newKsr >>= 2;
+        if(this.ksr === newKsr) return;
         this.ksr = newKsr;
         this.updateAttack(chip);
         this.updateDecay(chip);
@@ -223,13 +224,13 @@ class Operator {
 
     templateVolume() {
         let vol = this.volume;
-        switch (this.state) {
+        switch(this.state) {
             case OFF: return ENV_MAX;
             case ATTACK: {
                 const change = this.rateForward(this.attackAdd);
-                if (!change) return vol;
+                if(!change) return vol;
                 vol += ((~vol) * change) >> 3;
-                if (vol < 0) {
+                if(vol < 0) {
                     this.volume = 0;
                     this.rateIndex = 0;
                     this.state = DECAY;
@@ -239,8 +240,8 @@ class Operator {
             }
             case DECAY:
                 vol += this.rateForward(this.decayAdd);
-                if (vol >= this.sustainLevel) {
-                    if (vol >= ENV_MAX) {
+                if(vol >= this.sustainLevel) {
+                    if(vol >= ENV_MAX) {
                         this.volume = ENV_MAX;
                         this.state = OFF;
                         return ENV_MAX;
@@ -250,11 +251,11 @@ class Operator {
                 }
                 break;
             case SUSTAIN:
-                if (this.reg20 & MASK_SUSTAIN) return vol;
+                if(this.reg20 & MASK_SUSTAIN) return vol;
                 // fall through to release
             case RELEASE:
                 vol += this.rateForward(this.releaseAdd);
-                if (vol >= ENV_MAX) {
+                if(vol >= ENV_MAX) {
                     this.volume = ENV_MAX;
                     this.state = OFF;
                     return ENV_MAX;
@@ -280,7 +281,7 @@ class Operator {
 
     getSample(modulation) {
         const vol = this.forwardVolume();
-        if (vol >= ENV_LIMIT) {
+        if(vol >= ENV_LIMIT) {
             this.waveIndex = (this.waveIndex + this.waveCurrent) >>> 0;
             return 0;
         }
@@ -289,15 +290,15 @@ class Operator {
     }
 
     silent() {
-        if (this.totalLevel + this.volume < ENV_LIMIT) return false;
-        if (!(this.rateZero & (1 << this.state))) return false;
+        if(this.totalLevel + this.volume < ENV_LIMIT) return false;
+        if(!(this.rateZero & (1 << this.state))) return false;
         return true;
     }
 
     prepare(chip) {
         this.currentLevel = this.totalLevel + (chip.tremoloValue & this.tremoloMask);
         this.waveCurrent = this.waveAdd;
-        if ((this.vibStrength >>> chip.vibratoShift) !== 0) {
+        if((this.vibStrength >>> chip.vibratoShift) !== 0) {
             let add = (this.vibrato >>> chip.vibratoShift) | 0;
             const neg = chip.vibratoSign;
             add = (add ^ neg) - neg;
@@ -306,7 +307,7 @@ class Operator {
     }
 
     keyOnAction(mask) {
-        if (!this.keyOn) {
+        if(!this.keyOn) {
             this.waveIndex = this.waveStart;
             this.rateIndex = 0;
             this.state = ATTACK;
@@ -316,31 +317,31 @@ class Operator {
 
     keyOffAction(mask) {
         this.keyOn &= ~mask;
-        if (!this.keyOn && this.state !== OFF) {
+        if(!this.keyOn && this.state !== OFF) {
             this.state = RELEASE;
         }
     }
 
     write20(chip, val) {
         const change = this.reg20 ^ val;
-        if (!change) return;
+        if(!change) return;
         this.reg20 = val;
         this.tremoloMask = (val << 24) >> 31;
         this.tremoloMask &= ~((1 << ENV_EXTRA) - 1);
-        if (change & MASK_KSR) this.updateRates(chip);
-        if ((this.reg20 & MASK_SUSTAIN) || !this.releaseAdd) {
+        if(change & MASK_KSR) this.updateRates(chip);
+        if((this.reg20 & MASK_SUSTAIN) || !this.releaseAdd) {
             this.rateZero |= 1 << SUSTAIN;
         } else {
             this.rateZero &= ~(1 << SUSTAIN);
         }
-        if (change & (0xf | MASK_VIBRATO)) {
+        if(change & (0xf | MASK_VIBRATO)) {
             this.freqMul = chip.freqMul[val & 0xf];
             this.updateFrequency();
         }
     }
 
     write40(chip, val) {
-        if (this.reg40 === val) return;
+        if(this.reg40 === val) return;
         this.reg40 = val;
         this.updateAttenuation();
     }
@@ -348,22 +349,22 @@ class Operator {
     write60(chip, val) {
         const change = this.reg60 ^ val;
         this.reg60 = val;
-        if (change & 0x0f) this.updateDecay(chip);
-        if (change & 0xf0) this.updateAttack(chip);
+        if(change & 0x0f) this.updateDecay(chip);
+        if(change & 0xf0) this.updateAttack(chip);
     }
 
     write80(chip, val) {
         const change = this.reg80 ^ val;
-        if (!change) return;
+        if(!change) return;
         this.reg80 = val;
         let sustain = val >> 4;
         sustain |= (sustain + 1) & 0x10;
         this.sustainLevel = sustain << (ENV_BITS - 5);
-        if (change & 0x0f) this.updateRelease(chip);
+        if(change & 0x0f) this.updateRelease(chip);
     }
 
     writeE0(chip, val) {
-        if (this.regE0 === val) return;
+        if(this.regE0 === val) return;
         const waveForm = val & ((0x3 & chip.waveFormMask) | (0x7 & chip.opl3Active));
         this.regE0 = val;
         this.waveBaseIdx = WaveBaseTable[waveForm];
@@ -400,11 +401,11 @@ class Channel {
         this.op[1].chanData = data;
         this.op[0].updateFrequency();
         this.op[1].updateFrequency();
-        if (change & (0xff << SHIFT_KSLBASE)) {
+        if(change & (0xff << SHIFT_KSLBASE)) {
             this.op[0].updateAttenuation();
             this.op[1].updateAttenuation();
         }
-        if (change & (0xff << SHIFT_KEYCODE)) {
+        if(change & (0xff << SHIFT_KEYCODE)) {
             this.op[0].updateRates(chip);
             this.op[1].updateRates(chip);
         }
@@ -414,23 +415,23 @@ class Channel {
         let data = this.chanData & 0xffff;
         const kslBase = KslTable[data >> 6];
         let keyCode = (data & 0x1c00) >> 9;
-        if (chip.reg08 & 0x40) {
+        if(chip.reg08 & 0x40) {
             keyCode |= (data & 0x100) >> 8;
         } else {
             keyCode |= (data & 0x200) >> 9;
         }
         data |= (keyCode << SHIFT_KEYCODE) | (kslBase << SHIFT_KSLBASE);
         this.setChanData(chip, data);
-        if (fourOp & 0x3f) {
+        if(fourOp & 0x3f) {
             this.chip.chan[this.index + 1].setChanData(chip, data);
         }
     }
 
     writeA0(chip, val) {
         const fourOp = chip.reg104 & chip.opl3Active & this.fourMask;
-        if (fourOp > 0x80) return;
+        if(fourOp > 0x80) return;
         const change = (this.chanData ^ val) & 0xff;
-        if (change) {
+        if(change) {
             this.chanData ^= change;
             this.updateFrequency(chip, fourOp);
         }
@@ -438,25 +439,25 @@ class Channel {
 
     writeB0(chip, val) {
         const fourOp = chip.reg104 & chip.opl3Active & this.fourMask;
-        if (fourOp > 0x80) return;
+        if(fourOp > 0x80) return;
         const change = (this.chanData ^ (val << 8)) & 0x1f00;
-        if (change) {
+        if(change) {
             this.chanData ^= change;
             this.updateFrequency(chip, fourOp);
         }
-        if (!((val ^ this.regB0) & 0x20)) return;
+        if(!((val ^ this.regB0) & 0x20)) return;
         this.regB0 = val;
-        if (val & 0x20) {
+        if(val & 0x20) {
             this.op[0].keyOnAction(0x1);
             this.op[1].keyOnAction(0x1);
-            if (fourOp & 0x3f) {
+            if(fourOp & 0x3f) {
                 this.chip.chan[this.index + 1].op[0].keyOnAction(1);
                 this.chip.chan[this.index + 1].op[1].keyOnAction(1);
             }
         } else {
             this.op[0].keyOffAction(0x1);
             this.op[1].keyOffAction(0x1);
-            if (fourOp & 0x3f) {
+            if(fourOp & 0x3f) {
                 this.chip.chan[this.index + 1].op[0].keyOffAction(1);
                 this.chip.chan[this.index + 1].op[1].keyOffAction(1);
             }
@@ -464,7 +465,7 @@ class Channel {
     }
 
     writeC0(chip, val) {
-        if (!(val ^ this.regC0)) return;
+        if(!(val ^ this.regC0)) return;
         this.regC0 = val;
         this.feedback = (this.regC0 >> 1) & 7;
         this.feedback = this.feedback ? 9 - this.feedback : 31;
@@ -472,10 +473,10 @@ class Channel {
     }
 
     updateSynth(chip) {
-        if (chip.opl3Active) {
-            if ((chip.reg104 & this.fourMask) & 0x3f) {
+        if(chip.opl3Active) {
+            if((chip.reg104 & this.fourMask) & 0x3f) {
                 let chan0, chan1;
-                if (!(this.fourMask & 0x80)) {
+                if(!(this.fourMask & 0x80)) {
                     chan0 = this;
                     chan1 = chip.chan[this.index + 1];
                 } else {
@@ -483,15 +484,15 @@ class Channel {
                     chan1 = this;
                 }
                 const synth = ((chan0.regC0 & 1) << 0) | ((chan1.regC0 & 1) << 1);
-                switch (synth) {
+                switch(synth) {
                 case 0: chan0.synthMode = sm3FMFM; break;
                 case 1: chan0.synthMode = sm3AMFM; break;
                 case 2: chan0.synthMode = sm3FMAM; break;
                 case 3: chan0.synthMode = sm3AMAM; break;
                 }
-            } else if ((this.fourMask & 0x40) && (chip.regBD & 0x20)) {
+            } else if((this.fourMask & 0x40) && (chip.regBD & 0x20)) {
                 // Percussion - don't update
-            } else if (this.regC0 & 1) {
+            } else if(this.regC0 & 1) {
                 this.synthMode = sm3AM;
             } else {
                 this.synthMode = sm3FM;
@@ -499,9 +500,9 @@ class Channel {
             this.maskLeft = (this.regC0 & 0x10) ? -1 : 0;
             this.maskRight = (this.regC0 & 0x20) ? -1 : 0;
         } else {
-            if ((this.fourMask & 0x40) && (chip.regBD & 0x20)) {
+            if((this.fourMask & 0x40) && (chip.regBD & 0x20)) {
                 // Percussion - don't update
-            } else if (this.regC0 & 1) {
+            } else if(this.regC0 & 1) {
                 this.synthMode = sm2AM;
             } else {
                 this.synthMode = sm2FM;
@@ -514,7 +515,7 @@ class Channel {
         this.old[0] = this.old[1];
         this.old[1] = this.Op(0).getSample(mod);
 
-        if (this.regC0 & 1) { mod = 0; } else { mod = this.old[0]; }
+        if(this.regC0 & 1) { mod = 0; } else { mod = this.old[0]; }
         let sample = this.Op(1).getSample(mod);
 
         const noiseBit = chip.forwardNoise() & 0x1;
@@ -523,21 +524,21 @@ class Channel {
         const phaseBit = (((c2 & 0x88) ^ ((c2 << 5) & 0x80)) | ((c5 ^ (c5 << 2)) & 0x20)) ? 0x02 : 0x00;
 
         const hhVol = this.Op(2).forwardVolume();
-        if (hhVol < ENV_LIMIT) {
+        if(hhVol < ENV_LIMIT) {
             sample += this.Op(2).getWave((phaseBit << 8) | (0x34 << (phaseBit ^ (noiseBit << 1))), hhVol);
         }
         const sdVol = this.Op(3).forwardVolume();
-        if (sdVol < ENV_LIMIT) {
+        if(sdVol < ENV_LIMIT) {
             sample += this.Op(3).getWave((0x100 + (c2 & 0x100)) ^ (noiseBit << 8), sdVol);
         }
         sample += this.Op(4).getSample(0);
         const tcVol = this.Op(5).forwardVolume();
-        if (tcVol < ENV_LIMIT) {
+        if(tcVol < ENV_LIMIT) {
             sample += this.Op(5).getWave((1 + phaseBit) << 8, tcVol);
         }
 
         sample <<= 1;
-        if (opl3Mode) {
+        if(opl3Mode) {
             output[outIdx] += sample;
             output[outIdx + 1] += sample;
         } else {
@@ -547,41 +548,41 @@ class Channel {
 
     blockTemplate(chip, samples, output, outIdx) {
         const mode = this.synthMode;
-        switch (mode) {
+        switch(mode) {
         case sm2AM:
         case sm3AM:
-            if (this.Op(0).silent() && this.Op(1).silent()) {
+            if(this.Op(0).silent() && this.Op(1).silent()) {
                 this.old[0] = this.old[1] = 0;
                 return this.index + 1;
             }
             break;
         case sm2FM:
         case sm3FM:
-            if (this.Op(1).silent()) {
+            if(this.Op(1).silent()) {
                 this.old[0] = this.old[1] = 0;
                 return this.index + 1;
             }
             break;
         case sm3FMFM:
-            if (this.Op(3).silent()) {
+            if(this.Op(3).silent()) {
                 this.old[0] = this.old[1] = 0;
                 return this.index + 2;
             }
             break;
         case sm3AMFM:
-            if (this.Op(0).silent() && this.Op(3).silent()) {
+            if(this.Op(0).silent() && this.Op(3).silent()) {
                 this.old[0] = this.old[1] = 0;
                 return this.index + 2;
             }
             break;
         case sm3FMAM:
-            if (this.Op(1).silent() && this.Op(3).silent()) {
+            if(this.Op(1).silent() && this.Op(3).silent()) {
                 this.old[0] = this.old[1] = 0;
                 return this.index + 2;
             }
             break;
         case sm3AMAM:
-            if (this.Op(0).silent() && this.Op(2).silent() && this.Op(3).silent()) {
+            if(this.Op(0).silent() && this.Op(2).silent() && this.Op(3).silent()) {
                 this.old[0] = this.old[1] = 0;
                 return this.index + 2;
             }
@@ -590,20 +591,20 @@ class Channel {
 
         this.Op(0).prepare(chip);
         this.Op(1).prepare(chip);
-        if (mode > sm4Start) {
+        if(mode > sm4Start) {
             this.Op(2).prepare(chip);
             this.Op(3).prepare(chip);
         }
-        if (mode > sm6Start) {
+        if(mode > sm6Start) {
             this.Op(4).prepare(chip);
             this.Op(5).prepare(chip);
         }
 
-        for (let i = 0; i < samples; i++) {
-            if (mode === sm2Percussion) {
+        for(let i = 0; i < samples; i++) {
+            if(mode === sm2Percussion) {
                 this.generatePercussion(chip, output, outIdx + i, false);
                 continue;
-            } else if (mode === sm3Percussion) {
+            } else if(mode === sm3Percussion) {
                 this.generatePercussion(chip, output, outIdx + i * 2, true);
                 continue;
             }
@@ -613,31 +614,31 @@ class Channel {
             let sample;
             const out0 = this.old[0];
 
-            if (mode === sm2AM || mode === sm3AM) {
+            if(mode === sm2AM || mode === sm3AM) {
                 sample = out0 + this.Op(1).getSample(0);
-            } else if (mode === sm2FM || mode === sm3FM) {
+            } else if(mode === sm2FM || mode === sm3FM) {
                 sample = this.Op(1).getSample(out0);
-            } else if (mode === sm3FMFM) {
+            } else if(mode === sm3FMFM) {
                 let next = this.Op(1).getSample(out0);
                 next = this.Op(2).getSample(next);
                 sample = this.Op(3).getSample(next);
-            } else if (mode === sm3AMFM) {
+            } else if(mode === sm3AMFM) {
                 sample = out0;
                 let next = this.Op(1).getSample(0);
                 next = this.Op(2).getSample(next);
                 sample += this.Op(3).getSample(next);
-            } else if (mode === sm3FMAM) {
+            } else if(mode === sm3FMAM) {
                 sample = this.Op(1).getSample(out0);
                 const next = this.Op(2).getSample(0);
                 sample += this.Op(3).getSample(next);
-            } else if (mode === sm3AMAM) {
+            } else if(mode === sm3AMAM) {
                 sample = out0;
                 const next = this.Op(1).getSample(0);
                 sample += this.Op(2).getSample(next);
                 sample += this.Op(3).getSample(0);
             }
 
-            switch (mode) {
+            switch(mode) {
             case sm2AM:
             case sm2FM:
                 output[outIdx + i] += sample;
@@ -654,7 +655,7 @@ class Channel {
             }
         }
 
-        switch (mode) {
+        switch(mode) {
         case sm2AM:
         case sm2FM:
         case sm3AM:
@@ -677,7 +678,7 @@ class Channel {
 class Chip {
     constructor() {
         this.chan = [];
-        for (let i = 0; i < 18; i++) this.chan[i] = new Channel(i, this);
+        for(let i = 0; i < 18; i++) this.chan[i] = new Channel(i, this);
 
         this.lfoCounter = 0;
         this.lfoAdd = 0;
@@ -708,7 +709,7 @@ class Chip {
         this.noiseCounter += this.noiseAdd;
         let count = this.noiseCounter >>> LFO_SH;
         this.noiseCounter &= WAVE_MASK;
-        for (; count > 0; --count) {
+        for(; count > 0; --count) {
             this.noiseValue ^= 0x800302 & (0 - (this.noiseValue & 1));
             this.noiseValue >>>= 1;
         }
@@ -722,14 +723,14 @@ class Chip {
 
         const todo = LFO_MAX - this.lfoCounter;
         let count = ((todo + this.lfoAdd - 1) / this.lfoAdd) | 0;
-        if (count > samples) {
+        if(count > samples) {
             count = samples;
             this.lfoCounter += count * this.lfoAdd;
         } else {
             this.lfoCounter += count * this.lfoAdd;
             this.lfoCounter &= LFO_MAX - 1;
             this.vibratoIndex = (this.vibratoIndex + 1) & 31;
-            if (this.tremoloIndex + 1 < TREMOLO_TABLE) ++this.tremoloIndex;
+            if(this.tremoloIndex + 1 < TREMOLO_TABLE) ++this.tremoloIndex;
             else this.tremoloIndex = 0;
         }
         return count;
@@ -737,30 +738,30 @@ class Chip {
 
     writeBD(val) {
         const change = this.regBD ^ val;
-        if (!change) return;
+        if(!change) return;
         this.regBD = val;
         this.vibratoStrength = (val & 0x40) ? 0x00 : 0x01;
         this.tremoloStrength = (val & 0x80) ? 0x00 : 0x02;
 
-        if (val & 0x20) {
-            if (change & 0x20) {
-                if (this.opl3Active) {
+        if(val & 0x20) {
+            if(change & 0x20) {
+                if(this.opl3Active) {
                     this.chan[6].synthMode = sm3Percussion;
                 } else {
                     this.chan[6].synthMode = sm2Percussion;
                 }
             }
-            if (val & 0x10) { this.chan[6].op[0].keyOnAction(0x2); this.chan[6].op[1].keyOnAction(0x2); }
+            if(val & 0x10) { this.chan[6].op[0].keyOnAction(0x2); this.chan[6].op[1].keyOnAction(0x2); }
             else { this.chan[6].op[0].keyOffAction(0x2); this.chan[6].op[1].keyOffAction(0x2); }
-            if (val & 0x01) this.chan[7].op[0].keyOnAction(0x2);
+            if(val & 0x01) this.chan[7].op[0].keyOnAction(0x2);
             else this.chan[7].op[0].keyOffAction(0x2);
-            if (val & 0x08) this.chan[7].op[1].keyOnAction(0x2);
+            if(val & 0x08) this.chan[7].op[1].keyOnAction(0x2);
             else this.chan[7].op[1].keyOffAction(0x2);
-            if (val & 0x04) this.chan[8].op[0].keyOnAction(0x2);
+            if(val & 0x04) this.chan[8].op[0].keyOnAction(0x2);
             else this.chan[8].op[0].keyOffAction(0x2);
-            if (val & 0x02) this.chan[8].op[1].keyOnAction(0x2);
+            if(val & 0x02) this.chan[8].op[1].keyOnAction(0x2);
             else this.chan[8].op[1].keyOffAction(0x2);
-        } else if (change & 0x20) {
+        } else if(change & 0x20) {
             this.chan[6].updateSynth(this);
             this.chan[6].op[0].keyOffAction(0x2);
             this.chan[6].op[1].keyOffAction(0x2);
@@ -772,78 +773,78 @@ class Chip {
     }
 
     updateSynths() {
-        for (let i = 0; i < 18; i++) this.chan[i].updateSynth(this);
+        for(let i = 0; i < 18; i++) this.chan[i].updateSynth(this);
     }
 
     writeReg(reg, val) {
-        switch ((reg & 0xf0) >> 4) {
+        switch((reg & 0xf0) >> 4) {
             case 0:
-                if (reg === 0x01) this.waveFormMask = (val & 0x20) ? 0x7 : 0x0;
-                else if (reg === 0x104) {
-                    if (!((this.reg104 ^ val) & 0x3f)) return;
+                if(reg === 0x01) this.waveFormMask = (val & 0x20) ? 0x7 : 0x0;
+                else if(reg === 0x104) {
+                    if(!((this.reg104 ^ val) & 0x3f)) return;
                     this.reg104 = 0x80 | (val & 0x3f);
                     this.updateSynths();
                 }
-                else if (reg === 0x105) {
-                    if (!((this.opl3Active ^ val) & 1)) return;
+                else if(reg === 0x105) {
+                    if(!((this.opl3Active ^ val) & 1)) return;
                     this.opl3Active = (val & 1) ? 0xff : 0;
                     this.updateSynths();
                 }
-                else if (reg === 0x08) this.reg08 = val;
+                else if(reg === 0x08) this.reg08 = val;
                 // fall through
             case 1: break;
             case 2: case 3: {
                 const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
-                if (e) this.chan[e[0]].op[e[1]].write20(this, val);
+                if(e) this.chan[e[0]].op[e[1]].write20(this, val);
                 break;
             }
             case 4: case 5: {
                 const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
-                if (e) this.chan[e[0]].op[e[1]].write40(this, val);
+                if(e) this.chan[e[0]].op[e[1]].write40(this, val);
                 break;
             }
             case 6: case 7: {
                 const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
-                if (e) this.chan[e[0]].op[e[1]].write60(this, val);
+                if(e) this.chan[e[0]].op[e[1]].write60(this, val);
                 break;
             }
             case 8: case 9: {
                 const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
-                if (e) this.chan[e[0]].op[e[1]].write80(this, val);
+                if(e) this.chan[e[0]].op[e[1]].write80(this, val);
                 break;
             }
             case 0xa: {
                 const ch = chanLookup[((reg >> 4) & 0x10) | (reg & 0xf)];
-                if (ch >= 0) this.chan[ch].writeA0(this, val);
+                if(ch >= 0) this.chan[ch].writeA0(this, val);
                 break;
             }
             case 0xb:
-                if (reg === 0xbd) this.writeBD(val);
+                if(reg === 0xbd) this.writeBD(val);
                 else {
                     const ch = chanLookup[((reg >> 4) & 0x10) | (reg & 0xf)];
-                    if (ch >= 0) this.chan[ch].writeB0(this, val);
+                    if(ch >= 0) this.chan[ch].writeB0(this, val);
                 }
                 break;
             case 0xc: {
                 const ch = chanLookup[((reg >> 4) & 0x10) | (reg & 0xf)];
-                if (ch >= 0) this.chan[ch].writeC0(this, val);
+                if(ch >= 0) this.chan[ch].writeC0(this, val);
                 break;
             }
             case 0xd: break;
             case 0xe: case 0xf: {
                 const e = opLookup[((reg >> 3) & 0x20) | (reg & 0x1f)];
-                if (e) this.chan[e[0]].op[e[1]].writeE0(this, val);
+                if(e) this.chan[e[0]].op[e[1]].writeE0(this, val);
                 break;
             }
         }
     }
 
     writeAddr(port, val) {
-        switch (port & 3) {
+        switch(port & 3) {
         case 0:
             return val;
         case 2:
-            if (this.opl3Active || (val === 0x05))
+            if(this.opl3Active || (val === 0x05))
                 return 0x100 | val;
             else
                 return val;
@@ -853,11 +854,11 @@ class Chip {
 
     generateBlock2(total, output) {
         let outIdx = 0;
-        while (total > 0) {
+        while(total > 0) {
             const samples = this.forwardLFO(total);
-            for (let i = outIdx; i < outIdx + samples; i++) output[i] = 0;
+            for(let i = outIdx; i < outIdx + samples; i++) output[i] = 0;
             let chIdx = 0;
-            while (chIdx < 9) {
+            while(chIdx < 9) {
                 chIdx = this.chan[chIdx].blockTemplate(this, samples, output, outIdx);
             }
             total -= samples;
@@ -867,11 +868,11 @@ class Chip {
 
     generateBlock3(total, output) {
         let outIdx = 0;
-        while (total > 0) {
+        while(total > 0) {
             const samples = this.forwardLFO(total);
-            for (let i = outIdx; i < outIdx + samples * 2; i++) output[i] = 0;
+            for(let i = outIdx; i < outIdx + samples * 2; i++) output[i] = 0;
             let chIdx = 0;
-            while (chIdx < 18) {
+            while(chIdx < 18) {
                 chIdx = this.chan[chIdx].blockTemplate(this, samples, output, outIdx);
             }
             total -= samples;
@@ -891,40 +892,40 @@ class Chip {
         this.tremoloIndex = 0;
 
         const freqScale = Math.round(scale * (1 << (WAVE_SH - 1 - 10)));
-        for (let i = 0; i < 16; i++) this.freqMul[i] = freqScale * FreqCreateTable[i];
+        for(let i = 0; i < 16; i++) this.freqMul[i] = freqScale * FreqCreateTable[i];
 
-        for (let i = 0; i < 76; i++) {
+        for(let i = 0; i < 76; i++) {
             const [index, shift] = envelopeSelect(i);
             this.linearRates[i] = Math.trunc(scale * (EnvelopeIncreaseTable[index] << (RATE_SH + ENV_EXTRA - shift - 3)));
         }
 
-        for (let i = 0; i < 62; i++) {
+        for(let i = 0; i < 62; i++) {
             const [index, shift] = envelopeSelect(i);
             const origSamples = Math.trunc((AttackSamplesTable[index] << shift) / scale);
             let guessAdd = Math.trunc(scale * (EnvelopeIncreaseTable[index] << (RATE_SH - shift - 3)));
             let bestAdd = guessAdd, bestDiff = 1 << 30;
-            for (let passes = 0; passes < 16; passes++) {
+            for(let passes = 0; passes < 16; passes++) {
                 let volume = ENV_MAX, samples = 0, count = 0;
-                while (volume > 0 && samples < origSamples * 2) {
+                while(volume > 0 && samples < origSamples * 2) {
                     count += guessAdd;
                     const change = count >> RATE_SH;
                     count &= RATE_MASK;
-                    if (change) volume += ((~volume) * change) >> 3;
+                    if(change) volume += ((~volume) * change) >> 3;
                     samples++;
                 }
                 const diff = origSamples - samples;
                 const lDiff = Math.abs(diff);
-                if (lDiff < bestDiff) {
+                if(lDiff < bestDiff) {
                     bestDiff = lDiff;
                     bestAdd = guessAdd;
-                    if (!bestDiff) break;
+                    if(!bestDiff) break;
                 }
                 guessAdd = Math.trunc(guessAdd * ((origSamples - diff) / origSamples));
-                if (diff < 0) guessAdd++;
+                if(diff < 0) guessAdd++;
             }
             this.attackRates[i] = bestAdd;
         }
-        for (let i = 62; i < 76; i++) this.attackRates[i] = 8 << RATE_SH;
+        for(let i = 62; i < 76; i++) this.attackRates[i] = 8 << RATE_SH;
 
         this.chan[0].fourMask = 0x00 | (1 << 0);
         this.chan[1].fourMask = 0x80 | (1 << 0);
@@ -943,13 +944,13 @@ class Chip {
         this.chan[8].fourMask = 0x40;
 
         this.writeReg(0x105, 0x1);
-        for (let i = 0; i < 512; i++) {
-            if (i === 0x105) continue;
+        for(let i = 0; i < 512; i++) {
+            if(i === 0x105) continue;
             this.writeReg(i, 0xff);
             this.writeReg(i, 0x0);
         }
         this.writeReg(0x105, 0x0);
-        for (let i = 0; i < 255; i++) {
+        for(let i = 0; i < 255; i++) {
             this.writeReg(i, 0xff);
             this.writeReg(i, 0x0);
         }
@@ -965,27 +966,27 @@ class OPL2Processor extends AudioWorkletProcessor {
         this.buf = new Int32Array(128);
         this.port.onmessage = (e) => {
             const msg = e.data;
-            if (msg.t === "w") this.chip.writeReg(msg.r, msg.v);
+            if(msg.t === "w") this.chip.writeReg(msg.r, msg.v);
         };
     }
 
     process(inputs, outputs) {
         const outL = outputs[0][0];
-        if (!outL) return true;
+        if(!outL) return true;
         const outR = outputs[0][1];
         const len = outL.length;
-        if (!this.chip.opl3Active) {
-            if (this.buf.length < len) this.buf = new Int32Array(len);
+        if(!this.chip.opl3Active) {
+            if(this.buf.length < len) this.buf = new Int32Array(len);
             this.chip.generateBlock2(len, this.buf);
-            for (let i = 0; i < len; i++) outL[i] = this.buf[i] / 32768;
+            for(let i = 0; i < len; i++) outL[i] = this.buf[i] / 32768;
             // OPL2 is mono: copy left to right so both speakers get audio.
-            if (outR) for (let i = 0; i < len; i++) outR[i] = outL[i];
+            if(outR) for(let i = 0; i < len; i++) outR[i] = outL[i];
         } else {
-            if (this.buf.length < len * 2) this.buf = new Int32Array(len * 2);
+            if(this.buf.length < len * 2) this.buf = new Int32Array(len * 2);
             this.chip.generateBlock3(len, this.buf);
-            for (let i = 0; i < len; i++) {
+            for(let i = 0; i < len; i++) {
                 outL[i] = this.buf[i * 2] / 32768;
-                if (outR) outR[i] = this.buf[i * 2 + 1] / 32768;
+                if(outR) outR[i] = this.buf[i * 2 + 1] / 32768;
             }
         }
         return true;

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1,7 +1,7 @@
 import {
     LOG_SB16,
     MIXER_CHANNEL_BOTH, MIXER_CHANNEL_LEFT, MIXER_CHANNEL_RIGHT,
-    MIXER_SRC_PCSPEAKER, MIXER_SRC_DAC, MIXER_SRC_MASTER,
+    MIXER_SRC_PCSPEAKER, MIXER_SRC_DAC, MIXER_SRC_MASTER, MIXER_SRC_OPL,
 } from "./const.js";
 import { h } from "./lib.js";
 import { dbg_log } from "./log.js";
@@ -88,6 +88,49 @@ const
     SB_IRQ_MIDI = 0x1,
     SB_IRQ_MPU = 0x4;
 
+// Creative ADPCM lookup tables
+// ADPCM 4-bit (nybble compressed): each byte → 2 output samples
+const ADPCM4_SCALE_MAP = new Int8Array([
+     0,  1,  2,  3,  4,  5,  6,  7,  0, -1, -2, -3, -4, -5, -6, -7,
+     1,  3,  5,  7,  9, 11, 13, 15, -1, -3, -5, -7, -9,-11,-13,-15,
+     2,  6, 10, 14, 18, 22, 26, 30, -2, -6,-10,-14,-18,-22,-26,-30,
+     4, 12, 20, 28, 36, 44, 52, 60, -4,-12,-20,-28,-36,-44,-52,-60
+]);
+const ADPCM4_ADJUST_MAP = new Uint8Array([
+      0,  0,  0,  0,  0, 16, 16, 16,   0,  0,  0,  0,  0, 16, 16, 16,
+    240,  0,  0,  0,  0, 16, 16, 16, 240,  0,  0,  0,  0, 16, 16, 16,
+    240,  0,  0,  0,  0, 16, 16, 16, 240,  0,  0,  0,  0, 16, 16, 16,
+    240,  0,  0,  0,  0,  0,  0,  0, 240,  0,  0,  0,  0,  0,  0,  0
+]);
+
+// ADPCM 2-bit (pairs packed 4 per byte): each byte → 4 output samples
+const ADPCM2_SCALE_MAP = new Int8Array([
+     0,  1,  0, -1,  1,  3, -1, -3,
+     2,  6, -2, -6,  4, 12, -4,-12,
+     8, 24, -8,-24,  6, 48,-16,-48
+]);
+const ADPCM2_ADJUST_MAP = new Uint8Array([
+      0,  4,   0,  4,
+    252,  4, 252,  4, 252,  4, 252,  4,
+    252,  4, 252,  4, 252,  4, 252,  4,
+    252,  0, 252,  0
+]);
+
+// ADPCM 3-bit (packed 3 per byte, 2.6-bit resolution): each byte → 3 output samples
+const ADPCM3_SCALE_MAP = new Int8Array([
+     0,  1,  2,  3,  0, -1, -2, -3,
+     1,  3,  5,  7, -1, -3, -5, -7,
+     2,  6, 10, 14, -2, -6,-10,-14,
+     4, 12, 20, 28, -4,-12,-20,-28,
+     5, 15, 25, 35, -5,-15,-25,-35
+]);
+const ADPCM3_ADJUST_MAP = new Uint8Array([
+      0,  0,  0,  8,   0,  0,  0,  8,
+    248,  0,  0,  8, 248,  0,  0,  8,
+    248,  0,  0,  8, 248,  0,  0,  8,
+    248,  0,  0,  8, 248,  0,  0,  8,
+    248,  0,  0,  0, 248,  0,  0,  0
+]);
 
 // Probably less efficient, but it's more maintainable, instead
 // of having a single large unorganised and decoupled table.
@@ -180,11 +223,26 @@ export function SB16(cpu, bus)
     // MPU.
     this.mpu_read_buffer = new ByteQueue(DSP_BUFSIZE);
     this.mpu_read_buffer_lastvalue = 0;
+    // MPU-401 mode: 0=intelligent, 1=UART
+    this.mpu_uart_mode = false;
+
+    // Creative ADPCM decoder state.
+    // dma_transfer_type: 0=PCM, 2=ADPCM-2bit, 3=ADPCM-3bit, 4=ADPCM-4bit
+    this.dma_transfer_type = 0;
+    this.adpcm_reference = 0;
+    this.adpcm_stepsize = 0;
+    this.adpcm_haveref = false;
 
     // FM Synthesizer.
     this.fm_current_address0 = 0;
     this.fm_current_address1 = 0;
-    this.fm_waveform_select_enable = false;
+    this.fm_waveform_select_enable = [false, false];
+
+    // OPL Timer state (needed for OPL detection).
+    this.fm_timer1_expired = false;
+    this.fm_timer2_expired = false;
+    this.fm_timer1_counter = -1;
+    this.fm_timer2_counter = -1;
 
     // Interrupts.
     this.irq = SB_IRQ;
@@ -293,6 +351,11 @@ SB16.prototype.dsp_reset = function()
 
     this.sampling_rate = 22050;
     this.bytes_per_sample = 1;
+
+    this.dma_transfer_type = 0;
+    this.adpcm_reference = 0;
+    this.adpcm_stepsize = 0;
+    this.adpcm_haveref = false;
 
     this.lower_irq(SB_IRQ_8BIT);
     this.irq_triggered.fill(0);
@@ -430,8 +493,23 @@ SB16.prototype.set_state = function(state)
 
 SB16.prototype.port2x0_read = function()
 {
-    dbg_log("220 read: fm music status port (unimplemented)", LOG_SB16);
-    return 0xFF;
+    dbg_log("220 read: fm music status port", LOG_SB16);
+    // Decrement timer counters on each status read
+    if(this.fm_timer1_counter > 0)
+    {
+        this.fm_timer1_counter--;
+        if(this.fm_timer1_counter === 0) this.fm_timer1_expired = true;
+    }
+    if(this.fm_timer2_counter > 0)
+    {
+        this.fm_timer2_counter--;
+        if(this.fm_timer2_counter === 0) this.fm_timer2_expired = true;
+    }
+    // OPL status register: bit 7 = IRQ, bit 6 = Timer 1, bit 5 = Timer 2
+    var status = 0;
+    if(this.fm_timer1_expired) status |= 0xC0;
+    if(this.fm_timer2_expired) status |= 0xA0;
+    return status;
 };
 
 SB16.prototype.port2x1_read = function()
@@ -550,8 +628,8 @@ SB16.prototype.port2xF_read = function()
 // FM Address Port - primary register.
 SB16.prototype.port2x0_write = function(value)
 {
-    dbg_log("220 write: (unimplemented) fm register 0 address = " + h(value), LOG_SB16);
-    this.fm_current_address0 = 0;
+    dbg_log("220 write: fm register 0 address = " + h(value), LOG_SB16);
+    this.fm_current_address0 = value;
 };
 
 // FM Data Port - primary register.
@@ -569,8 +647,8 @@ SB16.prototype.port2x1_write = function(value)
 // FM Address Port - secondary register.
 SB16.prototype.port2x2_write = function(value)
 {
-    dbg_log("222 write: (unimplemented) fm register 1 address = " + h(value), LOG_SB16);
-    this.fm_current_address1 = 0;
+    dbg_log("222 write: fm register 1 address = " + h(value), LOG_SB16);
+    this.fm_current_address1 = value;
 };
 
 // FM Data Port - secondary register.
@@ -705,7 +783,8 @@ SB16.prototype.port3x0_read = function()
 };
 SB16.prototype.port3x0_write = function(value)
 {
-    dbg_log("330 write: mpu data (unimplemented) : " + h(value), LOG_SB16);
+    dbg_log("330 write: mpu data " + h(value), LOG_SB16);
+    // MIDI data discarded (no external MIDI output supported).
 };
 
 // MPU UART Mode - Status Port
@@ -713,10 +792,11 @@ SB16.prototype.port3x1_read = function()
 {
     dbg_log("331 read: mpu status", LOG_SB16);
 
-    var status = 0;
-    status |= 0x40 * 0; // Output Ready
-    status |= 0x80 * !this.mpu_read_buffer.length; // Input Ready
-
+    // Bits 0-5 always set per hardware spec.
+    // Bit 6: 0 = output ready, 1 = not ready.
+    // Bit 7: 0 = input data available, 1 = no data.
+    var status = 0x3F;
+    status |= 0x80 * !this.mpu_read_buffer.length;
     return status;
 };
 
@@ -726,8 +806,20 @@ SB16.prototype.port3x1_write = function(value)
     dbg_log("331 write: mpu command: " + h(value), LOG_SB16);
     if(value === 0xFF)
     {
-        // Command acknowledge.
+        // Reset: clear buffer, send ACK.
         this.mpu_read_buffer.clear();
+        this.mpu_uart_mode = false;
+        this.mpu_read_buffer.push(0xFE);
+    }
+    else if(value === 0x3F)
+    {
+        // Switch to UART mode (most programs use this).
+        this.mpu_uart_mode = true;
+        this.mpu_read_buffer.push(0xFE);
+    }
+    else
+    {
+        // Send ACK for any other command to avoid hanging programs.
         this.mpu_read_buffer.push(0xFE);
     }
 };
@@ -816,16 +908,39 @@ register_dsp_command([0x14, 0x15], 2, function()
     this.dsp_signed = false;
     this.dsp_16bit = false;
     this.dsp_highspeed = false;
+    this.dma_transfer_type = 0;
     this.dma_transfer_size_set();
     this.dma_transfer_start();
 });
 
 // Creative 8-bit to 2-bit ADPCM single-cycle DMA mode digitized sound output.
-register_dsp_command([0x16], 2);
+register_dsp_command([0x16], 2, function()
+{
+    this.adpcm_haveref = false;
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = false;
+    this.dsp_signed = false;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 2;
+    this.dma_transfer_size_set();
+    this.dma_transfer_start();
+});
 
-// Creative 8-bit to 2-bit ADPCM single-cycle DMA mode digitzed sound output
+// Creative 8-bit to 2-bit ADPCM single-cycle DMA mode digitized sound output
 // with reference byte.
-register_dsp_command([0x17], 2);
+register_dsp_command([0x17], 2, function()
+{
+    this.adpcm_haveref = true;
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = false;
+    this.dsp_signed = false;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 2;
+    this.dma_transfer_size_set();
+    this.dma_transfer_start();
+});
 
 // 8-bit auto-init DMA mode digitized sound output.
 register_dsp_command([0x1C], 0, function()
@@ -836,12 +951,23 @@ register_dsp_command([0x1C], 0, function()
     this.dsp_signed = false;
     this.dsp_16bit = false;
     this.dsp_highspeed = false;
+    this.dma_transfer_type = 0;
     this.dma_transfer_start();
 });
 
 // Creative 8-bit to 2-bit ADPCM auto-init DMA mode digitized sound output
 // with reference byte.
-register_dsp_command([0x1F], 0);
+register_dsp_command([0x1F], 0, function()
+{
+    this.adpcm_haveref = true;
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = true;
+    this.dsp_signed = false;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 2;
+    this.dma_transfer_start();
+});
 
 // 8-bit direct mode single byte digitized sound input.
 register_dsp_command([0x20], 0, function()
@@ -905,26 +1031,90 @@ register_dsp_command([0x48], 2, function()
 });
 
 // Creative 8-bit to 4-bit ADPCM single-cycle DMA mode digitized sound output.
-register_dsp_command([0x74], 2);
+register_dsp_command([0x74], 2, function()
+{
+    this.adpcm_haveref = false;
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = false;
+    this.dsp_signed = false;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 4;
+    this.dma_transfer_size_set();
+    this.dma_transfer_start();
+});
 
 // Creative 8-bit to 4-bit ADPCM single-cycle DMA mode digitized sound output
-// with referene byte.
-register_dsp_command([0x75], 2);
+// with reference byte.
+register_dsp_command([0x75], 2, function()
+{
+    this.adpcm_haveref = true;
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = false;
+    this.dsp_signed = false;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 4;
+    this.dma_transfer_size_set();
+    this.dma_transfer_start();
+});
 
 // Creative 8-bit to 3-bit ADPCM single-cycle DMA mode digitized sound output.
-register_dsp_command([0x76], 2);
+register_dsp_command([0x76], 2, function()
+{
+    this.adpcm_haveref = false;
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = false;
+    this.dsp_signed = false;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 3;
+    this.dma_transfer_size_set();
+    this.dma_transfer_start();
+});
 
 // Creative 8-bit to 3-bit ADPCM single-cycle DMA mode digitized sound output
-// with referene byte.
-register_dsp_command([0x77], 2);
+// with reference byte.
+register_dsp_command([0x77], 2, function()
+{
+    this.adpcm_haveref = true;
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = false;
+    this.dsp_signed = false;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 3;
+    this.dma_transfer_size_set();
+    this.dma_transfer_start();
+});
 
 // Creative 8-bit to 4-bit ADPCM auto-init DMA mode digitized sound output
 // with reference byte.
-register_dsp_command([0x7D], 0);
+register_dsp_command([0x7D], 0, function()
+{
+    this.adpcm_haveref = true;
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = true;
+    this.dsp_signed = false;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 4;
+    this.dma_transfer_start();
+});
 
 // Creative 8-bit to 3-bit ADPCM auto-init DMA mode digitized sound output
 // with reference byte.
-register_dsp_command([0x7F], 0);
+register_dsp_command([0x7F], 0, function()
+{
+    this.adpcm_haveref = true;
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = true;
+    this.dsp_signed = false;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 3;
+    this.dma_transfer_start();
+});
 
 // Pause DAC for a duration.
 register_dsp_command([0x80], 2);
@@ -938,6 +1128,7 @@ register_dsp_command([0x90], 0, function()
     this.dsp_signed = false;
     this.dsp_highspeed = true;
     this.dsp_16bit = false;
+    this.dma_transfer_type = 0;
     this.dma_transfer_start();
 });
 
@@ -1171,12 +1362,12 @@ SB16.prototype.mixer_reset = function()
     this.mixer_registers[0x28] = 0;
     this.mixer_registers[0x2E] = 0;
     this.mixer_registers[0x0A] = 0;
-    this.mixer_registers[0x30] = 24 << 3;
-    this.mixer_registers[0x31] = 24 << 3;
-    this.mixer_registers[0x32] = 24 << 3;
-    this.mixer_registers[0x33] = 24 << 3;
-    this.mixer_registers[0x34] = 24 << 3;
-    this.mixer_registers[0x35] = 24 << 3;
+    this.mixer_registers[0x30] = 31 << 3;
+    this.mixer_registers[0x31] = 31 << 3;
+    this.mixer_registers[0x32] = 31 << 3;
+    this.mixer_registers[0x33] = 31 << 3;
+    this.mixer_registers[0x34] = 31 << 3;
+    this.mixer_registers[0x35] = 31 << 3;
     this.mixer_registers[0x36] = 0;
     this.mixer_registers[0x37] = 0;
     this.mixer_registers[0x38] = 0;
@@ -1279,11 +1470,15 @@ function register_mixer_volume(address, mixer_source, channel)
     MIXER_WRITE_HANDLERS[address] = function(data)
     {
         this.mixer_registers[address] = data;
+        // Volume formula: amount = data>>3, count = 31-amount, db = count*2 - (count>20?1:0)
+        var amount = data >>> 3;
+        var count = 31 - amount;
+        var db = count * 2 - (count > 20 ? 1 : 0);
         this.bus.send("mixer-volume",
         [
             mixer_source,
             channel,
-            (data >>> 2) - 62
+            -db
         ]);
     };
 }
@@ -1325,10 +1520,10 @@ register_mixer_volume(0x31, MIXER_SRC_MASTER, MIXER_CHANNEL_RIGHT);
 register_mixer_volume(0x32, MIXER_SRC_DAC, MIXER_CHANNEL_LEFT);
 // Voice Volume Right.
 register_mixer_volume(0x33, MIXER_SRC_DAC, MIXER_CHANNEL_RIGHT);
-// MIDI Volume Left. TODO.
-//register_mixer_volume(0x34, MIXER_SRC_SYNTH, MIXER_CHANNEL_LEFT);
-// MIDI Volume Right. TODO.
-//register_mixer_volume(0x35, MIXER_SRC_SYNTH, MIXER_CHANNEL_RIGHT);
+// MIDI/FM Volume Left.
+register_mixer_volume(0x34, MIXER_SRC_OPL, MIXER_CHANNEL_LEFT);
+// MIDI/FM Volume Right.
+register_mixer_volume(0x35, MIXER_SRC_OPL, MIXER_CHANNEL_RIGHT);
 // CD Volume Left. TODO.
 //register_mixer_volume(0x36, MIXER_SRC_CD, MIXER_CHANNEL_LEFT);
 // CD Volume Right. TODO.
@@ -1566,8 +1761,8 @@ function get_fm_operator(register, offset)
 
 register_fm_write([0x01], function(bits, register, address)
 {
-    this.fm_waveform_select_enable[register] = bits & 0x20 > 0;
-    this.fm_update_waveforms();
+    this.fm_waveform_select_enable[register] = (bits & 0x20) > 0;
+    this.bus.send("opl2-reg-write", [address, bits]);
 });
 
 // Timer 1 Count.
@@ -1581,14 +1776,26 @@ register_fm_write([0x04], function(bits, register, address)
     switch(register)
     {
         case 0:
-            // if(bits & 0x80)
-            // {
-            //     // IQR Reset
-            // }
-            // else
-            // {
-            //     // Timer masks and on/off
-            // }
+            if(bits & 0x80)
+            {
+                // IRQ Reset / Timer flag reset
+                this.fm_timer1_expired = false;
+                this.fm_timer2_expired = false;
+                this.fm_timer1_counter = -1;
+                this.fm_timer2_counter = -1;
+            }
+            // Timer 1 start (bit 0), masked by bit 6
+            if((bits & 0x01) && !(bits & 0x40))
+            {
+                // Start countdown: expire after ~10 status reads
+                this.fm_timer1_counter = 10;
+            }
+            // Timer 2 start (bit 1), masked by bit 5
+            if((bits & 0x02) && !(bits & 0x20))
+            {
+                // Start countdown: expire after ~40 status reads
+                this.fm_timer2_counter = 40;
+            }
             break;
         case 1:
             // Four-operator enable
@@ -1611,78 +1818,58 @@ register_fm_write([0x05], function(bits, register, address)
 
 register_fm_write([0x08], function(bits, register, address)
 {
-    // Composite sine wave on/off
-    // Note select (keyboard split selection method)
+    this.bus.send("opl2-reg-write", [address, bits]);
 });
 
 register_fm_write(between(0x20, 0x35), function(bits, register, address)
 {
-    var operator = get_fm_operator(register, address - 0x20);
-    // Tremolo
-    // Vibrato
-    // Sustain
-    // KSR Envelope Scaling
-    // Frequency Multiplication Factor
+    this.bus.send("opl2-reg-write", [address, bits]);
 });
 
 register_fm_write(between(0x40, 0x55), function(bits, register, address)
 {
-    var operator = get_fm_operator(register, address - 0x40);
-    // Key Scale Level
-    // Output Level
+    this.bus.send("opl2-reg-write", [address, bits]);
 });
 
 register_fm_write(between(0x60, 0x75), function(bits, register, address)
 {
-    var operator = get_fm_operator(register, address - 0x60);
-    // Attack Rate
-    // Decay Rate
+    this.bus.send("opl2-reg-write", [address, bits]);
 });
 
 register_fm_write(between(0x80, 0x95), function(bits, register, address)
 {
-    var operator = get_fm_operator(register, address - 0x80);
-    // Sustain Level
-    // Release Rate
+    this.bus.send("opl2-reg-write", [address, bits]);
 });
 
 register_fm_write(between(0xA0, 0xA8), function(bits, register, address)
 {
-    var channel = address - 0xA0;
-    // Frequency Number (Lower 8 bits)
+    if(register === 0)
+    {
+        this.bus.send("opl2-reg-write", [address, bits]);
+    }
 });
 
 register_fm_write(between(0xB0, 0xB8), function(bits, register, address)
 {
-    // Key-On
-    // Block Number
-    // Frequency Number (Higher 2 bits)
+    if(register === 0)
+    {
+        this.bus.send("opl2-reg-write", [address, bits]);
+    }
 });
 
 register_fm_write([0xBD], function(bits, register, address)
 {
-    // Tremelo Depth
-    // Vibrato Depth
-    // Percussion Mode
-    // Bass Drum Key-On
-    // Snare Drum Key-On
-    // Tom-Tom Key-On
-    // Cymbal Key-On
-    // Hi-Hat Key-On
+    this.bus.send("opl2-reg-write", [address, bits]);
 });
 
 register_fm_write(between(0xC0, 0xC8), function(bits, register, address)
 {
-    // Right Speaker Enable
-    // Left Speaker Enable
-    // Feedback Modulation Factor
-    // Synthesis Type
+    this.bus.send("opl2-reg-write", [address, bits]);
 });
 
 register_fm_write(between(0xE0, 0xF5), function(bits, register, address)
 {
-    var operator = get_fm_operator(register, address - 0xE0);
-    // Waveform Select
+    this.bus.send("opl2-reg-write", [address, bits]);
 });
 
 //
@@ -1691,7 +1878,7 @@ register_fm_write(between(0xE0, 0xF5), function(bits, register, address)
 
 SB16.prototype.fm_update_waveforms = function()
 {
-    // To be implemented.
+    // Waveform select enable changed; no action needed for current synthesis.
 };
 
 //
@@ -1790,6 +1977,13 @@ SB16.prototype.dma_transfer_next = function()
 
 SB16.prototype.dma_to_dac = function(sample_count)
 {
+    // Route ADPCM modes to dedicated decoder.
+    if(this.dma_transfer_type !== 0)
+    {
+        this.dma_to_dac_adpcm(sample_count);
+        return;
+    }
+
     var amplitude = this.dsp_16bit ? 32767.5 : 127.5;
     var offset = this.dsp_signed ? 0 : -1;
     var repeats = this.dsp_stereo ? 1 : 2;
@@ -1816,6 +2010,123 @@ SB16.prototype.dma_to_dac = function(sample_count)
     }
 
     this.dac_send();
+};
+
+/**
+ * Decode Creative ADPCM compressed DMA data into the DAC buffers.
+ * sample_count = number of compressed bytes read from DMA.
+ * All ADPCM modes are mono; each compressed byte expands to 2/3/4 PCM samples.
+ */
+SB16.prototype.dma_to_dac_adpcm = function(byte_count)
+{
+    var i, b, s;
+    var start = 0;
+
+    // Handle reference byte (first byte of a "with reference" transfer).
+    if(this.adpcm_haveref && byte_count > 0)
+    {
+        this.adpcm_haveref = false;
+        this.adpcm_reference = this.dma_buffer_uint8[0];
+        this.adpcm_stepsize = 0; // MIN_ADAPTIVE_STEP_SIZE = 0
+        start = 1;
+    }
+
+    if(this.dma_transfer_type === 4)
+    {
+        // 4-bit ADPCM: each byte → 2 samples (high nybble first).
+        for(i = start; i < byte_count; i++)
+        {
+            b = this.dma_buffer_uint8[i];
+            s = audio_normalize(this.decode_adpcm_4(b >> 4), 127.5, -1);
+            this.dac_buffers[0].push(s);
+            this.dac_buffers[1].push(s);
+            s = audio_normalize(this.decode_adpcm_4(b & 0xF), 127.5, -1);
+            this.dac_buffers[0].push(s);
+            this.dac_buffers[1].push(s);
+        }
+    }
+    else if(this.dma_transfer_type === 3)
+    {
+        // 3-bit (2.6-bit) ADPCM: each byte → 3 samples.
+        // bits [7:5], bits [4:2], then bits [1:0] left-shifted to form 3-bit value.
+        for(i = start; i < byte_count; i++)
+        {
+            b = this.dma_buffer_uint8[i];
+            s = audio_normalize(this.decode_adpcm_3((b >> 5) & 0x7), 127.5, -1);
+            this.dac_buffers[0].push(s);
+            this.dac_buffers[1].push(s);
+            s = audio_normalize(this.decode_adpcm_3((b >> 2) & 0x7), 127.5, -1);
+            this.dac_buffers[0].push(s);
+            this.dac_buffers[1].push(s);
+            s = audio_normalize(this.decode_adpcm_3((b & 0x3) << 1), 127.5, -1);
+            this.dac_buffers[0].push(s);
+            this.dac_buffers[1].push(s);
+        }
+    }
+    else if(this.dma_transfer_type === 2)
+    {
+        // 2-bit ADPCM: each byte → 4 samples (bits 7:6, 5:4, 3:2, 1:0).
+        for(i = start; i < byte_count; i++)
+        {
+            b = this.dma_buffer_uint8[i];
+            s = audio_normalize(this.decode_adpcm_2((b >> 6) & 0x3), 127.5, -1);
+            this.dac_buffers[0].push(s);
+            this.dac_buffers[1].push(s);
+            s = audio_normalize(this.decode_adpcm_2((b >> 4) & 0x3), 127.5, -1);
+            this.dac_buffers[0].push(s);
+            this.dac_buffers[1].push(s);
+            s = audio_normalize(this.decode_adpcm_2((b >> 2) & 0x3), 127.5, -1);
+            this.dac_buffers[0].push(s);
+            this.dac_buffers[1].push(s);
+            s = audio_normalize(this.decode_adpcm_2((b >> 0) & 0x3), 127.5, -1);
+            this.dac_buffers[0].push(s);
+            this.dac_buffers[1].push(s);
+        }
+    }
+
+    this.dac_send();
+};
+
+/** Creative ADPCM 4-bit sample decoder. */
+SB16.prototype.decode_adpcm_4 = function(sample)
+{
+    var samp = sample + this.adpcm_stepsize;
+    if(samp < 0) samp = 0;
+    else if(samp > 63) samp = 63;
+    var ref = this.adpcm_reference + ADPCM4_SCALE_MAP[samp];
+    if(ref > 0xFF) this.adpcm_reference = 0xFF;
+    else if(ref < 0) this.adpcm_reference = 0;
+    else this.adpcm_reference = ref & 0xFF;
+    this.adpcm_stepsize = (this.adpcm_stepsize + ADPCM4_ADJUST_MAP[samp]) & 0xFF;
+    return this.adpcm_reference;
+};
+
+/** Creative ADPCM 2-bit sample decoder. */
+SB16.prototype.decode_adpcm_2 = function(sample)
+{
+    var samp = sample + this.adpcm_stepsize;
+    if(samp < 0) samp = 0;
+    else if(samp > 23) samp = 23;
+    var ref = this.adpcm_reference + ADPCM2_SCALE_MAP[samp];
+    if(ref > 0xFF) this.adpcm_reference = 0xFF;
+    else if(ref < 0) this.adpcm_reference = 0;
+    else this.adpcm_reference = ref & 0xFF;
+    this.adpcm_stepsize = (this.adpcm_stepsize + ADPCM2_ADJUST_MAP[samp]) & 0xFF;
+    return this.adpcm_reference;
+};
+
+/** Creative ADPCM 3-bit (2.6-bit) sample decoder. */
+SB16.prototype.decode_adpcm_3 = function(sample)
+{
+    var samp = sample + this.adpcm_stepsize;
+    if(samp < 0) samp = 0;
+    else if(samp > 39) samp = 39;
+    var ref = this.adpcm_reference + ADPCM3_SCALE_MAP[samp];
+    if(ref > 0xFF) this.adpcm_reference = 0xFF;
+    else if(ref < 0) this.adpcm_reference = 0;
+    else this.adpcm_reference = ref & 0xFF;
+    this.adpcm_stepsize = (this.adpcm_stepsize + ADPCM3_ADJUST_MAP[samp]) & 0xFF;
+    return this.adpcm_reference;
 };
 
 SB16.prototype.dac_handle_request = function()

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -209,6 +209,8 @@ export function SB16(cpu, bus)
     this.dma_syncbuffer = new SyncBuffer(this.dma_buffer);
     this.dma_waiting_transfer = false;
     this.dma_paused = false;
+    // Pending 8-bit single-cycle ADC (0x24) byte count; 0 = no transfer pending.
+    this.dma_adc_left = 0;
     this.sampling_rate = 22050;
     bus.send("dac-tell-sampling-rate", this.sampling_rate);
     this.bytes_per_sample = 1;
@@ -219,6 +221,8 @@ export function SB16(cpu, bus)
 
     // ASP data: not understood by me.
     this.asp_registers = new Uint8Array(256);
+    // Whether ASP chip initialisation sequence is in progress (used by 0x0F reg-toggle).
+    this.asp_init_in_progress = false;
 
     // MPU.
     this.mpu_read_buffer = new ByteQueue(DSP_BUFSIZE);
@@ -363,6 +367,7 @@ SB16.prototype.dsp_reset = function()
     this.asp_registers.fill(0);
     this.asp_registers[5] = 0x01;
     this.asp_registers[9] = 0xF8;
+    this.asp_init_in_progress = false;
 };
 
 SB16.prototype.get_state = function()
@@ -415,7 +420,7 @@ SB16.prototype.get_state = function()
 
     state[34] = this.irq;
     state[35] = this.irq_triggered;
-    //state[36]
+    state[36] = this.dma_adc_left;
 
     return state;
 };
@@ -469,7 +474,7 @@ SB16.prototype.set_state = function(state)
 
     this.irq = state[34];
     this.irq_triggered = state[35];
-    //state[36];
+    this.dma_adc_left = state[36] || 0;
 
     this.dma_buffer = this.dma_buffer_uint8.buffer;
     this.dma_buffer_int8 = new Int8Array(this.dma_buffer);
@@ -520,8 +525,11 @@ SB16.prototype.port2x1_read = function()
 
 SB16.prototype.port2x2_read = function()
 {
-    dbg_log("222 read: advanced fm music status port (unimplemented)", LOG_SB16);
-    return 0xFF;
+    dbg_log("222 read: advanced fm music status port (OPL3 bank1)", LOG_SB16);
+    // OPL3 (YMF262): bank-1 address port read returns 0x00.
+    // Bits 1-2 are always LOW on OPL3 (vs HIGH on OPL2), used for chip detection.
+    // verified on real YMF262 hardware.
+    return 0x00;
 };
 
 SB16.prototype.port2x3_read = function()
@@ -558,8 +566,11 @@ SB16.prototype.port2x7_read = function()
 
 SB16.prototype.port2x8_read = function()
 {
-    dbg_log("228 read: fm music status port (unimplemented)", LOG_SB16);
-    return 0xFF;
+    dbg_log("228 read: fm music status port (OPL2 AdLib compat)", LOG_SB16);
+    // 0x228 is the OPL2-compatible status port on SB16 (base+8).
+    // DOSBox adlib.cpp: PortRead, MODE_OPL3, port & 3 == 0 => chip[0].Read().
+    // Shares the same timer state as 0x220.
+    return this.port2x0_read();
 };
 
 SB16.prototype.port2x9_read = function()
@@ -706,12 +717,23 @@ SB16.prototype.port2x7_write = function(value)
 
 SB16.prototype.port2x8_write = function(value)
 {
-    dbg_log("228 write: fm music register port (unimplemented)", LOG_SB16);
+    // OPL2 AdLib compatible address register (base+8), mirrors bank-0 address.
+    // DOSBox adlib.cpp PortWrite: reg.normal = handler->WriteAddr(port, val) & 0xff
+    dbg_log("228 write: fm register 0 address (AdLib compat) = " + h(value), LOG_SB16);
+    this.fm_current_address0 = value;
 };
 
 SB16.prototype.port2x9_write = function(value)
 {
-    dbg_log("229 write: fm music data port (unimplemented)", LOG_SB16);
+    // OPL2 AdLib compatible data register (base+9), mirrors bank-0 data.
+    // DOSBox adlib.cpp PortWrite: handler->WriteReg(reg.normal, val)
+    dbg_log("229 write: fm register 0 data (AdLib compat) = " + h(value), LOG_SB16);
+    var handler = FM_HANDLERS[this.fm_current_address0];
+    if(!handler)
+    {
+        handler = this.fm_default_write;
+    }
+    handler.call(this, value, 0, this.fm_current_address0);
 };
 
 SB16.prototype.port2xA_write = function(value)
@@ -876,6 +898,36 @@ function any_first_digit(base)
     return commands;
 }
 
+// SB16 ASP set mode register.
+// Controls whether the ASP chip initialisation sequence is in progress.
+register_dsp_command([0x04], 1, function()
+{
+    var data = this.write_buffer.shift();
+    this.asp_init_in_progress = (data & 0xF1) === 0xF1;
+    dbg_log("DSP 0x04: ASP set mode register 0x" + h(data), LOG_SB16);
+});
+
+// SB16 ASP set codec parameter (no-op, as in DOSBox).
+register_dsp_command([0x05], 2, function()
+{
+    this.write_buffer.shift();
+    this.write_buffer.shift();
+    dbg_log("DSP 0x05: ASP set codec parameter (unimplemented)", LOG_SB16);
+});
+
+// SB16 ASP get version.
+// Sub-command 0x03 returns version ID 0x18 (as in DOSBox).
+register_dsp_command([0x08], 1, function()
+{
+    var sub = this.write_buffer.shift();
+    dbg_log("DSP 0x08: ASP get version sub=0x" + h(sub), LOG_SB16);
+    if(sub === 0x03)
+    {
+        this.read_buffer.clear();
+        this.read_buffer.push(0x18);
+    }
+});
+
 // ASP set register
 register_dsp_command([0x0E], 2, function()
 {
@@ -883,10 +935,16 @@ register_dsp_command([0x0E], 2, function()
 });
 
 // ASP get register
+// When initialisation is in progress, reading register 0x83 toggles its value (DOSBox behaviour).
 register_dsp_command([0x0F], 1, function()
 {
+    var reg = this.write_buffer.shift();
+    if(this.asp_init_in_progress && reg === 0x83)
+    {
+        this.asp_registers[0x83] = (~this.asp_registers[0x83]) & 0xFF;
+    }
     this.read_buffer.clear();
-    this.read_buffer.push(this.asp_registers[this.write_buffer.shift()]);
+    this.read_buffer.push(this.asp_registers[reg]);
 });
 
 // 8-bit direct mode single byte digitized sound output.
@@ -978,10 +1036,29 @@ register_dsp_command([0x20], 0, function()
 });
 
 // 8-bit single-cycle DMA mode digitized sound input.
-register_dsp_command([0x24], 2);
+// Faked: fills the DMA buffer with silence (0x80) then raises the 8-bit IRQ.
+// Mirrors DOSBox DSP_ADC_CallBack: wait for the DMA8 channel to be unmasked,
+// then write 0x80 for dma.left bytes and fire SB_IRQ_8.
+register_dsp_command([0x24], 2, function()
+{
+    var low = this.write_buffer.shift();
+    var high = this.write_buffer.shift();
+    this.dma_adc_left = 1 + low + (high << 8);
+    dbg_log("DSP 0x24: Faked 8-bit DMA ADC for " + this.dma_adc_left + " bytes", LOG_SB16);
+    if(!this.dma.channel_mask[this.dma_channel_8bit])
+    {
+        // DMA channel already unmasked — transfer immediately.
+        this.dma_adc_do_transfer();
+    }
+    // else: dma_on_unmask fires dma_adc_do_transfer when the channel is unmasked.
+});
 
 // 8-bit auto-init DMA mode digitized sound input.
-register_dsp_command([0x2C], 0);
+// DOSBox logs "DSP:Unimplemented input command" and does nothing; same here.
+register_dsp_command([0x2C], 0, function()
+{
+    dbg_log("DSP 0x2C: Unimplemented input command", LOG_SB16);
+});
 
 // Polling mode MIDI input.
 register_dsp_command([0x30], 0);
@@ -1001,8 +1078,16 @@ register_dsp_command([0x36], 0);
 // UART interrupt mode MIDI I/O with time stamping.
 register_dsp_command([0x37], 0);
 
-// MIDI output.
-register_dsp_command([0x38], 0);
+// MIDI output single byte.
+// DOSBox: MIDI_RawOutByte(data) when sb.midi == true.
+// TODO: implement real MIDI output via Web MIDI API (navigator.requestMIDIAccess)
+// — skipped to avoid the permission popup and because Web MIDI is not universally
+// available. Data is silently discarded.
+register_dsp_command([0x38], 1, function()
+{
+    this.write_buffer.shift();
+    dbg_log("DSP 0x38: MIDI output byte discarded (no MIDI support)", LOG_SB16);
+});
 
 // Set digitized sound transfer Time Constant.
 register_dsp_command([0x40], 1, function()
@@ -1117,7 +1202,16 @@ register_dsp_command([0x7F], 0, function()
 });
 
 // Pause DAC for a duration.
-register_dsp_command([0x80], 2);
+// Raises the 8-bit IRQ after the silence period expires, matching DOSBox behaviour.
+register_dsp_command([0x80], 2, function()
+{
+    var low = this.write_buffer.shift();
+    var high = this.write_buffer.shift();
+    var count = 1 + low + (high << 8);
+    var delay_ms = count * 1000 / this.sampling_rate;
+    dbg_log("DSP 0x80: Silence DAC for " + count + " samples (" + delay_ms.toFixed(2) + " ms)", LOG_SB16);
+    setTimeout(() => { this.raise_irq(SB_IRQ_8BIT); }, delay_ms);
+});
 
 // 8-bit high-speed auto-init DMA mode digitized sound output.
 register_dsp_command([0x90], 0, function()
@@ -1292,6 +1386,13 @@ register_dsp_command([0xF2, 0xF3], 0, function()
     this.raise_irq();
 });
 
+// Undocumented pre-SB16 command: returns 0x00 (matches DOSBox).
+register_dsp_command([0xF8], 0, function()
+{
+    this.read_buffer.clear();
+    this.read_buffer.push(0x00);
+});
+
 // ASP - unknown function
 var SB_F9 = new Uint8Array(256);
 SB_F9[0x0E] = 0xFF;
@@ -1361,7 +1462,8 @@ SB16.prototype.mixer_reset = function()
     this.mixer_registers[0x26] = 12 << 4 | 12;
     this.mixer_registers[0x28] = 0;
     this.mixer_registers[0x2E] = 0;
-    this.mixer_registers[0x0A] = 0;
+    // 0x0A and 0x3A share the same internal mic field (mixer_registers[0x3A] stores 0-31 raw value)
+    // DOSBox CTMIXER_Reset() does NOT reset mic, so we leave it as-is during reset.
     this.mixer_registers[0x30] = 31 << 3;
     this.mixer_registers[0x31] = 31 << 3;
     this.mixer_registers[0x32] = 31 << 3;
@@ -1372,6 +1474,7 @@ SB16.prototype.mixer_reset = function()
     this.mixer_registers[0x37] = 0;
     this.mixer_registers[0x38] = 0;
     this.mixer_registers[0x39] = 0;
+    this.mixer_registers[0x3A] = 0;
     this.mixer_registers[0x3B] = 0;
     this.mixer_registers[0x3C] = 0x1F;
     this.mixer_registers[0x3D] = 0x15;
@@ -1494,14 +1597,31 @@ register_mixer_write(0x00);
 // Legacy Voice Volume Left/Right.
 register_mixer_legacy(0x04, 0x32, 0x33);
 
-// Legacy Mic Volume. TODO.
-//register_mixer_read(0x0A);
-//register_mixer_write(0x0A, function(data)
-//{
-//    this.mixer_registers[0x0A] = data;
-//    var prev = this.mixer_registers[0x3A];
-//    this.mixer_write(0x3A, data << 5 | (prev & 0x0F));
-//});
+// Mic Level (SBPro, 3-bit at bits 2:0; SB16 uses 3-bit too but shares storage with 0x3A).
+// DOSBox: mic = (val & 0x7)<<2 | 1 [SB16]; read: (mic>>2) & 7.
+// mixer_registers[0x3A] stores the raw 5-bit mic value (same as DOSBox sb.mixer.mic).
+register_mixer_read(0x0A, function()
+{
+    return (this.mixer_registers[0x3A] >> 2) & 7;
+});
+register_mixer_write(0x0A, function(data)
+{
+    // SB16 mode: mic = (val & 0x7)<<2 | 1  (low bit = 1 for SB16, 3 for SBPro)
+    this.mixer_registers[0x3A] = ((data & 0x7) << 2) | 1;
+});
+
+// Stereo/Filter Select (SBPro). Bit 1 = stereo output; bit 5 = filter (not applied in v86).
+// On SB16 stereo is set per-command, but this register is honoured for SBPro compatibility.
+// DOSBox: stereo=(val&0x2)>0; filtered=(val&0x20)>0; read: 0x11|(stereo?0x02:0)|(filtered?0x20:0).
+register_mixer_read(0x0E, function()
+{
+    return 0x11 | (this.dsp_stereo ? 0x02 : 0x00) | (this.mixer_registers[0x0E] & 0x20);
+});
+register_mixer_write(0x0E, function(data)
+{
+    this.mixer_registers[0x0E] = data;
+    this.dsp_stereo = (data & 0x02) !== 0;
+});
 
 // Legacy Master Volume Left/Right.
 register_mixer_legacy(0x22, 0x30, 0x31);
@@ -1524,16 +1644,43 @@ register_mixer_volume(0x33, MIXER_SRC_DAC, MIXER_CHANNEL_RIGHT);
 register_mixer_volume(0x34, MIXER_SRC_OPL, MIXER_CHANNEL_LEFT);
 // MIDI/FM Volume Right.
 register_mixer_volume(0x35, MIXER_SRC_OPL, MIXER_CHANNEL_RIGHT);
-// CD Volume Left. TODO.
-//register_mixer_volume(0x36, MIXER_SRC_CD, MIXER_CHANNEL_LEFT);
-// CD Volume Right. TODO.
-//register_mixer_volume(0x37, MIXER_SRC_CD, MIXER_CHANNEL_RIGHT);
-// Line Volume Left. TODO.
-//register_mixer_volume(0x38, MIXER_SRC_LINE, MIXER_CHANNEL_LEFT);
-// Line Volume Right. TODO.
-//register_mixer_volume(0x39, MIXER_SRC_LINE, MIXER_CHANNEL_RIGHT);
-// Mic Volume. TODO.
-//register_mixer_volume(0x3A, MIXER_SRC_MIC, MIXER_CHANNEL_BOTH);
+// CD Volume Left (SB16). Bits 7:3. No CD audio source in v86; stored for read-back.
+// DOSBox: cda[0] = val>>3; read: cda[0]<<3 (bits 2:0 always zero).
+register_mixer_read(0x36);
+register_mixer_write(0x36, function(data)
+{
+    this.mixer_registers[0x36] = data & 0xF8;
+});
+// CD Volume Right (SB16). Bits 7:3.
+register_mixer_read(0x37);
+register_mixer_write(0x37, function(data)
+{
+    this.mixer_registers[0x37] = data & 0xF8;
+});
+// Line-in Volume Left (SB16). Bits 7:3. No line-in source in v86; stored for read-back.
+// DOSBox: lin[0] = val>>3; read: lin[0]<<3.
+register_mixer_read(0x38);
+register_mixer_write(0x38, function(data)
+{
+    this.mixer_registers[0x38] = data & 0xF8;
+});
+// Line-in Volume Right (SB16). Bits 7:3.
+register_mixer_read(0x39);
+register_mixer_write(0x39, function(data)
+{
+    this.mixer_registers[0x39] = data & 0xF8;
+});
+// Mic Volume (SB16). Bits 7:3. No mic input in v86; stored for read-back.
+// DOSBox: mic = val>>3; read: mic<<3.
+// mixer_registers[0x3A] stores the raw 5-bit value (same field as 0x0A above).
+register_mixer_read(0x3A, function()
+{
+    return this.mixer_registers[0x3A] << 3;
+});
+register_mixer_write(0x3A, function(data)
+{
+    this.mixer_registers[0x3A] = data >> 3;
+});
 
 // PC Speaker Volume.
 register_mixer_read(0x3B);
@@ -1543,43 +1690,43 @@ register_mixer_write(0x3B, function(data)
     this.bus.send("mixer-volume", [MIXER_SRC_PCSPEAKER, MIXER_CHANNEL_BOTH, (data >>> 6) * 6 - 18]);
 });
 
-// Output Mixer Switches. TODO.
-//register_mixer_read(0x3C);
-//register_mixer_write(0x3C, function(data)
-//{
-//    this.mixer_registers[0x3C] = data;
-//
-//    if(data & 0x01) this.bus.send("mixer-connect", [MIXER_SRC_MIC, MIXER_CHANNEL_BOTH]);
-//    else this.bus.send("mixer-disconnect", [MIXER_SRC_MIC, MIXER_CHANNEL_BOTH]);
-//
-//    if(data & 0x02) this.bus.send("mixer-connect", [MIXER_SRC_CD, MIXER_CHANNEL_RIGHT]);
-//    else this.bus.send("mixer-disconnect", [MIXER_SRC_CD, MIXER_CHANNEL_RIGHT]);
-//
-//    if(data & 0x04) this.bus.send("mixer-connect", [MIXER_SRC_CD, MIXER_CHANNEL_LEFT]);
-//    else this.bus.send("mixer-disconnect", [MIXER_SRC_CD, MIXER_CHANNEL_LEFT]);
-//
-//    if(data & 0x08) this.bus.send("mixer-connect", [MIXER_SRC_LINE, MIXER_CHANNEL_RIGHT]);
-//    else this.bus.send("mixer-disconnect", [MIXER_SRC_LINE, MIXER_CHANNEL_RIGHT]);
-//
-//    if(data & 0x10) this.bus.send("mixer-connect", [MIXER_SRC_LINE, MIXER_CHANNEL_LEFT]);
-//    else this.bus.send("mixer-disconnect", [MIXER_SRC_LINE, MIXER_CHANNEL_LEFT]);
-//});
+// Output Mixer Switches (SB16). Bits 4:0: bit0=Mic, bit1=CD-R, bit2=CD-L, bit3=Line-R, bit4=Line-L.
+// DOSBox stores to unhandled[0x3C]; v86 has no CD/Line/Mic sources, stored for read-back.
+register_mixer_read(0x3C);
+register_mixer_write(0x3C, function(data)
+{
+    this.mixer_registers[0x3C] = data;
+});
 
-// Input Mixer Left Switches. TODO.
-//register_mixer_read(0x3D);
-//register_mixer_write(0x3D);
+// Input Mixer Left Switches (SB16). Bits 5:0: bit0=Mic, bit1=CD-R, bit2=CD-L, bit3=Line-R, bit4=Line-L, bit5=MIDI.
+// DOSBox stores to unhandled[0x3D]; stored for read-back.
+register_mixer_read(0x3D);
+register_mixer_write(0x3D, function(data)
+{
+    this.mixer_registers[0x3D] = data;
+});
 
-// Input Mixer Right Switches. TODO.
-//register_mixer_read(0x3E);
-//register_mixer_write(0x3E);
+// Input Mixer Right Switches (SB16). Bits 5:0 (same layout as 0x3D).
+register_mixer_read(0x3E);
+register_mixer_write(0x3E, function(data)
+{
+    this.mixer_registers[0x3E] = data;
+});
 
-// Input Gain Left. TODO.
-//register_mixer_read(0x3F);
-//register_mixer_write(0x3F);
+// Input Gain Left (SB16). Bits 7:6: 0=0 dB, 1=+1.5 dB, 2=+3 dB, 3=+4.5 dB.
+// DOSBox stores to unhandled[0x3F]; stored for read-back.
+register_mixer_read(0x3F);
+register_mixer_write(0x3F, function(data)
+{
+    this.mixer_registers[0x3F] = data;
+});
 
-// Input Gain Right. TODO.
-//register_mixer_read(0x40);
-//register_mixer_write(0x40);
+// Input Gain Right (SB16). Bits 7:6.
+register_mixer_read(0x40);
+register_mixer_write(0x40, function(data)
+{
+    this.mixer_registers[0x40] = data;
+});
 
 // Output Gain Left.
 register_mixer_read(0x41);
@@ -1597,9 +1744,13 @@ register_mixer_write(0x42, function(data)
     this.bus.send("mixer-gain-right", (data >>> 6) * 6);
 });
 
-// Mic AGC. TODO.
-//register_mixer_read(0x43);
-//register_mixer_write(0x43);
+// Mic AGC (SB16). Bit 0: 0 = AGC enabled, 1 = fixed gain.
+// DOSBox stores to unhandled[0x43]; stored for read-back.
+register_mixer_read(0x43);
+register_mixer_write(0x43, function(data)
+{
+    this.mixer_registers[0x43] = data;
+});
 
 // Treble Left.
 register_mixer_read(0x44);
@@ -1933,6 +2084,14 @@ SB16.prototype.dma_transfer_start = function()
 
 SB16.prototype.dma_on_unmask = function(channel)
 {
+    // Handle pending single-cycle ADC transfer (0x24), mirroring DOSBox DSP_ADC_CallBack.
+    if(channel === this.dma_channel_8bit && this.dma_adc_left > 0)
+    {
+        this.dma_adc_do_transfer();
+        // ADC and DAC cannot be active simultaneously; skip DAC path.
+        return;
+    }
+
     if(channel !== this.dma_channel || !this.dma_waiting_transfer)
     {
         return;
@@ -1944,6 +2103,19 @@ SB16.prototype.dma_on_unmask = function(channel)
     this.dma_bytes_left = this.dma_bytes_count;
     this.dma_paused = false;
     this.bus.send("dac-enable");
+};
+
+// Perform a faked single-cycle ADC DMA transfer: fill memory with silence (0x80)
+// for dma_adc_left bytes and raise SB_IRQ_8BIT, matching DOSBox DSP_ADC_CallBack.
+SB16.prototype.dma_adc_do_transfer = function()
+{
+    var left = this.dma_adc_left;
+    this.dma_adc_left = 0;
+    this.dma_buffer_uint8.fill(0x80, 0, Math.min(left, SB_DMA_BUFSIZE));
+    this.dma.do_read(this.dma_syncbuffer, 0, left, this.dma_channel_8bit, (error) =>
+    {
+        if(!error) this.raise_irq(SB_IRQ_8BIT);
+    });
 };
 
 SB16.prototype.dma_transfer_next = function()

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -209,8 +209,12 @@ export function SB16(cpu, bus)
     this.dma_syncbuffer = new SyncBuffer(this.dma_buffer);
     this.dma_waiting_transfer = false;
     this.dma_paused = false;
-    // Pending 8-bit single-cycle ADC (0x24) byte count; 0 = no transfer pending.
+    // Pending 8-bit ADC DMA byte count; 0 = no transfer pending.
     this.dma_adc_left = 0;
+    // Block count for 8-bit auto-init ADC (0x2C) restart; 0 = single-cycle.
+    this.dma_adc_count = 0;
+    // Whether currently running in auto-init ADC mode.
+    this.dma_adc_autoinit = false;
     this.sampling_rate = 22050;
     bus.send("dac-tell-sampling-rate", this.sampling_rate);
     this.bytes_per_sample = 1;
@@ -349,6 +353,9 @@ SB16.prototype.dsp_reset = function()
     this.dma_buffer_uint8.fill(0);
     this.dma_waiting_transfer = false;
     this.dma_paused = false;
+    this.dma_adc_left = 0;
+    this.dma_adc_count = 0;
+    this.dma_adc_autoinit = false;
 
     this.e2_value = 0xAA;
     this.e2_count = 0;
@@ -421,6 +428,8 @@ SB16.prototype.get_state = function()
     state[34] = this.irq;
     state[35] = this.irq_triggered;
     state[36] = this.dma_adc_left;
+    state[37] = this.dma_adc_count;
+    state[38] = this.dma_adc_autoinit;
 
     return state;
 };
@@ -475,6 +484,8 @@ SB16.prototype.set_state = function(state)
     this.irq = state[34];
     this.irq_triggered = state[35];
     this.dma_adc_left = state[36] || 0;
+    this.dma_adc_count = state[37] || 0;
+    this.dma_adc_autoinit = state[38] || false;
 
     this.dma_buffer = this.dma_buffer_uint8.buffer;
     this.dma_buffer_int8 = new Int8Array(this.dma_buffer);
@@ -1054,10 +1065,21 @@ register_dsp_command([0x24], 2, function()
 });
 
 // 8-bit auto-init DMA mode digitized sound input.
-// DOSBox logs "DSP:Unimplemented input command" and does nothing; same here.
-register_dsp_command([0x2C], 0, function()
+// Takes 2 bytes: low then high of (block_count - 1).
+// Mirrors 0x24 but auto-restarts after each block until 0xDA is issued.
+register_dsp_command([0x2C], 2, function()
 {
-    dbg_log("DSP 0x2C: Unimplemented input command", LOG_SB16);
+    var low = this.write_buffer.shift();
+    var high = this.write_buffer.shift();
+    this.dma_adc_count = 1 + low + (high << 8);
+    this.dma_adc_left = this.dma_adc_count;
+    this.dma_adc_autoinit = true;
+    dbg_log("DSP 0x2C: 8-bit auto-init DMA ADC, block=" + this.dma_adc_count + " bytes", LOG_SB16);
+    if(!this.dma.channel_mask[this.dma_channel_8bit])
+    {
+        this.dma_adc_do_transfer();
+    }
+    // else: dma_on_unmask fires dma_adc_do_transfer when channel is unmasked.
 });
 
 // Polling mode MIDI input.
@@ -1226,8 +1248,20 @@ register_dsp_command([0x90], 0, function()
     this.dma_transfer_start();
 });
 
-// 8-bit high-speed single-cycle DMA mode digitized sound input.
-register_dsp_command([0x91], 0);
+// 8-bit high-speed single-cycle DMA mode digitized sound output (DAC).
+// Like 0x90 but single-cycle (dma_autoinit = false).  DOSBox: "High speed
+// single cycle DMA DAC, 8-bit".
+register_dsp_command([0x91], 0, function()
+{
+    this.dma_irq = SB_IRQ_8BIT;
+    this.dma_channel = this.dma_channel_8bit;
+    this.dma_autoinit = false;
+    this.dsp_signed = false;
+    this.dsp_highspeed = true;
+    this.dsp_16bit = false;
+    this.dma_transfer_type = 0;
+    this.dma_transfer_start();
+});
 
 // 8-bit high-speed auto-init DMA mode digitized sound input.
 register_dsp_command([0x98], 0);
@@ -1335,6 +1369,7 @@ register_dsp_command([0xD8], 0, function()
 register_dsp_command([0xD9, 0xDA], 0, function()
 {
     this.dma_autoinit = false;
+    this.dma_adc_autoinit = false;
 });
 
 // DSP identification
@@ -2107,8 +2142,10 @@ SB16.prototype.dma_on_unmask = function(channel)
     this.bus.send("dac-enable");
 };
 
-// Perform a faked single-cycle ADC DMA transfer: fill memory with silence (0x80)
-// for dma_adc_left bytes and raise SB_IRQ_8BIT, matching DOSBox DSP_ADC_CallBack.
+// Perform a faked ADC DMA transfer: fill memory with silence (0x80) for
+// dma_adc_left bytes and raise SB_IRQ_8BIT.  In auto-init mode (0x2C) the
+// transfer is rescheduled at the sampling rate after each block, mirroring
+// real hardware behaviour.  Single-cycle (0x24) stops after one block.
 SB16.prototype.dma_adc_do_transfer = function()
 {
     var left = this.dma_adc_left;
@@ -2116,7 +2153,22 @@ SB16.prototype.dma_adc_do_transfer = function()
     this.dma_buffer_uint8.fill(0x80, 0, Math.min(left, SB_DMA_BUFSIZE));
     this.dma.do_read(this.dma_syncbuffer, 0, left, this.dma_channel_8bit, (error) =>
     {
-        if(!error) this.raise_irq(SB_IRQ_8BIT);
+        if(error) return;
+        this.raise_irq(SB_IRQ_8BIT);
+        if(this.dma_adc_autoinit)
+        {
+            // Schedule next block at the sampling rate to avoid a synchronous
+            // infinite loop (SyncBuffer fires the callback immediately).
+            var delay_ms = Math.max(1, Math.round(this.dma_adc_count / this.sampling_rate * 1000));
+            setTimeout(() =>
+            {
+                if(this.dma_adc_autoinit)
+                {
+                    this.dma_adc_left = this.dma_adc_count;
+                    this.dma_adc_do_transfer();
+                }
+            }, delay_ms);
+        }
     });
 };
 

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -671,7 +671,7 @@ SB16.prototype.port2x3_write = function(value)
     {
         handler = this.fm_default_write;
     }
-    handler.call(this, value, 1, this.fm_current_address1);
+    handler.call(this, value, 1, 0x100 | this.fm_current_address1);
 };
 
 // Mixer Address Port.
@@ -1949,7 +1949,8 @@ register_fm_write([0x04], function(bits, register, address)
             }
             break;
         case 1:
-            // Four-operator enable
+            // Four-operator enable (OPL3 reg 0x104)
+            this.bus.send("opl2-reg-write", [address, bits]);
             break;
     }
 });
@@ -1963,7 +1964,8 @@ register_fm_write([0x05], function(bits, register, address)
     }
     else
     {
-        // OPL3 Mode Enable
+        // OPL3 Mode Enable (OPL3 reg 0x105)
+        this.bus.send("opl2-reg-write", [address, bits]);
     }
 });
 

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1645,9 +1645,10 @@ register_mixer_write(0x0A, function(data)
     this.mixer_registers[0x3A] = ((data & 0x7) << 2) | 1;
 });
 
-// Stereo/Filter Select (SBPro). Bit 1 = stereo output; bit 5 = filter (not applied in v86).
+// Stereo/Filter Select (SBPro). Bit 1 = stereo output; bit 5 = analogue output filter (active-low).
 // On SB16 stereo is set per-command, but this register is honoured for SBPro compatibility.
 // DOSBox: stereo=(val&0x2)>0; filtered=(val&0x20)>0; read: 0x11|(stereo?0x02:0)|(filtered?0x20:0).
+// Hardware filter cutoff: ~3.2 kHz mono, ~8 kHz stereo (first-order RC lowpass, modelled as BiquadFilter).
 register_mixer_read(0x0E, function()
 {
     return 0x11 | (this.dsp_stereo ? 0x02 : 0x00) | (this.mixer_registers[0x0E] & 0x20);
@@ -1656,6 +1657,8 @@ register_mixer_write(0x0E, function(data)
 {
     this.mixer_registers[0x0E] = data;
     this.dsp_stereo = (data & 0x02) !== 0;
+    // Bit 5=0 → filter ON (active-low), bit 5=1 → filter OFF.
+    this.bus.send("mixer-sbpro-filter", [(data & 0x20) === 0, this.dsp_stereo]);
 });
 
 // Legacy Master Volume Left/Right.

--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1497,6 +1497,10 @@ SB16.prototype.mixer_reset = function()
     this.mixer_registers[0x26] = 12 << 4 | 12;
     this.mixer_registers[0x28] = 0;
     this.mixer_registers[0x2E] = 0;
+    // 0x0E Output/Stereo Select (SBPro): bit 5 is active-low filter enable.
+    // DOSBox never applies this filter; default to bit 5=1 (filter bypass) so
+    // mixer_full_update() does not engage the 3.2 kHz low-pass at startup.
+    this.mixer_registers[0x0E] = 0x20;
     // 0x0A and 0x3A share the same internal mic field (mixer_registers[0x3A] stores 0-31 raw value)
     // DOSBox CTMIXER_Reset() does NOT reset mic, so we leave it as-is during reset.
     this.mixer_registers[0x30] = 31 << 3;
@@ -1814,7 +1818,7 @@ register_mixer_write(0x46, function(data)
 {
     this.mixer_registers[0x46] = data;
     data >>>= 3;
-    this.bus.send("mixer-bass-right", data - (data < 16 ? 14 : 16));
+    this.bus.send("mixer-bass-left", data - (data < 16 ? 14 : 16));
 });
 
 // Bass Right.


### PR DESCRIPTION
Replace the ScriptProcessorNode-based OPL2 synthesizer with an AudioWorklet and implement a large set of previously missing SB16 features.

## OPL2/OPL3 Synthesizer (`opl2-worklet.js`)

- Port the DBOPL FM synthesizer from DOSBox (GPL v2+) as an `AudioWorkletProcessor`
- Full OPL2 operator: ADSR envelope, KSR, tremolo, vibrato, waveform selection (all 8), `MASK_SUSTAIN`
- OPL3 mode: 4-op channels (reg 0x104), stereo panning (L/R/both), extended synthesis modes, OPL3 enable (reg 0x105)
- OPL2 mono output: copy left channel to right
- Wire OPL through `SpeakerMixer` so hardware FM volume registers (0x34/0x35) take effect
- Bank-1 writes (port 0x222/0x223) forwarded as `addr | 0x100` so the worklet routes them to the correct OPL3 operator/channel set

## AdLib Compatible Ports

| Port | Dir | Before | After |
|------|-----|--------|-------|
| 0x222 read | R | returned 0xFF | returns 0x00 (OPL3 bits 1-2 LOW, used for chip detection) |
| 0x228 read | R | returned 0xFF | delegates to `port2x0_read()` — correct timer/status value |
| 0x228 write | W | no-op | sets `fm_current_address0` (AdLib compat address latch) |
| 0x229 write | W | no-op | dispatches `FM_HANDLERS` like port 0x221 (AdLib compat data) |

## Creative ADPCM Decoding

| Commands | Format | Expansion |
|----------|--------|-----------|
| 0x16 / 0x17 / 0x1F | 2-bit ADPCM | 4 samples/byte |
| 0x74 / 0x75 / 0x7D | 4-bit ADPCM | 2 samples/byte |
| 0x76 / 0x77 / 0x7F | 3-bit ADPCM | 3 samples/byte |

Reference-byte and auto-init variants all supported.

## DSP Commands

| Cmd | Function | Before | After |
|-----|----------|--------|-------|
| 0x04 | ASP set mode register | missing | implemented; tracks `asp_init_in_progress` |
| 0x05 | ASP set codec parameter | missing | no-op consuming 2 bytes (matches DOSBox) |
| 0x08 | ASP get version | missing | sub=0x03 returns 0x18 (matches DOSBox) |
| 0x0F | ASP get register | basic | reg 0x83 toggles when init in progress |
| 0x24 | 8-bit single-cycle DMA ADC | empty stub | faked: fill DMA with 0x80 silence, raise SB_IRQ_8BIT (mirrors DOSBox `DSP_ADC_CallBack`) |
| 0x2C | 8-bit auto-init DMA ADC | silent no-op | explicit stub with log (matches DOSBox — not implemented there either) |
| 0x38 | MIDI output byte | size=0 (byte lost) | size=1; byte consumed and discarded |
| 0x80 | Silence DAC | empty stub | fires SB_IRQ_8BIT after computed delay via `setTimeout` |
| 0xF8 | Undocumented pre-SB16 | missing | returns 0x00 (matches DOSBox) |

## MPU-401 (port 0x330/0x331)

- UART mode (command 0x3F) and reset (0xFF) with ACK byte (0xFE)
- Generic ACK for any unrecognised command (prevents driver hang)
- Status register: bits 0–5 always set, bit 7 = input-not-ready
- MIDI data writes silently discarded (no Web MIDI to avoid permission popup)

## Mixer Registers

| Register | Function | Before | After |
|----------|----------|--------|-------|
| 0x0A | Mic Level (SBPro compat) | TODO stub | read `(mic>>2)&7`, write `mic=(val&7)<<2\|1`, shares 0x3A storage |
| 0x0E | SBPro Stereo/Filter Select | missing | bit 1 → `dsp_stereo`; bit 5 stored for read-back |
| 0x36/0x37 | CD Volume L/R | TODO | stored with bits 2:0 masked (no CD audio source in v86) |
| 0x38/0x39 | Line-in Volume L/R | TODO | stored with bits 2:0 masked (no line-in source) |
| 0x3A | Mic Volume (SB16) | TODO | `val>>3` / read `val<<3`, shared with 0x0A |
| 0x3C | Output Mixer Switches | TODO | stored for read-back |
| 0x3D/0x3E | Input Mixer Switches | TODO | stored for read-back |
| 0x3F/0x40 | Input Gain L/R | TODO | stored |
| 0x43 | Mic AGC | TODO | stored |
| 0x30–0x35 | Master/Voice/FM volume | wrong defaults | reset to `31<<3` (0 dB), correct attenuation formula |

## Remaining Known Gaps (vs DOSBox)

| Area | Notes |
|------|-------|
| 0x2C auto-init DMA ADC | stub; DOSBox also does not implement this |
| 0x91/0x98/0x99 high-speed ADC | stub; no recording hardware in v86 |
| MPU-401 intelligent mode | UART mode is sufficient for the vast majority of DOS games |
| GUS (Gravis UltraSound) | separate device, out of scope |
| Tandy Sound (SN76496) | separate device, out of scope |
| Analogue filter (mixer 0x0E bit 5) | stored for read-back; no Web Audio biquad filter applied |