### PR TITLE
Dial-up Modem device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ LIB_FILES=9p.js filesystem.js marshall.js
 BROWSER_FILES=screen.js keyboard.js mouse.js speaker.js serial.js \
 	      network.js starter.js worker_bus.js dummy_screen.js \
 	      inbrowser_network.js fake_network.js wisp_network.js fetch_network.js \
-          print_stats.js filestorage.js
+          print_stats.js filestorage.js modem.js
 
 RUST_FILES=$(shell find src/rust/ -name '*.rs') \
 	   src/rust/gen/interpreter.rs src/rust/gen/interpreter0f.rs \

--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,7 @@ list of emulated hardware:
 - An NE2000 (RTL8390) PCI network card.
 - Various virtio devices: Filesystem, network and balloon.
 - A SoundBlaster 16 sound card.
+- A hayes-compatible dial-up Modem.
 
 ## Demos
 
@@ -61,6 +62,7 @@ list of emulated hardware:
 
 [How it works](docs/how-it-works.md) —
 [Networking](docs/networking.md) —
+[Dial-up modem networking](docs/modem.md) —
 [Alpine Linux guest setup](tools/docker/alpine/) —
 [Arch Linux guest setup](docs/archlinux.md) —
 [Windows NT guest setup](docs/windows-nt.md) —

--- a/debug.html
+++ b/debug.html
@@ -175,6 +175,22 @@
                  </td>
             </tr>
 
+            <tr>
+                <td colspan="2"><hr></td>
+            </tr>
+
+            <tr>
+                <td><label for="modem">Modem</label></td>
+                <td>
+                    <select id="modem">
+                        <option value="-1">None</option>
+                        <option value="0">UART0</option>
+                        <option value="1">UART1</option>
+                        <option value="2">UART2</option>
+                        <option value="3">UART3</option>
+                    </select>
+                 </td>
+            </tr>
 
             <tr>
                 <td colspan="2"><hr></td>

--- a/debug.html
+++ b/debug.html
@@ -183,10 +183,10 @@
                 <td><label for="modem">Modem</label></td>
                 <td>
                     <select id="modem">
-                        <option value="0">None</option>
-                        <option value="2">UART1</option>
-                        <option value="3">UART2</option>
-                        <option value="4">UART3</option>
+                        <option value="none">None</option>
+                        <option value="1">UART1</option>
+                        <option value="2">UART2</option>
+                        <option value="3">UART3</option>
                     </select>
                  </td>
             </tr>

--- a/debug.html
+++ b/debug.html
@@ -183,11 +183,10 @@
                 <td><label for="modem">Modem</label></td>
                 <td>
                     <select id="modem">
-                        <option value="-1">None</option>
-                        <option value="0">UART0</option>
-                        <option value="1">UART1</option>
-                        <option value="2">UART2</option>
-                        <option value="3">UART3</option>
+                        <option value="0">None</option>
+                        <option value="2">UART1</option>
+                        <option value="3">UART2</option>
+                        <option value="4">UART3</option>
                     </select>
                  </td>
             </tr>

--- a/docs/modem.md
+++ b/docs/modem.md
@@ -20,8 +20,6 @@ Limitations:
 
 At **https://copy.sh/v86/**, enable the Modem by selecting a COM-Port (UART) from its menu (default: `None`).
 
-`UART0` should be avoided as it is used for the serial console, only use it if you're sure that it is available in your configuration.
-
 ### Code-based setup
 
 Use the optional `modem` field in the v86 `options` Object to enable the Modem:
@@ -30,18 +28,18 @@ Use the optional `modem` field in the v86 `options` Object to enable the Modem:
 const options = {
     // ...
     modem: {
-        uart: 1
+        uart: 2
     },
     // ...
 };
-let emulator = new V86(options);
+const emulator = new V86(options);
 ```
 
 The `modem` field defines an Object with the supported Modem settings:
 
 | Setting                     | Type    | Description |
 | :-------------------------- | :------ | :---------- |
-| **uart**                    | number  | Required, selects the UART that the Modem is connected to: 0, 1, 2 or 3. The selected UART is automatically enabled in the v86 device tree. |
+| **uart**                    | number  | Required, selects the UART that the Modem is connected to: 1, 2, 3 or 4 (for UART0 to UART3, respectively). The selected UART is automatically enabled in the v86 device tree. |
 | **phonebook**               | Object  | Optional, maps address strings received in dial commands to WebSocket address strings. |
 
 #### Example `modem` settings
@@ -49,10 +47,10 @@ The `modem` field defines an Object with the supported Modem settings:
 Install Modem on UART1 and map dial address `123` to WebSocket address `wss://example.com:5678`:
 
 ```javascript
-let example_1 = new V86({
+const emulator = new V86({
    // ...
    modem: {
-       uart: 1,
+       uart: 2,
        phonebook: {"123": "wss://example.com:5678"}
    }
 });
@@ -62,7 +60,7 @@ let example_1 = new V86({
 
 The v86 Modem behaves as described in V.250 when decoding command lines, executing commmands or when generating informational and result code messages.
 
-All command lines have the common basic syntax
+All command lines share the common basic syntax:
 
 * **AT &lt;CMD&gt;[&lt;ARG&gt;] [&lt;CMD&gt;[&lt;ARG&gt;] ...] &lt;CR&gt;**
 
@@ -72,7 +70,7 @@ Maximum accepted command line length is 256 characters.
 
 ### AT command set
 
-This Modem emulation implements all V.250 **base** commands plus a few from the Telit command set (in order to simplify the command syntax).
+This Modem emulation implements all V.250 **baseline** commands plus a few from the Telit command set (in order to simplify the command syntax).
 
 Some commands (like **L**, **M** and **X**) have no effect in this emulation.
 
@@ -121,7 +119,7 @@ If the optional **;** is present at the end of the dial command then the Modem w
 The Modem follows these rules to translate **&lt;dial-address&gt;** into a WebSocket address string:
 
 * It first checks whether its phonebook contains a matching entry for **&lt;dial-address&gt;** and, if it exists, uses that entry's mapped value as the WebSocket address string.
-* Otherwise, if **&lt;dial-address&gt;** is a sequence of 12 to 17 digits then it is interpreted as a digit-encoded IPv4 address with an optional port number. The first 12 digits are split into 4 groups of 3 digits each, each group represents one of the 4 tuples of the IPv4 address (zero-padded, left to right). The remaining 0 to 5 digits represent the optional port number. For example, `1921680330022345` is decoded into IPv4 address and port `192.168.33.2:2345`.
+* Otherwise, if **&lt;dial-address&gt;** is an IPv4/Port-address in either dotted-IP:Port or zero-padded IP/Port notation then it is translated into an equivalent WebSocket address (the Port number is always optional). Note that in **dotted-IP:Port notation**, any non-digit and non-whitespace characters may be used as separator characters for the four IPv4 octets and the Port number. A **zero-padded IP/Port-number** is a sequence of 12 to 17 digits where the four IPv4 octets are encoded as 3-digit, zero-padded numbers followed by an optional Port number (for example, `1921680330021111` is translated into IPv4 address and Port `192.168.33.2:1111`).
 * If **&lt;dial-address&gt;** is not defined in the phonebook and it is also not a digit-encoded IPv4 address, then **&lt;dial-address&gt;** is directly used as the WebSocket address string.
 
 If the translated WebSocket address string does not already start with `ws://` or `wss://`, then
@@ -141,6 +139,7 @@ then all of these dial commands will connect to same WebSocket server:
 
 ```
 AT D 111.22.3.44:56789
+AT D 111-22-3-44-56789
 AT D example.com:56789
 AT D "example.com:56789"        # NOTE: use quotes if your address starts with a "P", "T, "p" or a "t"
 AT D ws://example.com:56789
@@ -189,17 +188,19 @@ Of course, any suitable application can be passed to `websocketd` to execute, in
 Demonstrates a WebSocket-PPP concentrator for up to 4 simultaneously connected Modems using `pppd`.
 
 > [!NOTE]
-> The limit of 4 is arbitrary, this example supports any limit in the range of 1 to 253 connections, though the method used to manage the pool gets unpractical for larger pool sizes.
+> The limit of 4 connections is arbitrary, this example supports any limit in the range of 1 to 253 connections, though the method used to manage the pool gets unpractical for larger pool sizes.
 
 Create a script file `wsppp.sh` with the following content, note the variables at the top which you will likely have to adjust to your host's environment:
 
 ```bash
 #!/bin/bash
 
+# WS_PORT: WebSocket server port number
 # ETH_IF: your host's ethernet interface name, for example: "eth0"
 # SUBNET: any private /24 address space that is not used on your host's network
 # LOCAL_IP: should be the first IP in SUBNET (ending on ".1"), must not be used in the pool
 # REMOTE_IP_POOL: pool of client IPs, any subset of the remaining IPs in SUBNET (ending on ".2" ... ".254")
+WS_PORT=23456
 ETH_IF=enp0s3
 SUBNET=192.168.100.0/24
 LOCAL_IP=192.168.100.1
@@ -222,7 +223,9 @@ if [[ $# -gt 0 ]]; then
             break
         fi
     done
-    [ -z "$REMOTE_IP" ] && exit 1
+    if [[ -z "$REMOTE_IP" ]]; then
+        exit 1
+    fi
     # exec pppd (exec never returns), arguments:
     # - nodetach, notty, local: do not fork into background, transport is a raw stream
     # - noauth: do not require the peer to authenticate itself
@@ -253,11 +256,12 @@ iptables -t nat -A POSTROUTING -o "$ETH_IF" -s "$SUBNET" -j MASQUERADE
 iptables -A FORWARD -i ppp+ -o "$ETH_IF" -j ACCEPT
 iptables -A FORWARD -i "$ETH_IF" -o ppp+ -m state --state RELATED,ESTABLISHED -j ACCEPT
 
-# call websocketd, limit number of simultaneous WebSocket connections to tbe size of the pool
-websocketd -binary --maxforks ${#REMOTE_IP_POOL[@]} --port 23456 "$0" --exec-pppd
+# execute websocketd, limit number of simultaneous WebSocket connections to tbe pool size
+# for each accepted WebSocket connection, execute this script again but with command line option "--exec-pppd"
+websocketd -binary --maxforks ${#REMOTE_IP_POOL[@]} --port $WS_PORT "$0" --exec-pppd
 ```
 
-Make the script executable using `chmod +x wsppp.sh`, then start the WebSocket server using:
+Make the script executable using `chmod +x wsppp.sh`, then start the WebSocket server as root using:
 
 ```bash
 sudo ./wsppp.sh

--- a/docs/modem.md
+++ b/docs/modem.md
@@ -1,0 +1,272 @@
+# v86 Modem device
+
+The v86 Modem device emulates a Hayes-compatible dial-up Modem connected by UART, main features:
+
+* V.250-compatible command-line interpreter with support for a subset of the V.250 AT command set
+* Full UART support (guest's output signals: DTR/RTS/TxD, input: DCD/DSR/RING/CTS/RxD)
+* RTS/CTS hardware flow control, DCD online signalling, hangup on DTR low
+* Online escape sequence `+++`
+* WebSocket-based backend with upstream buffering
+* Phonebook to simplify dial destination addresses
+
+Limitations:
+
+* Inbound calls (RING, ATA, S0 and S1) are currently not supported
+* XON/XOFF software flow control is not implemented
+
+## Modem setup
+
+### Web interface setup
+
+At **https://copy.sh/v86/**, enable the Modem by selecting a COM-Port (UART) from its menu (default: `None`).
+
+`UART0` should be avoided as it is used for the serial console, only use it if you're sure that it is available in your configuration.
+
+### Code-based setup
+
+Use the optional `modem` field in the v86 `options` Object to enable the Modem:
+
+```javascript
+const options = {
+    // ...
+    modem: {
+        uart: 1
+    },
+    // ...
+};
+let emulator = new V86(options);
+```
+
+The `modem` field defines an Object with the supported Modem settings:
+
+| Setting                     | Type    | Description |
+| :-------------------------- | :------ | :---------- |
+| **uart**                    | number  | Required, selects the UART that the Modem is connected to: 0, 1, 2 or 3. The selected UART is automatically enabled in the v86 device tree. |
+| **phonebook**               | Object  | Optional, maps address strings received in dial commands to WebSocket address strings. |
+
+#### Example `modem` settings
+
+Install Modem on UART1 and map dial address `123` to WebSocket address `wss://example.com:5678`:
+
+```javascript
+let example_1 = new V86({
+   // ...
+   modem: {
+       uart: 1,
+       phonebook: {"123": "wss://example.com:5678"}
+   }
+});
+```
+
+## AT command interpreter
+
+The v86 Modem behaves as described in V.250 when decoding command lines, executing commmands or when generating informational and result code messages.
+
+All command lines have the common basic syntax
+
+* **AT &lt;CMD&gt;[&lt;ARG&gt;] [&lt;CMD&gt;[&lt;ARG&gt;] ...] &lt;CR&gt;**
+
+where **&lt;CMD&gt;** is one or more non-numerical characters and **&lt;ARG&gt;** and optional sequence of digits (with the exception of the [Dial command](#dial-command) and the [S-Register commands](#s-register-commands)). All whitespace is ignored and command names are treated case-insensitive. Commands **A**, **D**, **H**, **Z** and **&F** terminate the command line, all other commands can be freely combined in any order.
+
+Maximum accepted command line length is 256 characters.
+
+### AT command set
+
+This Modem emulation implements all V.250 **base** commands plus a few from the Telit command set (in order to simplify the command syntax).
+
+Some commands (like **L**, **M** and **X**) have no effect in this emulation.
+
+| Command | Description | Reference    |
+| :------ | :---------- | :----------- |
+| **A**   | Answer      | [V250] 6.3.5 |
+| **D ... [;]**<br>**DP ... [;]**<br>**DT ... [;]** | Dial using preset dialling method, see [Dial command](#dial-command)<br>Dial using pulse dialling<br>Dial using tone dialling | [V250] 6.3.1 |
+| **E[1]**<br>**E0** | Echo on (default)<br>Echo off | [V250] 6.2.4 |
+| **H[0]** | Hook control | [V250] 6.3.6 |
+| **I3** | Request identification information | [V250] 6.1.3 |
+| **L[0-3]** | Monitor speaker loudness | [V250] 6.3.13 |
+| **M[0-2]** | Monitor speaker mode | [V250] 6.3.14 |
+| **O[0]** | Return to online data state | [V250] 6.3.7 |
+| **P** | Select pulse dialling (default) | [V250] 6.3.3 |
+| **Q[0]**<br>**Q1** | Transmit result codes (default)<br>Suppress result codes | [V250] 6.2.5 |
+| **S0?, S0=`n`** | Automatic answer (default 0) | [V250] 6.3.8 |
+| **S1?, S1=`n`** | Ring counter (default 0) | [TELIT] 3.5.3.6.2 |
+| **S2?, S2=`n`** | Escape Character (default 43=`+`) | [TELIT] 3.5.3.6.3 |
+| **S3?, S3=`n`** | Command line termination character (default 13=`\r`) | [V250] 6.2.1 |
+| **S4?, S4=`n`** | Response formatting character (default 10=`\n`) | [V250] 6.2.2 |
+| **S5?, S5=`n`** | Command line editing character (default 8=`\b`) | [V250] 6.2.3 |
+| **T** | Select tone dialling | [V250] 6.3.2 |
+| **V[0]**<br>**V1** | Limited response format<br>Verbose response format (default) | [V250] 6.2.6 |
+| **X[0-4]** | Result code selection | [V250] 6.2.7 |
+| **Z[0]** | Reset to default configuration | [V250] 6.1.1 |
+| **&C[1]**<br>**&C0** | DCD is on when modem is online (default)<br>DCD is always on | [V250] 6.2.8 |
+| **&D0**<br>**&D1**<br>**&D2** | Ignore DTR<br>DTR low: Enter command mode, stay online<br>DTR low: Enter command mode, go offline (default) | [V250] 6.2.9 |
+| **&F** | Set to factory-defined configuration | [V250] 6.1.2 |
+| **&K0**<br>**&K3** | Disable flow Control<br>Use RTS/CTS flow control (default) | [TELIT] 3.5.3.2.9 |
+
+### Dial command
+
+Dial command syntax:
+
+* **D ["] &lt;dial-address&gt; ["] [;]**  
+  Dial **&lt;dial-address&gt;** using preset dialling method, see commands **P** and **T** (default: pulse dialling)
+* **DP ["] &lt;dial-address&gt; ["] [;]**  
+  Dial **&lt;dial-address&gt;** using pulse dialling (`ws://`)
+* **DT ["] &lt;dial-address&gt; ["] [;]**  
+  Dial **&lt;dial-address&gt;** using tone dialling (`wss://`)
+
+If the optional **;** is present at the end of the dial command then the Modem will stay in AT command mode after successfull command completion, otherwise it will switch into online data mode.
+
+**Dial address translation**
+
+The Modem follows these rules to translate **&lt;dial-address&gt;** into a WebSocket address string:
+
+* It first checks whether its phonebook contains a matching entry for **&lt;dial-address&gt;** and, if it exists, uses that entry's mapped value as the WebSocket address string.
+* Otherwise, if **&lt;dial-address&gt;** is a sequence of 12 to 17 digits then it is interpreted as a digit-encoded IPv4 address with an optional port number. The first 12 digits are split into 4 groups of 3 digits each, each group represents one of the 4 tuples of the IPv4 address (zero-padded, left to right). The remaining 0 to 5 digits represent the optional port number. For example, `1921680330022345` is decoded into IPv4 address and port `192.168.33.2:2345`.
+* If **&lt;dial-address&gt;** is not defined in the phonebook and it is also not a digit-encoded IPv4 address, then **&lt;dial-address&gt;** is directly used as the WebSocket address string.
+
+If the translated WebSocket address string does not already start with `ws://` or `wss://`, then
+
+* `ws://` is prepended if **pulse dialling** is currently selected and
+* `wss://` if **tone dialling** is selected.
+
+**Dial command examples**
+
+Assuming that:
+
+* host name `example.com` had the IPv4 address `111.22.3.44`,
+* the Modem is configured to use pulse dialling by default, and
+* the Modem's phonbook is defined as `{"911": "ws://example.com:56789"}`,
+
+then all of these dial commands will connect to same WebSocket server:
+
+```
+AT D 111.22.3.44:56789
+AT D example.com:56789
+AT D "example.com:56789"        # NOTE: use quotes if your address starts with a "P", "T, "p" or a "t"
+AT D ws://example.com:56789
+AT DP ws://111.22.3.44:56789
+AT DT ws://111.22.3.44:56789    # NOTE: "ws://" overrides "DT"
+AT D 11102200304456789
+AT D 911
+```
+
+### S-Register commands
+
+The Modem supports several S-Registers **S0**, **S1**, ..., **S5**, use these commands for read and write access:
+
+* **S&lt;reg&gt;?**  
+  Generates a response with the current value of register **S&lt;reg&gt;** as a zero-padded, three-digit number.
+* **S&lt;reg&gt;=&lt;val&gt;**  
+  Sets the value of register **S&lt;reg&gt;** to **&lt;val&gt;**.
+
+## Example WebSocket servers
+
+A WebSocket server is required to provide a dial-in point for the v86 Modem. The bytestream from and to the Modem is transported in binary WebSocket messages. Closing the WebSocket connection corresponds to the Modem hanging up (and vice versa).
+
+The following examples were tested under Debian GNU/Linux 12 (Bookworm). All commands used in the examples below (like `websocketd`, `pppd` etc.) are standard Debian packages.
+
+> [!TIP]
+> `websocketd` connects programs with WebSocket channels using plain pipes. Some programs (like `login` or `bash`) cannot run on a plain pipe but expect a pseudoterminal (PTY) instead (they rely on line editing and signals, for example). One possibility to create the PTY for such programs is to wrap their command line in a call to `script -qc "<CMDLINE>" /dev/null`, as used in some of the examples below.
+
+### Example 1: login
+
+To start a WebSocket server on port 23456 that serves a new login shell for each WebSocket client that connects use:
+
+```bash
+websocketd -binary --port 23456 script -qc "sudo TERM=$TERM login" /dev/null
+```
+
+To serve a bash shell instead that behaves like a login shell:
+
+```bash
+websocketd -binary --port 23456 script -qc "env -i HOME=$HOME TERM=$TERM PATH=/usr/bin:/bin bash -l" /dev/null
+```
+
+Of course, any suitable application can be passed to `websocketd` to execute, including any script files. Some examples besides `login` and `bash` for such applications are `lynx`, `mutt`, `telnet`, `sz` and `pppd`.
+
+### Example 2: PPP
+
+Demonstrates a WebSocket-PPP concentrator for up to 4 simultaneously connected Modems using `pppd`.
+
+> [!NOTE]
+> The limit of 4 is arbitrary, this example supports any limit in the range of 1 to 253 connections, though the method used to manage the pool gets unpractical for larger pool sizes.
+
+Create a script file `wsppp.sh` with the following content, note the variables at the top which you will likely have to adjust to your host's environment:
+
+```bash
+#!/bin/bash
+
+# ETH_IF: your host's ethernet interface name, for example: "eth0"
+# SUBNET: any private /24 address space that is not used on your host's network
+# LOCAL_IP: should be the first IP in SUBNET (ending on ".1"), must not be used in the pool
+# REMOTE_IP_POOL: pool of client IPs, any subset of the remaining IPs in SUBNET (ending on ".2" ... ".254")
+ETH_IF=enp0s3
+SUBNET=192.168.100.0/24
+LOCAL_IP=192.168.100.1
+REMOTE_IP_POOL=(
+    192.168.100.2
+    192.168.100.3
+    192.168.100.4
+    192.168.100.5
+)
+
+if [[ $# -gt 0 ]]; then
+    # ensure that this script was invoked with command line argument "--exec-pppd"
+    if [[ $# -ne 1 || "$1" != "--exec-pppd" ]]; then
+        exit 1
+    fi
+    # fetch unused IP from pool or abort if all IPs are in use
+    for i_ip in "${REMOTE_IP_POOL[@]}"; do
+        if ! ip route | grep -q "$i_ip dev ppp"; then
+            REMOTE_IP="$i_ip"
+            break
+        fi
+    done
+    [ -z "$REMOTE_IP" ] && exit 1
+    # exec pppd (exec never returns), arguments:
+    # - nodetach, notty, local: do not fork into background, transport is a raw stream
+    # - noauth: do not require the peer to authenticate itself
+    # - mtu, mru: set maximum PPP payload size to 1400 bytes to avoid TCP fragmentation
+    # - asyncmap 0, escape 0: disable control character escaping
+    # - noccp, nobsdcomp, nodeflate, nopcomp, noaccomp: disable compression support
+    # - lcp-echo-interval 10, lcp-echo-failure 3: monitor that the peer is still reachable
+    # - ms-dns <DNS-IP>: advertise DNS server to the peer
+    exec pppd nodetach notty local noauth noproxyarp \
+        mtu 1400 mru 1400 \
+        asyncmap 0 escape 0 \
+        noccp nobsdcomp nodeflate nopcomp noaccomp \
+        lcp-echo-interval 10 lcp-echo-failure 3 \
+        ms-dns 8.8.4.4 ms-dns 8.8.8.8 \
+        "$LOCAL_IP:$REMOTE_IP"
+fi
+
+# install common NAT rules for all PPP interfaces (ppp0, ppp1, ...), remove rules when this script exits
+cleanup() {
+    iptables -t nat -D POSTROUTING -o "$ETH_IF" -s "$SUBNET" -j MASQUERADE
+    iptables -D FORWARD -i ppp+ -o "$ETH_IF" -j ACCEPT
+    iptables -D FORWARD -i "$ETH_IF" -o ppp+ -m state --state RELATED,ESTABLISHED -j ACCEPT
+}
+trap cleanup EXIT
+
+sysctl -q net.ipv4.ip_forward=1
+iptables -t nat -A POSTROUTING -o "$ETH_IF" -s "$SUBNET" -j MASQUERADE
+iptables -A FORWARD -i ppp+ -o "$ETH_IF" -j ACCEPT
+iptables -A FORWARD -i "$ETH_IF" -o ppp+ -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+# call websocketd, limit number of simultaneous WebSocket connections to tbe size of the pool
+websocketd -binary --maxforks ${#REMOTE_IP_POOL[@]} --port 23456 "$0" --exec-pppd
+```
+
+Make the script executable using `chmod +x wsppp.sh`, then start the WebSocket server using:
+
+```bash
+sudo ./wsppp.sh
+```
+
+## Links
+
+* [V250] [V.250: Serial asynchronous automatic dialling and control](https://www.itu.int/rec/T-REC-V.250-200307-I/en)
+* [TELIT] [AT Commands Reference Guide](https://docs.rs-online.com/c5f6/0900766b81541066.pdf)
+* [websocketd](http://websocketd.com/), also [websockify](https://linux.die.net/man/1/websockify)
+* [WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)
+* [WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)

--- a/docs/modem.md
+++ b/docs/modem.md
@@ -28,7 +28,7 @@ Use the optional `modem` field in the v86 `options` Object to enable the Modem:
 const options = {
     // ...
     modem: {
-        uart: 2
+        uart: 1
     },
     // ...
 };
@@ -39,7 +39,7 @@ The `modem` field defines an Object with the supported Modem settings:
 
 | Setting                     | Type    | Description |
 | :-------------------------- | :------ | :---------- |
-| **uart**                    | number  | Required, selects the UART that the Modem is connected to: 1, 2, 3 or 4 (for UART0 to UART3, respectively). The selected UART is automatically enabled in the v86 device tree. |
+| **uart**                    | number  | Required, selects the UART that the Modem is connected to: 0, 1, 2 or 3 (for UART0 to UART3, respectively). The selected UART is automatically enabled in the v86 device tree. |
 | **phonebook**               | Object  | Optional, maps address strings received in dial commands to WebSocket address strings. |
 
 #### Example `modem` settings
@@ -50,7 +50,7 @@ Install Modem on UART1 and map dial address `123` to WebSocket address `wss://ex
 const emulator = new V86({
    // ...
    modem: {
-       uart: 2,
+       uart: 1,
        phonebook: {"123": "wss://example.com:5678"}
    }
 });

--- a/index.html
+++ b/index.html
@@ -281,6 +281,23 @@
             </tr>
 
             <tr>
+                <td><label for="modem">Modem</label></td>
+                <td>
+                    <select id="modem">
+                        <option value="-1">None</option>
+                        <option value="0">UART0</option>
+                        <option value="1">UART1</option>
+                        <option value="2">UART2</option>
+                        <option value="3">UART3</option>
+                    </select>
+                 </td>
+            </tr>
+
+            <tr>
+                <td colspan="2"><hr></td>
+            </tr>
+
+            <tr>
                 <td><label for="disable_audio">Disable audio</label></td>
                 <td>
                     <input id="disable_audio" type="checkbox"><br>

--- a/index.html
+++ b/index.html
@@ -284,10 +284,10 @@
                 <td><label for="modem">Modem</label></td>
                 <td>
                     <select id="modem">
-                        <option value="0">None</option>
-                        <option value="2">UART1</option>
-                        <option value="3">UART2</option>
-                        <option value="4">UART3</option>
+                        <option value="none">None</option>
+                        <option value="1">UART1</option>
+                        <option value="2">UART2</option>
+                        <option value="3">UART3</option>
                     </select>
                  </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -284,11 +284,10 @@
                 <td><label for="modem">Modem</label></td>
                 <td>
                     <select id="modem">
-                        <option value="-1">None</option>
-                        <option value="0">UART0</option>
-                        <option value="1">UART1</option>
-                        <option value="2">UART2</option>
-                        <option value="3">UART3</option>
+                        <option value="0">None</option>
+                        <option value="2">UART1</option>
+                        <option value="3">UART2</option>
+                        <option value="4">UART3</option>
                     </select>
                  </td>
             </tr>

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -14,6 +14,7 @@ const DEFAULT_VGA_MEMORY_SIZE = 8;
 const DEFAULT_BOOT_ORDER = 0;
 const DEFAULT_MTU = 1500;
 const DEFAULT_NIC_TYPE = "ne2k";
+const DEFAULT_MODEM_UART = 0;
 
 const MAX_ARRAY_BUFFER_SIZE_MB = 2000;
 
@@ -2182,6 +2183,10 @@ function start_emulation(profile, query_args)
         settings.relay_url = query_args.get("relay_url");
         settings.disable_jit = bool_arg(query_args.get("disable_jit"));
         settings.disable_audio = bool_arg(query_args.get("mute"));
+        if(query_args.has("modem"))
+        {
+            settings.modem = { modem_uart: parseInt(query_args.get("modem"), 10) || 0 };
+        }
     }
 
     if(!settings.relay_url)
@@ -2340,11 +2345,12 @@ function start_emulation(profile, query_args)
         }
         if(settings.mtu !== DEFAULT_MTU) new_query_args.set("mtu", settings.mtu.toString());
 
-        const modem_uart = parseInt($("modem").value, 10) || -1;
-        if(modem_uart >= 0 && modem_uart < 4)
+        const modem_uart = parseInt($("modem").value, 10) || DEFAULT_MODEM_UART;
+        if(!settings.modem || modem_uart !== DEFAULT_MODEM_UART)
         {
             settings.modem = {uart: modem_uart};
         }
+        if(settings.modem.uart !== DEFAULT_MODEM_UART) new_query_args.set("modem", modem_uart.toString());
     }
 
     if(!query_args)

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -2075,6 +2075,7 @@ function start_emulation(profile, query_args)
         settings.vga_memory_size = profile.vga_memory_size;
         settings.boot_order = profile.boot_order;
         settings.net_device_type = profile.net_device_type;
+        settings.modem = profile.modem;
 
         if(!DEBUG && profile.homepage)
         {
@@ -2339,6 +2340,11 @@ function start_emulation(profile, query_args)
         }
         if(settings.mtu !== DEFAULT_MTU) new_query_args.set("mtu", settings.mtu.toString());
 
+        const modem_uart = parseInt($("modem").value, 10) || -1;
+        if(modem_uart >= 0 && modem_uart < 4)
+        {
+            settings.modem = {uart: modem_uart};
+        }
     }
 
     if(!query_args)
@@ -2358,6 +2364,7 @@ function start_emulation(profile, query_args)
             cors_proxy: settings.cors_proxy,
             mtu: settings.mtu
         },
+        modem: settings.modem,
         autostart: true,
 
         memory_size: settings.memory_size,

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1774,6 +1774,7 @@ function onload()
     if(query_args.has("boot_order")) $("boot_order").value = query_args.get("boot_order");
     if(query_args.has("net_device_type")) $("net_device_type").value = query_args.get("net_device_type");
     if(query_args.has("mtu")) $("mtu").value = query_args.get("mtu");
+    if(query_args.has("modem")) $("modem").value = query_args.get("modem");
 
     for(const dev of ["fda", "fdb"])
     {
@@ -2185,7 +2186,7 @@ function start_emulation(profile, query_args)
         settings.disable_audio = bool_arg(query_args.get("mute"));
         if(query_args.has("modem"))
         {
-            settings.modem = { modem_uart: parseInt(query_args.get("modem"), 10) || 0 };
+            settings.modem = { uart: parseInt(query_args.get("modem"), 10) || 0 };
         }
     }
 

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -14,7 +14,6 @@ const DEFAULT_VGA_MEMORY_SIZE = 8;
 const DEFAULT_BOOT_ORDER = 0;
 const DEFAULT_MTU = 1500;
 const DEFAULT_NIC_TYPE = "ne2k";
-const DEFAULT_MODEM_UART = 0;
 
 const MAX_ARRAY_BUFFER_SIZE_MB = 2000;
 
@@ -2184,9 +2183,14 @@ function start_emulation(profile, query_args)
         settings.relay_url = query_args.get("relay_url");
         settings.disable_jit = bool_arg(query_args.get("disable_jit"));
         settings.disable_audio = bool_arg(query_args.get("mute"));
+
         if(query_args.has("modem"))
         {
-            settings.modem = { uart: parseInt(query_args.get("modem"), 10) || 0 };
+            const modem = parseInt(query_args.get("modem"), 10);
+            if(!Number.isNaN(modem) && modem >= 0 && modem < 4)
+            {
+                settings.modem = {uart: modem};
+            }
         }
     }
 
@@ -2346,12 +2350,12 @@ function start_emulation(profile, query_args)
         }
         if(settings.mtu !== DEFAULT_MTU) new_query_args.set("mtu", settings.mtu.toString());
 
-        const modem_uart = parseInt($("modem").value, 10) || DEFAULT_MODEM_UART;
-        if(!settings.modem || modem_uart !== DEFAULT_MODEM_UART)
+        const modem = parseInt($("modem").value, 10);
+        if(!Number.isNaN(modem) && modem >= 0 && modem < 4)
         {
-            settings.modem = {uart: modem_uart};
+            settings.modem = {uart: modem};
+            new_query_args.set("modem", modem.toString());
         }
-        if(settings.modem.uart !== DEFAULT_MODEM_UART) new_query_args.set("modem", modem_uart.toString());
     }
 
     if(!query_args)

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -88,7 +88,6 @@ const ESC_MAX_DELAY_MS = 200;
 const CMDLINE_BUF_SIZE = 256;
 
 const SEND_BUF_SIZE = 512;
-const SEND_BUF_SAMPLE_INTERVAL_MS = 10;
 const SEND_BUF_MAX_IDLE_TIME_MS = 5;
 
 // matches all strings that start with "ws://" or "wss://" (case-insensitive)
@@ -122,7 +121,7 @@ export function Modem(bus, options)
     this.in_data_mode = false;
     this.data_mode_send_buffer = new Uint8Array(SEND_BUF_SIZE);
     this.data_mode_send_cursor = 0;
-    this.data_mode_send_inverval = null;
+    this.data_mode_send_timer = null;
     this.data_mode_esc_timer = null;
 
     this.phonebook = options.phonebook || {};
@@ -131,9 +130,9 @@ export function Modem(bus, options)
 
     this.reset();
 
-    this.bus.register("serial" + this.uart + "-data-terminal-ready-output", this.uart_dtr_changed, this);
-    this.bus.register("serial" + this.uart + "-request-to-send-output", this.uart_rts_changed, this);
-    this.bus.register("serial" + this.uart + "-output-byte", this.uart_byte_received, this);
+    this.bus.register(`serial${this.uart}-data-terminal-ready-output`, this.uart_dtr_changed, this);
+    this.bus.register(`serial${this.uart}-request-to-send-output`, this.uart_rts_changed, this);
+    this.bus.register(`serial${this.uart}-output-byte`, this.uart_byte_received, this);
 }
 
 Modem.prototype.initialize = function()
@@ -148,22 +147,32 @@ Modem.prototype.initialize = function()
 Modem.prototype.destroy = function()
 {
     this.destroyed = true;
-    this.bus.unregister("serial" + this.uart + "-data-terminal-ready-output", this.uart_dtr_changed);
-    this.bus.unregister("serial" + this.uart + "-request-to-send-output", this.uart_rts_changed);
-    this.bus.unregister("serial" + this.uart + "-output-byte", this.uart_byte_received);
-    if(this.data_mode_send_inverval !== null)
+    this.bus.unregister(`serial${this.uart}-data-terminal-ready-output`, this.uart_dtr_changed);
+    this.bus.unregister(`serial${this.uart}-request-to-send-output`, this.uart_rts_changed);
+    this.bus.unregister(`serial${this.uart}-output-byte`, this.uart_byte_received);
+    this.cancel_data_mode_send_timer();
+    this.cancel_data_mode_esc_timer();
+    if(this.socket)
     {
-        clearInterval(this.data_mode_send_inverval);
-        this.data_mode_send_inverval = null;
+        this.socket.close();
     }
+};
+
+Modem.prototype.cancel_data_mode_send_timer = function()
+{
+    if(this.data_mode_send_timer !== null)
+    {
+        clearTimeout(this.data_mode_send_timer);
+        this.data_mode_send_timer = null;
+    }
+};
+
+Modem.prototype.cancel_data_mode_esc_timer = function()
+{
     if(this.data_mode_esc_timer !== null)
     {
         clearTimeout(this.data_mode_esc_timer);
         this.data_mode_esc_timer = null;
-    }
-    if(this.socket)
-    {
-        this.socket.close();
     }
 };
 
@@ -289,11 +298,7 @@ Modem.prototype.uart_rts_changed = function(rts_state)
  */
 Modem.prototype.uart_byte_received = function(data)
 {
-    if(this.data_mode_esc_timer !== null)
-    {
-        clearTimeout(this.data_mode_esc_timer);
-        this.data_mode_esc_timer = null;
-    }
+    this.cancel_data_mode_esc_timer();
     if(this.in_data_mode)
     {
         this.data_mode_uart_recv(data);
@@ -310,13 +315,9 @@ Modem.prototype.enter_cli_mode = function()
     {
         dbg_log(`switching to command mode`, LOG_MODEM);
         this.in_data_mode = false;
+        this.cancel_data_mode_esc_timer();
+        this.cancel_data_mode_send_timer();
         this.data_mode_flush();
-        if(this.data_mode_send_inverval !== null)
-        {
-            clearInterval(this.data_mode_send_inverval);
-            this.data_mode_send_inverval = null;
-        }
-
         this.uart_set_dsr(true);
         this.uart_set_cts(true);
         this.uart_set_ring(false);
@@ -333,13 +334,7 @@ Modem.prototype.enter_data_mode = function()
     {
         dbg_log(`switching to data mode`, LOG_MODEM);
         this.in_data_mode = true;
-        this.data_mode_send_inverval = setInterval(() => {
-            if(this.data_mode_send_cursor && (performance.now() - this.uart_recv_tm) > SEND_BUF_MAX_IDLE_TIME_MS)
-            {
-                this.data_mode_flush();
-            }
-        }, SEND_BUF_SAMPLE_INTERVAL_MS);
-
+        this.data_mode_send_cursor = 0;
         this.uart_set_ring(false);
         if(!this.dcd_always_on)
         {
@@ -370,21 +365,35 @@ Modem.prototype.data_mode_send = function(data)
 {
     if(this.socket)
     {
+        this.cancel_data_mode_send_timer();
         this.data_mode_send_buffer[this.data_mode_send_cursor++] = data;
         if(this.data_mode_send_cursor === this.data_mode_send_buffer.byteLength)
         {
             this.data_mode_flush();
+        }
+        else
+        {
+            this.data_mode_send_timer = setTimeout(() => {
+                this.data_mode_flush();
+            }, SEND_BUF_MAX_IDLE_TIME_MS);
         }
     }
 };
 
 Modem.prototype.data_mode_flush = function()
 {
-    if(this.data_mode_send_cursor && this.socket)
+    if(this.data_mode_send_cursor && this.socket && this.socket.readyState === WebSocket.OPEN)
     {
-        this.socket.send(this.data_mode_send_buffer.slice(0, this.data_mode_send_cursor));
-        this.data_mode_send_cursor = 0;
+        if(this.data_mode_send_cursor === this.data_mode_send_buffer.byteLength)
+        {
+            this.socket.send(this.data_mode_send_buffer);
+        }
+        else
+        {
+            this.socket.send(this.data_mode_send_buffer.subarray(0, this.data_mode_send_cursor));
+        }
     }
+    this.data_mode_send_cursor = 0;
 };
 
 /**
@@ -605,7 +614,6 @@ Modem.prototype.cli_exec_dial = function(dial_address, offset)
 
     this.socket.binaryType = "arraybuffer";
     this.socket.addEventListener("open", (event) => {
-        this.data_mode_send_cursor = 0;
         if(enter_data_mode)
         {
             this.enter_data_mode();

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -682,16 +682,13 @@ Modem.prototype.cli_exec = function(cmdline)
             }
         }
 
-        if(DEBUG)
+        if(arg !== undefined)
         {
-            if(arg !== undefined)
-            {
-                dbg_log(`AT command: "${cmd}${arg}"`, LOG_MODEM);
-            }
-            else
-            {
-                dbg_log(`AT command: "${cmd}"`, LOG_MODEM);
-            }
+            dbg_log(`AT command: "${cmd}${arg}"`, LOG_MODEM);
+        }
+        else
+        {
+            dbg_log(`AT command: "${cmd}"`, LOG_MODEM);
         }
 
         switch(cmd)

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -114,6 +114,7 @@ export function Modem(bus, options)
     this.cli_buffer = new Uint8Array(CMDLINE_BUF_SIZE);
 
     // state that is not defined in this.reset():
+    this.destroyed = false;
     this.dtr_state = false;
     this.rts_state = false;
     this.sreg = new Uint8Array(6);
@@ -130,66 +131,41 @@ export function Modem(bus, options)
 
     this.reset();
 
-    this.bus.register("serial" + this.uart + "-data-terminal-ready-output", function(dtr_state)
-    {
-        dtr_state = !!dtr_state;
-        if(this.dtr_state !== dtr_state)
-        {
-            dbg_log(`DTR=${dtr_state}`, LOG_MODEM);
-            this.dtr_state = dtr_state;
-            if(this.socket && !dtr_state)
-            {
-                if(this.dtr_low_behaviour === DTR_LOW_KEEP_CONN)
-                {
-                    this.enter_cli_mode();
-                    this.cli_write_response_code(AT_RESP_OK);
-                }
-                else if(this.dtr_low_behaviour === DTR_LOW_DROP_CONN)
-                {
-                    this.socket.close();
-                }
-            }
-        }
-    }, this);
-
-    this.bus.register("serial" + this.uart + "-request-to-send-output", function(rts_state)
-    {
-        rts_state = !!rts_state;
-        if(this.rts_state !== rts_state)
-        {
-            dbg_log(`RTS=${rts_state}`, LOG_MODEM);
-            this.rts_state = rts_state;
-        }
-    }, this);
-
-    this.bus.register("serial" + this.uart + "-output-byte", function(data)
-    {
-        if(this.data_mode_esc_timer !== null)
-        {
-            clearTimeout(this.data_mode_esc_timer);
-            this.data_mode_esc_timer = null;
-        }
-        if(this.in_data_mode)
-        {
-            this.data_mode_uart_recv(data);
-        }
-        else
-        {
-            this.cli_mode_uart_recv(data);
-        }
-    }, this);
-
-    // must wait for CPU to be initialized before we can use the bus
-    this.bus.register("emulator-ready", function()
-    {
-        this.uart_set_dsr(true);
-        this.uart_set_cts(true);
-        this.uart_set_ring(false);
-        this.uart_set_dcd(false);
-    }, this);
-
-    dbg_log(`Modem at UART${this.uart} ready`, LOG_MODEM);
+    this.bus.register("serial" + this.uart + "-data-terminal-ready-output", this.uart_dtr_changed, this);
+    this.bus.register("serial" + this.uart + "-request-to-send-output", this.uart_rts_changed, this);
+    this.bus.register("serial" + this.uart + "-output-byte", this.uart_byte_received, this);
 }
+
+Modem.prototype.initialize = function()
+{
+    this.uart_set_dsr(true);
+    this.uart_set_cts(true);
+    this.uart_set_ring(false);
+    this.uart_set_dcd(false);
+    dbg_log(`Modem at UART${this.uart} ready`, LOG_MODEM);
+};
+
+Modem.prototype.destroy = function()
+{
+    this.destroyed = true;
+    this.bus.unregister("serial" + this.uart + "-data-terminal-ready-output", this.uart_dtr_changed);
+    this.bus.unregister("serial" + this.uart + "-request-to-send-output", this.uart_rts_changed);
+    this.bus.unregister("serial" + this.uart + "-output-byte", this.uart_byte_received);
+    if(this.data_mode_send_inverval !== null)
+    {
+        clearInterval(this.data_mode_send_inverval);
+        this.data_mode_send_inverval = null;
+    }
+    if(this.data_mode_esc_timer !== null)
+    {
+        clearTimeout(this.data_mode_esc_timer);
+        this.data_mode_esc_timer = null;
+    }
+    if(this.socket)
+    {
+        this.socket.close();
+    }
+};
 
 Modem.prototype.reset = function()
 {
@@ -267,6 +243,64 @@ Modem.prototype.uart_write = function(str)
     for(const ch of text_encoder.encode(str))
     {
         this.uart_write_byte(ch);
+    }
+};
+
+/**
+ * @param {boolean} dtr_state
+ */
+Modem.prototype.uart_dtr_changed = function(dtr_state)
+{
+    dtr_state = !!dtr_state;
+    if(this.dtr_state !== dtr_state)
+    {
+        dbg_log(`DTR=${dtr_state}`, LOG_MODEM);
+        this.dtr_state = dtr_state;
+        if(this.socket && !dtr_state)
+        {
+            if(this.dtr_low_behaviour === DTR_LOW_KEEP_CONN)
+            {
+                this.enter_cli_mode();
+                this.cli_write_response_code(AT_RESP_OK);
+            }
+            else if(this.dtr_low_behaviour === DTR_LOW_DROP_CONN)
+            {
+                this.socket.close();
+            }
+        }
+    }
+};
+
+/**
+ * @param {boolean} rts_state
+ */
+Modem.prototype.uart_rts_changed = function(rts_state)
+{
+    rts_state = !!rts_state;
+    if(this.rts_state !== rts_state)
+    {
+        dbg_log(`RTS=${rts_state}`, LOG_MODEM);
+        this.rts_state = rts_state;
+    }
+};
+
+/**
+ * @param {number} data
+ */
+Modem.prototype.uart_byte_received = function(data)
+{
+    if(this.data_mode_esc_timer !== null)
+    {
+        clearTimeout(this.data_mode_esc_timer);
+        this.data_mode_esc_timer = null;
+    }
+    if(this.in_data_mode)
+    {
+        this.data_mode_uart_recv(data);
+    }
+    else
+    {
+        this.cli_mode_uart_recv(data);
     }
 };
 
@@ -594,13 +628,16 @@ Modem.prototype.cli_exec_dial = function(dial_address, offset)
     });
     this.socket.addEventListener("close", (event) => {
         this.socket = null;
-        this.enter_cli_mode();
-        if(this.reset_on_disconnect)
+        if(!this.destroyed)
         {
-            this.reset();
-            this.reset_on_disconnect = false;
+            this.enter_cli_mode();
+            if(this.reset_on_disconnect)
+            {
+                this.reset();
+                this.reset_on_disconnect = false;
+            }
+            this.cli_write_response_code(AT_RESP_NO_CARRIER);
         }
-        this.cli_write_response_code(AT_RESP_NO_CARRIER);
     });
 };
 

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -107,7 +107,7 @@ export function Modem(bus, options)
     this.bus = bus;
 
     /** @const @type {number} */
-    this.uart = options.uart - 1;
+    this.uart = options.uart;
 
     /** @const @type {Uint8Array} */
     this.cli_buffer = new Uint8Array(CMDLINE_BUF_SIZE);

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -578,10 +578,10 @@ Modem.prototype.cli_exec_dial = function(dial_address, offset)
     this.socket.addEventListener("message", (event) => {
         if(this.in_data_mode && (!this.use_rtscts_flowctrl || this.rts_state))
         {
-            const view = new DataView(event.data);
+            const bytes = new Uint8Array(event.data);
             for(let i=0; i<event.data.byteLength; i++)
             {
-                this.uart_write_byte(view.getUint8(i));
+                this.uart_write_byte(bytes[i]);
             }
         }
     });

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -1,0 +1,854 @@
+import { dbg_log } from "../log.js";
+import { LOG_MODEM } from "../const.js";
+
+// For Types Only
+import { BusConnector } from "../bus.js";
+
+/*
+ * Hayes-compatible Modem emulation.
+ *
+ * Reference:
+ * - [V250] V.250: Serial asynchronous automatic dialling and control
+ *   https://www.itu.int/rec/T-REC-V.250-200307-I/en
+ * - [TELIT] AT Commands Reference Guide
+ *   https://docs.rs-online.com/c5f6/0900766b81541066.pdf
+ */
+
+const ASCII_BEL = 0x07;     // bell character
+const ASCII_WS = 0x20;      // whitespace character " "
+const ASCII_ZERO = 0x30;    // "0"
+
+/*
+ * AT command sprecifications
+ *
+ * The standard syntax for base AT commands is:
+ *     "AT" ["&"]<CMD>[<ARG>]
+ * - Commands that do not expect an argument are declared below using [].
+ * - Commands that do not support a default argument value are declared using [<min>, <max>],
+ *   with <min> and <max> defining the integer boundaries of <ARG>, both inclusive.
+ * - Commands that support a default argument value are declared using [<min>, <max>, <default>].
+ * - Commands having a non-standard syntax are declared using "custom".
+ */
+const AT_COMMANDS =
+{
+    "A":   [],          // [V250] 6.3.5 Answer
+    "D":   "custom",    // [V250] 6.3.1 Dial
+    "E":   [0, 1, 1],   // [V250] 6.2.4 Command echo
+    "H":   [0, 0, 0],   // [V250] 6.3.6 Hook control
+    "I":   [3, 3],      // [V250] 6.1.3 Request identification information
+    "L":   [0, 3, 1],   // [V250] 6.3.13 Monitor speaker loudness
+    "M":   [0, 2, 1],   // [V250] 6.3.14 Monitor speaker mode
+    "O":   [0, 0, 0],   // [V250] 6.3.7 Return to online data state
+    "P":   [],          // [V250] 6.3.3 Select pulse dialling
+    "Q":   [0, 1, 0],   // [V250] 6.2.5 Result code suppression
+    "S":   [0, 5],      // [V250] see Modem.reset() below
+    "T":   [],          // [V250] 6.3.2 Select tone dialling
+    "V":   [0, 1, 0],   // [V250] 6.2.6 DCE response format
+    "X":   [0, 4, 0],   // [V250] 6.2.7 Result code selection
+    "Z":   [0, 0, 0],   // [V250] 6.1.1 Reset to default configuration
+    "&C":  [0, 1, 1],   // [V250] 6.2.8 Received line signal (DCD) detector behaviour
+    "&D":  [0, 2, 2],   // [V250] 6.2.9 Data terminal ready (DTR) behaviour
+    "&F":  [0, 0, 0],   // [V250] 6.1.2 Set to factory-defined configuration
+    "&K":  [0, 6, 3]    // [TELIT] 3.5.3.2.9 Flow Control
+};
+
+// AT response codes
+const AT_RESP_OK = 0;
+const AT_RESP_CONNECT = 1;
+const AT_RESP_RING = 2;
+const AT_RESP_NO_CARRIER = 3;
+const AT_RESP_ERROR = 4;
+
+const AT_RESP_NAME =
+{
+    [AT_RESP_OK]: "OK",
+    [AT_RESP_CONNECT]: "CONNECT",
+    [AT_RESP_RING]: "RING",
+    [AT_RESP_NO_CARRIER]: "NO CARRIER",
+    [AT_RESP_ERROR]: "ERROR"
+};
+
+// S-Register indices
+const SREG_AUTOANSWER_CNT = 0;
+const SREG_RING_CNT = 1;
+const SREG_ESC = 2;
+const SREG_CR = 3;
+const SREG_LF = 4;
+const SREG_BS = 5;
+
+// what to do when DTR drops from high to low (Modem.dtr_low_behaviour)
+const DTR_LOW_IGNORE = 0;
+const DTR_LOW_KEEP_CONN = 1;
+const DTR_LOW_DROP_CONN = 2;
+
+// online escape sequence timing
+const ESC_MIN_PAUSE_MS = 1000;
+const ESC_MAX_DELAY_MS = 200;
+
+const CMDLINE_BUF_SIZE = 256;
+
+const SEND_BUF_SIZE = 512;
+const SEND_BUF_SAMPLE_INTERVAL_MS = 10;
+const SEND_BUF_MAX_IDLE_TIME_MS = 5;
+
+// matches all strings that start with "ws://" or "wss://" (case-insensitive)
+const RE_WS_ADDR = /^ws[s]?:\/\//i;
+
+/**
+ * @constructor
+ * @param {BusConnector} bus
+ * @param {Object} options
+ */
+export function Modem(bus, options)
+{
+    /** @const @type {BusConnector} */
+    this.bus = bus;
+
+    /** @const @type {number} */
+    this.uart = options.uart;
+
+    /** @const @type {TextDecoder} */
+    this.decoder = new TextDecoder();
+
+    /** @const @type {TextEncoder} */
+    this.encoder = new TextEncoder();
+
+    /** @const @type {Uint8Array} */
+    this.cli_buffer = new Uint8Array(CMDLINE_BUF_SIZE);
+
+    // state that is not defined in this.reset():
+    this.dtr_state = false;
+    this.rts_state = false;
+    this.sreg = new Uint8Array(6);
+
+    this.in_data_mode = false;
+    this.data_mode_send_buffer = new Uint8Array(SEND_BUF_SIZE);
+    this.data_mode_send_cursor = 0;
+    this.data_mode_send_inverval = null;
+    this.data_mode_esc_timer = null;
+
+    this.phonebook = options.phonebook || {};
+
+    this.socket = null;
+
+    this.reset();
+
+    this.bus.register("serial" + this.uart + "-data-terminal-ready-output", function(dtr_state)
+    {
+        dtr_state = !!dtr_state;
+        if(this.dtr_state !== dtr_state)
+        {
+            dbg_log(`DTR=${dtr_state}`, LOG_MODEM);
+            this.dtr_state = dtr_state;
+            if(this.socket && !dtr_state)
+            {
+                if(this.dtr_low_behaviour === DTR_LOW_KEEP_CONN)
+                {
+                    this.enter_cli_mode();
+                    this.cli_write_response_code(AT_RESP_OK);
+                }
+                else if(this.dtr_low_behaviour === DTR_LOW_DROP_CONN)
+                {
+                    this.socket.close();
+                }
+            }
+        }
+    }, this);
+
+    this.bus.register("serial" + this.uart + "-request-to-send-output", function(rts_state)
+    {
+        rts_state = !!rts_state;
+        if(this.rts_state !== rts_state)
+        {
+            dbg_log(`RTS=${rts_state}`, LOG_MODEM);
+            this.rts_state = rts_state;
+        }
+    }, this);
+
+    this.bus.register("serial" + this.uart + "-output-byte", function(data)
+    {
+        if(this.data_mode_esc_timer !== null)
+        {
+            clearTimeout(this.data_mode_esc_timer);
+            this.data_mode_esc_timer = null;
+        }
+        if(this.in_data_mode)
+        {
+            this.data_mode_uart_recv(data);
+        }
+        else
+        {
+            this.cli_mode_uart_recv(data);
+        }
+    }, this);
+
+    // must wait for CPU to be initialized before we can use the bus
+    this.bus.register("emulator-ready", function()
+    {
+        this.uart_set_dsr(true);
+        this.uart_set_cts(true);
+        this.uart_set_ring(false);
+        this.uart_set_dcd(false);
+    }, this);
+
+    dbg_log(`Modem at UART${this.uart} ready`, LOG_MODEM);
+}
+
+Modem.prototype.reset = function()
+{
+    this.do_echo = true;
+    this.cli_cursor = 0;
+    this.cli_overflow = false;
+    this.resp_suppress = false;
+    this.resp_verbose = true;
+    this.use_rtscts_flowctrl = true;
+    this.use_tone_dialling = false;
+    this.dcd_always_on = false;
+    this.dtr_low_behaviour = DTR_LOW_DROP_CONN;
+
+    this.uart_recv_tm = 0;
+    this.data_mode_esc_count = 0;
+    this.reset_on_disconnect = false;
+
+    this.sreg[SREG_AUTOANSWER_CNT] = 0; // S0: Number of RINGs before automatic answer, see [V250] 6.3.8
+    this.sreg[SREG_RING_CNT] = 0;       // S1: RING counter, see [TELIT] 3.5.3.6.2
+    this.sreg[SREG_ESC] = 0x2b;         // S2: DATA mode escape character "+", see [TELIT] 3.5.3.6.3
+    this.sreg[SREG_CR] = 0x0d;          // S3: Command line termination character "\r" (Carriage return), see [V250] 6.2.1
+    this.sreg[SREG_LF] = 0x0a;          // S4: Response formatting character "\n" (Line feed), see [V250] 6.2.2
+    this.sreg[SREG_BS] = 0x08;          // S5: Command line editing character "\b" (Backspace), see [V250] 6.2.3
+};
+
+/**
+ * @param {boolean} dcd_state
+ */
+Modem.prototype.uart_set_dcd = function(dcd_state)
+{
+    dbg_log(`DCD=${dcd_state}`, LOG_MODEM);
+    this.bus.send(`serial${this.uart}-carrier-detect-input`, dcd_state);
+};
+
+/**
+ * @param {boolean} ring_state
+ */
+Modem.prototype.uart_set_ring = function(ring_state)
+{
+    dbg_log(`RING=${ring_state}`, LOG_MODEM);
+    this.bus.send(`serial${this.uart}-ring-indicator-input`, ring_state);
+};
+
+/**
+ * @param {boolean} dsr_state
+ */
+Modem.prototype.uart_set_dsr = function(dsr_state)
+{
+    dbg_log(`DSR=${dsr_state}`, LOG_MODEM);
+    this.bus.send(`serial${this.uart}-data-set-ready-input`, dsr_state);
+};
+
+/**
+ * @param {boolean} cts_state
+ */
+Modem.prototype.uart_set_cts = function(cts_state)
+{
+    dbg_log(`CTS=${cts_state}`, LOG_MODEM);
+    this.bus.send(`serial${this.uart}-clear-to-send-input`, cts_state);
+};
+
+/**
+ * @param {number} data
+ */
+Modem.prototype.uart_write_byte = function(data)
+{
+    this.bus.send(`serial${this.uart}-input`, data);
+};
+
+/**
+ * @param {string} str
+ */
+Modem.prototype.uart_write = function(str)
+{
+    for(const ch of this.encoder.encode(str))
+    {
+        this.uart_write_byte(ch);
+    }
+};
+
+Modem.prototype.enter_cli_mode = function()
+{
+    if(this.in_data_mode)
+    {
+        dbg_log(`switching to command mode`, LOG_MODEM);
+        this.in_data_mode = false;
+        this.data_mode_flush();
+        if(this.data_mode_send_inverval !== null)
+        {
+            clearInterval(this.data_mode_send_inverval);
+            this.data_mode_send_inverval = null;
+        }
+
+        this.uart_set_dsr(true);
+        this.uart_set_cts(true);
+        this.uart_set_ring(false);
+        if(!this.dcd_always_on)
+        {
+            this.uart_set_dcd(this.socket !== null);
+        }
+    }
+};
+
+Modem.prototype.enter_data_mode = function()
+{
+    if(!this.in_data_mode)
+    {
+        dbg_log(`switching to data mode`, LOG_MODEM);
+        this.in_data_mode = true;
+        this.data_mode_send_inverval = setInterval(() => {
+            if(this.data_mode_send_cursor && (performance.now() - this.uart_recv_tm) > SEND_BUF_MAX_IDLE_TIME_MS)
+            {
+                this.data_mode_flush();
+            }
+        }, SEND_BUF_SAMPLE_INTERVAL_MS);
+
+        this.uart_set_ring(false);
+        if(!this.dcd_always_on)
+        {
+            this.uart_set_dcd(true);
+        }
+    }
+};
+
+Modem.prototype.flush_escape_buffer = function()
+{
+    for(; this.data_mode_esc_count > 0; this.data_mode_esc_count--)
+    {
+        if(this.in_data_mode)
+        {
+            this.data_mode_send(this.sreg[SREG_ESC]);
+        }
+        else
+        {
+            this.uart_write_byte(this.sreg[SREG_ESC]);
+        }
+    }
+};
+
+/**
+ * @param {number} data
+ */
+Modem.prototype.data_mode_send = function(data)
+{
+    if(this.socket)
+    {
+        this.data_mode_send_buffer[this.data_mode_send_cursor++] = data;
+        if(this.data_mode_send_cursor === this.data_mode_send_buffer.byteLength)
+        {
+            this.data_mode_flush();
+        }
+    }
+};
+
+Modem.prototype.data_mode_flush = function()
+{
+    if(this.data_mode_send_cursor && this.socket)
+    {
+        this.socket.send(this.data_mode_send_buffer.slice(0, this.data_mode_send_cursor));
+        this.data_mode_send_cursor = 0;
+    }
+};
+
+/**
+ * @param {number} uart_byte
+ */
+Modem.prototype.data_mode_uart_recv = function(uart_byte)
+{
+    if(uart_byte === this.sreg[SREG_ESC] &&
+        this.data_mode_esc_count < 3 &&
+        (this.data_mode_esc_count > 0 || (performance.now() - this.uart_recv_tm) > ESC_MIN_PAUSE_MS))
+    {
+        // received an escape character (default "+", escape sequence: pause +++ pause)
+        // - if it's the 1st in the sequence of 3 then a minimum pause of ESC_MIN_PAUSE_MS has passed before
+        // - if it's the 2nd or 3rd then at most ESC_MAX_DELAY_MS have passed since the previous escape character
+        // - if, after the 3rd, no other byte was received for a time of ESC_MIN_PAUSE_MS, accept the escape sequence
+        // - in all other cases abort and send the 1..3 buffered escape characters
+        if(++this.data_mode_esc_count < 3)
+        {
+            this.data_mode_esc_timer = setTimeout(() => {
+                this.data_mode_esc_timer = null;
+                this.flush_escape_buffer();
+            }, ESC_MAX_DELAY_MS);
+        }
+        else
+        {
+            this.data_mode_esc_timer = setTimeout(() => {
+                this.data_mode_esc_timer = null;
+                this.enter_cli_mode();
+                this.flush_escape_buffer();
+                this.cli_write_response_code(AT_RESP_OK);
+            }, ESC_MIN_PAUSE_MS);
+        }
+    }
+    else
+    {
+        this.uart_recv_tm = performance.now();
+        this.flush_escape_buffer();
+        this.data_mode_send(uart_byte);
+    }
+};
+
+/**
+ * @param {number} uart_byte
+ */
+Modem.prototype.cli_mode_uart_recv = function(uart_byte)
+{
+    if(this.do_echo)
+    {
+        this.uart_write_byte(uart_byte);
+        if(uart_byte === this.sreg[SREG_BS])
+        {
+            this.uart_write_byte(ASCII_WS);
+            this.uart_write_byte(this.sreg[SREG_BS]);
+        }
+    }
+    switch(uart_byte)
+    {
+        case this.sreg[SREG_BS]:
+            if(this.cli_cursor > 0)
+            {
+                this.cli_cursor--;
+            }
+            break;
+        case this.sreg[SREG_CR]:
+            if(this.cli_overflow)
+            {
+                this.cli_overflow = false;
+                this.cli_write_response_code(AT_RESP_ERROR);
+            }
+            else
+            {
+                this.cli_exec(this.decoder.decode(this.cli_buffer.slice(0, this.cli_cursor)).replace(/\s/g, ""));
+            }
+            this.cli_cursor = 0;
+            break;
+        case this.sreg[SREG_LF]:
+            break;
+        default:
+            if(this.cli_cursor < this.cli_buffer.length)
+            {
+                this.cli_buffer[this.cli_cursor++] = uart_byte;
+            }
+            else
+            {
+                this.cli_overflow = true;
+                this.uart_write_byte(ASCII_BEL);
+            }
+            break;
+    }
+};
+
+/**
+ * @param {Array} cmd_spec
+ * @param {number|undefined} arg
+ */
+Modem.prototype.cli_decode_arg = function(cmd_spec, arg)
+{
+    if(arg === undefined)
+    {
+        if(cmd_spec.length)
+        {
+            if(cmd_spec.length > 2)
+            {
+                return cmd_spec[2];  // use default argument value
+            }
+            else
+            {
+                return false;  // error: missing required argument
+            }
+        }
+    }
+    else if(cmd_spec.length < 2 || arg < cmd_spec[0] || arg > cmd_spec[1])
+    {
+        return false;  // error: unexpected argument or value out of bounds
+    }
+    return arg;
+};
+
+/**
+ * @param {string} dial_address
+ * @param {boolean} use_wss_protocol
+ */
+Modem.prototype.cli_translate_dial_address = function(dial_address, use_wss_protocol)
+{
+    let ws_address;
+    if(dial_address in this.phonebook)
+    {
+        ws_address = this.phonebook[dial_address];
+    }
+    else if(dial_address.length)
+    {
+        const m = dial_address.match(/(\d{3})(\d{3})(\d{3})(\d{3})(\d{0,5})$/);
+        if(m)
+        {
+            ws_address = Number(m[1]) + "." + Number(m[2]) + "." + Number(m[3]) + "." + Number(m[4]);
+            if(m[5].length)
+            {
+                ws_address += ":" + Number(m[5]);
+            }
+        }
+        else
+        {
+            ws_address = dial_address;
+        }
+        if(ws_address && !RE_WS_ADDR.test(ws_address))
+        {
+            ws_address = (use_wss_protocol ? "wss://" : "ws://") + ws_address;
+        }
+    }
+    return ws_address;
+};
+
+/**
+ * @param {string} dial_address
+ * @param {number} offset
+ */
+Modem.prototype.cli_exec_dial = function(dial_address, offset)
+{
+    // strip prefix "T" or "P", quotes and trailing ";" from dial_address
+    let enter_data_mode = true;
+    let use_wss_protocol = this.use_tone_dialling;
+    const index_semi = dial_address.lastIndexOf(";");
+    if(index_semi >= 0)
+    {
+        enter_data_mode = false;
+        dial_address = dial_address.substring(0, index_semi);
+    }
+    if(offset < dial_address.length)
+    {
+        const dial_method = dial_address[offset].toUpperCase();
+        if(dial_method === "T" || dial_method === "P")
+        {
+            offset++;
+            use_wss_protocol = dial_method === "T";
+        }
+    }
+    if(offset < dial_address.length && dial_address[offset] === "\"")
+    {
+        offset++;
+        const index_quot = dial_address.indexOf("\"", offset);
+        if(index_quot >= 0)
+        {
+            dial_address = dial_address.substring(0, index_quot);
+        }
+    }
+    dial_address = dial_address.substring(offset);
+
+    // translate remaining dial address into a fully-qualified WebSocket address
+    const ws_address = this.cli_translate_dial_address(dial_address, use_wss_protocol);
+    if(ws_address === undefined)
+    {
+        dbg_log(`error: invalid dial address "${dial_address}"`, LOG_MODEM);
+        this.cli_write_response_code(AT_RESP_ERROR);
+        return;
+    }
+
+    // create and connect client WebSocket
+    dbg_log(`connecting "${ws_address}"`, LOG_MODEM);
+    try
+    {
+        this.socket = new WebSocket(ws_address);
+    }
+    catch(e)
+    {
+        dbg_log(`error: WebSocket constructor failed using address "${ws_address}"`, LOG_MODEM);
+        this.cli_write_response_code(AT_RESP_ERROR);
+        return;
+    }
+
+    this.socket.binaryType = "arraybuffer";
+    this.socket.addEventListener("open", (event) => {
+        if(enter_data_mode)
+        {
+            this.enter_data_mode();
+            this.cli_write_response_code(AT_RESP_CONNECT);
+        }
+        else
+        {
+            this.cli_write_response_code(AT_RESP_OK);
+        }
+    });
+    this.socket.addEventListener("message", (event) => {
+        if(this.in_data_mode && (!this.use_rtscts_flowctrl || this.rts_state))
+        {
+            const view = new DataView(event.data);
+            for(let i=0; i<event.data.byteLength; i++)
+            {
+                this.uart_write_byte(view.getUint8(i));
+            }
+        }
+    });
+    this.socket.addEventListener("close", (event) => {
+        this.socket = null;
+        this.enter_cli_mode();
+        if(this.reset_on_disconnect)
+        {
+            this.reset();
+            this.reset_on_disconnect = false;
+        }
+        this.cli_write_response_code(AT_RESP_NO_CARRIER);
+    });
+};
+
+/**
+ * @param {string} cmdline
+ */
+Modem.prototype.cli_exec = function(cmdline)
+{
+    const length = cmdline.length;
+    let offset = cmdline.search(/(at|AT)/);
+    if(offset < 0)
+    {
+        dbg_log(`error: missing AT in command line "${cmdline}"`, LOG_MODEM);
+        this.cli_write_response_code(AT_RESP_ERROR);
+        return;
+    }
+    offset += 2;
+
+    const decode_uint = () => {
+        const start_offset = offset;
+        let acc = 0;
+        while(offset < length)
+        {
+            const digit = cmdline.charCodeAt(offset) - ASCII_ZERO;
+            if(digit < 0 || digit > 9)
+            {
+                break;
+            }
+            else
+            {
+                acc = acc * 10 + digit;
+                offset++;
+            }
+        }
+        return offset === start_offset ? undefined : acc;
+    };
+
+    dbg_log(`executing command line "${cmdline}"`, LOG_MODEM);
+
+    let response_code = true;
+    while(offset < length && response_code === true)
+    {
+        let cmd = cmdline[offset++].toUpperCase();
+        if(offset < length && cmd === "&")
+        {
+            cmd += cmdline[offset++].toUpperCase();
+        }
+        if(!(cmd in AT_COMMANDS))
+        {
+            dbg_log(`error: unknown command "${cmd}"`, LOG_MODEM);
+            response_code = AT_RESP_ERROR;
+            break;
+        }
+        const cmd_spec = AT_COMMANDS[cmd];
+
+        let arg;
+        if(cmd_spec !== "custom")
+        {
+            arg = this.cli_decode_arg(cmd_spec, decode_uint());
+            if(arg === false)
+            {
+                dbg_log(`error: bad argument for command "${cmd}"`, LOG_MODEM);
+                response_code = AT_RESP_ERROR;
+                break;
+            }
+        }
+
+        if(DEBUG)
+        {
+            if(arg !== undefined)
+            {
+                dbg_log(`AT command: "${cmd}${arg}"`, LOG_MODEM);
+            }
+            else
+            {
+                dbg_log(`AT command: "${cmd}"`, LOG_MODEM);
+            }
+        }
+
+        switch(cmd)
+        {
+            case "D":   // D[T|P](.*)[;]: Dial
+                if(this.socket)
+                {
+                    response_code = AT_RESP_ERROR;
+                }
+                else
+                {
+                    this.cli_exec_dial(cmdline, offset);
+                    response_code = false; // exit parser without response (delayed in dial command)
+                }
+                break;
+            case "E":   // E[0..1]: Command echo
+                this.do_echo = arg === 1;
+                break;
+            case "H":   // H[0]: Hook control
+                if(this.socket)
+                {
+                    this.socket.close();
+                    response_code = false; // exit parser without response (delayed in "close" socket event)
+                }
+                else
+                {
+                    response_code = AT_RESP_ERROR;
+                }
+                break;
+            case "I":   // I3: Request identification information
+                this.cli_write_info_text("V86 Modem Emulation");
+                break;
+            case "L":   // L[0..3]: Monitor speaker loudness
+                break;
+            case "M":   // M[0..3]: Monitor speaker mode
+                break;
+            case "O":   // O: Switch to online data mode
+                if(this.socket)
+                {
+                    this.enter_data_mode();
+                    response_code = AT_RESP_CONNECT;
+                }
+                else
+                {
+                    response_code = AT_RESP_ERROR;
+                }
+                break;
+            case "P":   // P: Select pulse dialling
+                this.use_tone_dialling = false;
+                break;
+            case "Q":   // Q[0..1]: Result code suppression
+                this.resp_suppress = arg === 1;
+                break;
+            case "S":   // S(0..5) [?|=<n>]: Read or write register S<n>
+                if(offset < length && cmdline[offset] === "?")
+                {
+                    offset++;
+                    this.cli_write_info_text(this.sreg[arg].toString().padStart(3, "0"));
+                }
+                else if(offset < length && cmdline[offset] === "=")
+                {
+                    offset++;
+                    const val = decode_uint();
+                    if(val !== undefined && val < 256)
+                    {
+                        this.sreg[arg] = val;
+                    }
+                    else
+                    {
+                        response_code = AT_RESP_ERROR;
+                    }
+                }
+                else
+                {
+                    response_code = AT_RESP_ERROR;
+                }
+                break;
+            case "T":   // T: Select tone dialling
+                this.use_tone_dialling = true;
+                break;
+            case "V":   // V[0..1]: DCE response format
+                this.resp_verbose = arg === 1;
+                break;
+            case "X":   // X[0..4]: Result code selection
+                break;
+            case "Z":   // Z[0]: Reset to default configuration
+            case "&F":  // &F[0]: Set to factory-defined configuration (same as Z)
+                if(this.socket)
+                {
+                    this.reset_on_disconnect = true;
+                    this.socket.close();
+                    response_code = false; // exit parser without response (delayed in "close" socket event)
+                }
+                else
+                {
+                    this.reset();
+                    response_code = AT_RESP_OK;
+                }
+                break;
+            case "&C":  // &C[0..1]: Received line signal (DCD) detector behaviour
+                this.dcd_always_on = arg === 0;
+                if(this.dcd_always_on)
+                {
+                    this.uart_set_dcd(true);
+                }
+                else
+                {
+                    this.uart_set_dcd(this.socket !== null);
+                }
+                break;
+            case "&D":  // &D(0..2): Data terminal ready (DTR) behaviour
+                this.dtr_low_behaviour = arg;
+                break;
+            case "&K":  // &K[0..6]: Flow Control
+                if(arg === 0 || arg === 3)
+                {
+                    this.use_rtscts_flowctrl = arg === 3;
+                }
+                else
+                {
+                    response_code = AT_RESP_ERROR;
+                }
+                break;
+            default:
+                dbg_log(`error: command "${cmd}" is without implementation`, LOG_MODEM);
+                response_code = AT_RESP_ERROR;
+                break;
+        }
+    }
+
+    if(response_code === true)
+    {
+        this.cli_write_response_code(AT_RESP_OK);
+    }
+    else if(typeof(response_code) === "number")
+    {
+        this.cli_write_response_code(response_code);
+    }
+};
+
+/**
+ * @param {string} text
+ */
+Modem.prototype.cli_write_info_text = function(text)
+{
+    dbg_log(`AT info response: "${text}"`, LOG_MODEM);
+    if(this.resp_verbose)
+    {
+        this.uart_write_byte(this.sreg[SREG_CR]);
+        this.uart_write_byte(this.sreg[SREG_LF]);
+    }
+    this.uart_write(text);
+    this.uart_write_byte(this.sreg[SREG_CR]);
+    this.uart_write_byte(this.sreg[SREG_LF]);
+};
+
+/**
+ * @param {number} code
+ */
+Modem.prototype.cli_write_response_code = function(code)
+{
+    if(!this.resp_suppress)
+    {
+        const text = AT_RESP_NAME[code in AT_RESP_NAME ? code : AT_RESP_ERROR];
+        if(this.resp_verbose)
+        {
+            dbg_log(`AT response: "${text}"`, LOG_MODEM);
+            this.uart_write_byte(this.sreg[SREG_CR]);
+            this.uart_write_byte(this.sreg[SREG_LF]);
+            this.uart_write(text);
+            this.uart_write_byte(this.sreg[SREG_CR]);
+            this.uart_write_byte(this.sreg[SREG_LF]);
+        }
+        else
+        {
+            dbg_log(`AT response code: "${code} (${text})"`, LOG_MODEM);
+            this.uart_write(code.toString());
+            this.uart_write_byte(this.sreg[SREG_CR]);
+        }
+    }
+};

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -610,8 +610,7 @@ Modem.prototype.cli_exec = function(cmdline)
     let offset = cmdline.search(/(at|AT)/);
     if(offset < 0)
     {
-        dbg_log(`error: missing AT in command line "${cmdline}"`, LOG_MODEM);
-        this.cli_write_response_code(AT_RESP_ERROR);
+        this.cli_write_response_code(AT_RESP_OK);
         return;
     }
     offset += 2;

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -94,6 +94,9 @@ const SEND_BUF_MAX_IDLE_TIME_MS = 5;
 // matches all strings that start with "ws://" or "wss://" (case-insensitive)
 const RE_WS_ADDR = /^ws[s]?:\/\//i;
 
+const text_encoder = new TextEncoder();
+const text_decoder = new TextDecoder();
+
 /**
  * @constructor
  * @param {BusConnector} bus
@@ -106,12 +109,6 @@ export function Modem(bus, options)
 
     /** @const @type {number} */
     this.uart = options.uart - 1;
-
-    /** @const @type {TextDecoder} */
-    this.decoder = new TextDecoder();
-
-    /** @const @type {TextEncoder} */
-    this.encoder = new TextEncoder();
 
     /** @const @type {Uint8Array} */
     this.cli_buffer = new Uint8Array(CMDLINE_BUF_SIZE);
@@ -267,7 +264,7 @@ Modem.prototype.uart_write_byte = function(data)
  */
 Modem.prototype.uart_write = function(str)
 {
-    for(const ch of this.encoder.encode(str))
+    for(const ch of text_encoder.encode(str))
     {
         this.uart_write_byte(ch);
     }
@@ -425,7 +422,7 @@ Modem.prototype.cli_mode_uart_recv = function(uart_byte)
             }
             else
             {
-                this.cli_exec(this.decoder.decode(this.cli_buffer.slice(0, this.cli_cursor)).replace(/\s/g, ""));
+                this.cli_exec(text_decoder.decode(this.cli_buffer.slice(0, this.cli_cursor)).replace(/\s/g, ""));
             }
             this.cli_cursor = 0;
             break;

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -417,8 +417,10 @@ Modem.prototype.cli_mode_uart_recv = function(uart_byte)
         case this.sreg[SREG_CR]:
             if(this.cli_overflow)
             {
+                const data = text_decoder.decode(this.cli_buffer.buffer);
+                dbg_log(`error: AT command buffer overflow: "${data}"`, LOG_MODEM);
                 this.cli_overflow = false;
-                this.cli_write_response_code(AT_RESP_ERROR);
+                // do NOT send any response when clearing buffer after overflow
             }
             else
             {
@@ -502,7 +504,7 @@ Modem.prototype.cli_translate_dial_address = function(dial_address, use_wss_prot
         {
             ws_address = dial_address;
         }
-        if(ws_address && !RE_WS_ADDR.test(ws_address))
+        if(!RE_WS_ADDR.test(ws_address))
         {
             ws_address = (use_wss_protocol ? "wss://" : "ws://") + ws_address;
         }
@@ -569,6 +571,7 @@ Modem.prototype.cli_exec_dial = function(dial_address, offset)
 
     this.socket.binaryType = "arraybuffer";
     this.socket.addEventListener("open", (event) => {
+        this.data_mode_send_cursor = 0;
         if(enter_data_mode)
         {
             this.enter_data_mode();
@@ -607,10 +610,25 @@ Modem.prototype.cli_exec_dial = function(dial_address, offset)
 Modem.prototype.cli_exec = function(cmdline)
 {
     const length = cmdline.length;
+    if(length === 0)
+    {
+        dbg_log(`received empty AT command line`, LOG_MODEM);
+        if(this.socket && this.socket.readyState === WebSocket.CONNECTING)
+        {
+            // abort dial command, exit parser without response (delayed in "close" socket event)
+            this.socket.close();
+        }
+        else
+        {
+            this.cli_write_response_code(AT_RESP_OK);
+        }
+        return;
+    }
     let offset = cmdline.search(/(at|AT)/);
     if(offset < 0)
     {
-        this.cli_write_response_code(AT_RESP_OK);
+        // do NOT send any response for non-empty lines without AT command (Trumpet Winsock trips over this)
+        dbg_log(`error: missing AT command in "${cmdline}"`, LOG_MODEM);
         return;
     }
     offset += 2;
@@ -760,7 +778,7 @@ Modem.prototype.cli_exec = function(cmdline)
             case "X":   // X[0..4]: Result code selection
                 break;
             case "Z":   // Z[0]: Reset to default configuration
-            case "&F":  // &F[0]: Set to factory-defined configuration (same as Z)
+            case "&F":  // &F[0]: Set to factory-defined configuration (same as Z, but continue command line evaluation)
                 if(this.socket)
                 {
                     this.reset_on_disconnect = true;
@@ -770,7 +788,6 @@ Modem.prototype.cli_exec = function(cmdline)
                 else
                 {
                     this.reset();
-                    response_code = AT_RESP_OK;
                 }
                 break;
             case "&C":  // &C[0..1]: Received line signal (DCD) detector behaviour

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -105,7 +105,7 @@ export function Modem(bus, options)
     this.bus = bus;
 
     /** @const @type {number} */
-    this.uart = options.uart;
+    this.uart = options.uart - 1;
 
     /** @const @type {TextDecoder} */
     this.decoder = new TextDecoder();

--- a/src/browser/modem.js
+++ b/src/browser/modem.js
@@ -482,16 +482,23 @@ Modem.prototype.cli_translate_dial_address = function(dial_address, use_wss_prot
     }
     else if(dial_address.length)
     {
-        const m = dial_address.match(/(\d{3})(\d{3})(\d{3})(\d{3})(\d{0,5})$/);
+        const m = dial_address.match(/(\d{1,3})[^\d]*(\d{1,3})[^\d]*(\d{1,3})[^\d]*(\d{1,3})[^\d]*(\d{0,5})/);
         if(m)
         {
-            ws_address = Number(m[1]) + "." + Number(m[2]) + "." + Number(m[3]) + "." + Number(m[4]);
-            if(m[5].length)
+            const num = (index, limit) => {
+                if(m[index].length) {
+                    const n = Number(m[index]);
+                    return n < limit ? n : -1;
+                }
+                return undefined;
+            };
+            const n1 = num(1, 256), n2 = num(2, 256), n3 = num(3, 256), n4 = num(4, 256), n5 = num(5, 65536);
+            if(n1 >= 0 && n2 >= 0 && n3 >= 0 && n4 >= 0 && (n5 === undefined || n5 >= 0))
             {
-                ws_address += ":" + Number(m[5]);
+                ws_address = n5 === undefined ? `${n1}.${n2}.${n3}.${n4}` : `${n1}.${n2}.${n3}.${n4}:${n5}`;
             }
         }
-        else
+        if(ws_address === undefined)
         {
             ws_address = dial_address;
         }

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -209,18 +209,18 @@ V86.prototype.continue_init = async function(emulator, options)
         options.fda ? BOOT_ORDER_FD_FIRST :
         options.hda ? BOOT_ORDER_HD_FIRST : BOOT_ORDER_CD_FIRST;
 
-    if(options.modem && options.modem.uart)
+    if(options.modem)
     {
         settings.modem = options.modem;
         switch(options.modem.uart)
         {
-            case 2:
+            case 1:
                 options.uart1 = true;
                 break;
-            case 3:
+            case 2:
                 options.uart2 = true;
                 break;
-            case 4:
+            case 3:
                 options.uart3 = true;
                 break;
         }
@@ -335,7 +335,7 @@ V86.prototype.continue_init = async function(emulator, options)
         this.virtio_console_adapter = new VirtioConsoleAdapter(virtio_console_settings.container, this.bus);
     }
 
-    if(settings.modem?.uart)
+    if(settings.modem)
     {
         this.modem = new Modem(this.bus, settings.modem);
     }

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -209,18 +209,18 @@ V86.prototype.continue_init = async function(emulator, options)
         options.fda ? BOOT_ORDER_FD_FIRST :
         options.hda ? BOOT_ORDER_HD_FIRST : BOOT_ORDER_CD_FIRST;
 
-    if(options.modem && options.modem.uart !== undefined)
+    if(options.modem && options.modem.uart)
     {
         settings.modem = options.modem;
         switch(options.modem.uart)
         {
-            case 1:
+            case 2:
                 options.uart1 = true;
                 break;
-            case 2:
+            case 3:
                 options.uart2 = true;
                 break;
-            case 3:
+            case 4:
                 options.uart3 = true;
                 break;
         }
@@ -335,7 +335,7 @@ V86.prototype.continue_init = async function(emulator, options)
         this.virtio_console_adapter = new VirtioConsoleAdapter(virtio_console_settings.container, this.bus);
     }
 
-    if(settings.modem)
+    if(settings.modem?.uart)
     {
         this.modem = new Modem(this.bus, settings.modem);
     }

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -17,6 +17,7 @@ import { ScreenAdapter } from "./screen.js";
 import { DummyScreenAdapter } from "./dummy_screen.js";
 import { SerialAdapter, VirtioConsoleAdapter, SerialAdapterXtermJS, VirtioConsoleAdapterXtermJS } from "./serial.js";
 import { InBrowserNetworkAdapter } from "./inbrowser_network.js";
+import { Modem } from "./modem.js";
 
 import { MemoryFileStorage, ServerFileStorageWrapper } from "./filestorage.js";
 import { SyncBuffer, buffer_from_object } from "../buffer.js";
@@ -208,6 +209,23 @@ V86.prototype.continue_init = async function(emulator, options)
         options.fda ? BOOT_ORDER_FD_FIRST :
         options.hda ? BOOT_ORDER_HD_FIRST : BOOT_ORDER_CD_FIRST;
 
+    if(options.modem && options.modem.uart !== undefined)
+    {
+        settings.modem = options.modem;
+        switch(options.modem.uart)
+        {
+            case 1:
+                options.uart1 = true;
+                break;
+            case 2:
+                options.uart2 = true;
+                break;
+            case 3:
+                options.uart3 = true;
+                break;
+        }
+    }
+
     settings.acpi = options.acpi;
     settings.disable_jit = options.disable_jit;
     settings.load_devices = true;
@@ -315,6 +333,11 @@ V86.prototype.continue_init = async function(emulator, options)
     else if(virtio_console_settings?.type === "textarea")
     {
         this.virtio_console_adapter = new VirtioConsoleAdapter(virtio_console_settings.container, this.bus);
+    }
+
+    if(settings.modem)
+    {
+        this.modem = new Modem(this.bus, settings.modem);
     }
 
     if(!options.disable_speaker)

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -614,6 +614,8 @@ V86.prototype.continue_init = async function(emulator, options)
 
         this.v86.init(settings);
 
+        this.modem && this.modem.initialize();
+
         if(settings.initial_state)
         {
             emulator.restore_state(settings.initial_state);
@@ -812,6 +814,7 @@ V86.prototype.destroy = async function()
     this.serial_adapter && this.serial_adapter.destroy();
     this.speaker_adapter && this.speaker_adapter.destroy();
     this.virtio_console_adapter && this.virtio_console_adapter.destroy();
+    this.modem && this.modem.destroy();
 };
 
 /**

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -1216,14 +1216,6 @@ V86.prototype.serial_send_bytes = function(serial, data)
 };
 
 /**
- * Set the modem status of a serial port.
- */
-V86.prototype.serial_set_modem_status = function(serial, status)
-{
-    this.bus.send("serial" + serial + "-modem-status-input", status);
-};
-
-/**
  * Set the carrier detect status of a serial port.
  */
 V86.prototype.serial_set_carrier_detect = function(serial, status)

--- a/src/const.js
+++ b/src/const.js
@@ -26,7 +26,8 @@ export const
     LOG_VIRTIO = 0x0200000,
     LOG_9P =     0x0400000,
     LOG_SB16 =   0x0800000,
-    LOG_FETCH =  0x1000000;
+    LOG_FETCH =  0x1000000,
+    LOG_MODEM =  0x2000000;
 
 
 /**
@@ -57,6 +58,7 @@ export const LOG_NAMES = [
     [LOG_9P, "9P"],
     [LOG_SB16, "SB16"],
     [LOG_FETCH, "FETC"],
+    [LOG_MODEM, "MODM"],
 ];
 
 export const

--- a/src/uart.js
+++ b/src/uart.js
@@ -28,6 +28,8 @@ const UART_IIR_CTI = 0x0c; /* Character timeout */
 
 // Modem control register
 const UART_MCR_LOOPBACK = 0x10;
+const UART_MCR_RTS = 0x2;
+const UART_MCR_DTR = 0x1;
 
 const UART_LSR_DATA_READY        = 0x1;  // data available
 const UART_LSR_TX_EMPTY        = 0x20; // TX (THR) buffer is empty
@@ -268,7 +270,16 @@ export function UART(cpu, port, bus)
     io.register_write(port | 4, this, function(out_byte)
     {
         dbg_log("modem control: " + h(out_byte), LOG_SERIAL);
+        const bits_changed = this.modem_control ^ out_byte;
         this.modem_control = out_byte;
+        if(bits_changed & UART_MCR_DTR)
+        {
+            this.bus.send("serial" + this.com + "-data-terminal-ready-output", !!(out_byte & UART_MCR_DTR));
+        }
+        if(bits_changed & UART_MCR_RTS)
+        {
+            this.bus.send("serial" + this.com + "-request-to-send-output", !!(out_byte & UART_MCR_RTS));
+        }
     });
 
     io.register_read(port | 5, this, function()

--- a/src/uart.js
+++ b/src/uart.js
@@ -118,43 +118,26 @@ export function UART(cpu, port, bus)
         this.data_received(data);
     }, this);
 
-    this.bus.register("serial" + this.com + "-modem-status-input", function(data)
-    {
-        this.set_modem_status(data);
-    }, this);
-
     // Set individual modem status bits
 
     this.bus.register("serial" + this.com + "-carrier-detect-input", function(data)
     {
-        const status = data ?
-            this.modem_status | (1 << UART_MSR_DCD) | (1 << UART_MSR_DDCD) :
-            this.modem_status & ~(1 << UART_MSR_DCD) & ~(1 << UART_MSR_DDCD);
-        this.set_modem_status(status);
+        this.set_modem_status_bit(UART_MSR_DCD, data);
     }, this);
 
     this.bus.register("serial" + this.com + "-ring-indicator-input", function(data)
     {
-        const status = data ?
-            this.modem_status | (1 << UART_MSR_RI) | (1 << UART_MSR_TERI) :
-            this.modem_status & ~(1 << UART_MSR_RI) & ~(1 << UART_MSR_TERI);
-        this.set_modem_status(status);
+        this.set_modem_status_bit(UART_MSR_RI, data);
     }, this);
 
     this.bus.register("serial" + this.com + "-data-set-ready-input", function(data)
     {
-        const status = data ?
-            this.modem_status | (1 << UART_MSR_DSR) | (1 << UART_MSR_DDSR) :
-            this.modem_status & ~(1 << UART_MSR_DSR) & ~(1 << UART_MSR_DDSR);
-        this.set_modem_status(status);
+        this.set_modem_status_bit(UART_MSR_DSR, data);
     }, this);
 
     this.bus.register("serial" + this.com + "-clear-to-send-input", function(data)
     {
-        const status = data ?
-            this.modem_status | (1 << UART_MSR_CTS) | (1 << UART_MSR_DCTS) :
-            this.modem_status & ~(1 << UART_MSR_CTS) & ~(1 << UART_MSR_DCTS);
-        this.set_modem_status(status);
+        this.set_modem_status_bit(UART_MSR_CTS, data);
     }, this);
 
     var io = cpu.io;
@@ -295,14 +278,11 @@ export function UART(cpu, port, bus)
     io.register_read(port | 6, this, function()
     {
         dbg_log("read modem status: " + h(this.modem_status), LOG_SERIAL);
-        // Clear delta bits
+        const result = this.modem_status;
+        // clear MSR delta bits and interrupt flag
         this.modem_status &= 0xF0;
-        return this.modem_status;
-    });
-    io.register_write(port | 6, this, function(out_byte)
-    {
-        dbg_log("write modem status: " + h(out_byte), LOG_SERIAL);
-        this.set_modem_status(out_byte);
+        this.ClearInterrupt(UART_IIR_MSI);
+        return result;
     });
 
     io.register_read(port | 7, this, function()
@@ -349,34 +329,43 @@ UART.prototype.set_state = function(state)
     this.irq = state[10];
 };
 
-UART.prototype.CheckInterrupt = function() {
-    if((this.ints & (1 << UART_IIR_CTI))  && (this.ier & UART_IER_RDI)) {
+UART.prototype.CheckInterrupt = function()
+{
+    if((this.ints & (1 << UART_IIR_CTI)) && (this.ier & UART_IER_RDI))
+    {
         this.iir = UART_IIR_CTI;
         this.cpu.device_raise_irq(this.irq);
-    } else
-    if((this.ints & (1 << UART_IIR_RDI))  && (this.ier & UART_IER_RDI)) {
+    }
+    else if((this.ints & (1 << UART_IIR_RDI)) && (this.ier & UART_IER_RDI))
+    {
         this.iir = UART_IIR_RDI;
         this.cpu.device_raise_irq(this.irq);
-    } else
-    if((this.ints & (1 << UART_IIR_THRI)) && (this.ier & UART_IER_THRI)) {
+    }
+    else if((this.ints & (1 << UART_IIR_THRI)) && (this.ier & UART_IER_THRI))
+    {
         this.iir = UART_IIR_THRI;
         this.cpu.device_raise_irq(this.irq);
-    } else
-    if((this.ints & (1 << UART_IIR_MSI))  && (this.ier & UART_IER_MSI)) {
+    }
+    else if((this.ints & (1 << UART_IIR_MSI)) && (this.ier & UART_IER_MSI))
+    {
         this.iir = UART_IIR_MSI;
         this.cpu.device_raise_irq(this.irq);
-    } else {
+    }
+    else
+    {
         this.iir = UART_IIR_NO_INT;
         this.cpu.device_lower_irq(this.irq);
     }
 };
 
-UART.prototype.ThrowInterrupt = function(line) {
+UART.prototype.ThrowInterrupt = function(line)
+{
     this.ints |= (1 << line);
     this.CheckInterrupt();
 };
 
-UART.prototype.ClearInterrupt = function(line) {
+UART.prototype.ClearInterrupt = function(line)
+{
     this.ints &= ~(1 << line);
     this.CheckInterrupt();
 };
@@ -433,19 +422,34 @@ UART.prototype.write_data = function(out_byte)
     }
 };
 
-UART.prototype.set_modem_status = function(status)
+/**
+ * Set or clear bit "msr_bit" in the Modem Status Register (MSR).
+ *
+ * The upper nibble of the MSR reflects the current status of the 4
+ * control lines (CTS/DSR/RI/DCD), the lower nibble (the delta bits)
+ * indicates which of of these have changed since the last time the
+ * MSR was read.
+ *
+ * If any delta bit is set at the end of this operation and interrupts
+ * are enabled, raise a Modem Status Register interrupt.
+ *
+ * The MSR is a read-only register for the PC, its upper nibble is
+ * controlled by the Modem, and its lower nibble by the UART. The UART
+ * clears all delta bits (and lowers the interrupt) after the MSR has
+ * been read by the PC.
+ *
+ * @param {number} msr_bit
+ * @param {boolean} set_bit
+ */
+UART.prototype.set_modem_status_bit = function(msr_bit, set_bit)
 {
-    dbg_log("modem status: " + h(status), LOG_SERIAL);
-    const prev_delta_bits = this.modem_status & 0x0F;
-    // compare the bits that have changed and shift them into the delta bits
-    let delta = (this.modem_status ^ status) >> 4;
-    // The delta should stay set if they were previously set
-    delta |= prev_delta_bits;
-
-    // update the current modem status
-    this.modem_status = status;
-    // update the delta bits based on the changes and previous
-    // values, but also leave the delta bits set if they were
-    // passed in as part of the status
-    this.modem_status |= delta;
+    const new_modem_status = set_bit ?
+        this.modem_status | (1 << msr_bit) :
+        this.modem_status & ~(1 << msr_bit);
+    const new_delta_bits = (this.modem_status ^ new_modem_status) >> 4;
+    this.modem_status = new_modem_status | new_delta_bits;
+    if(this.modem_status & 0x0F)
+    {
+        this.ThrowInterrupt(UART_IIR_MSI);
+    }
 };

--- a/v86.d.ts
+++ b/v86.d.ts
@@ -79,6 +79,8 @@ export enum LogLevel {
     LOG_VIRTIO = 0x200000,
     LOG_9P = 0x400000,
     LOG_SB16 = 0x800000,
+    LOG_FETCH = 0x1000000,
+    LOG_MODEM = 0x2000000,
 }
 
 export enum BootOrder {


### PR DESCRIPTION
Addresses #1512.

Add a serial Modem device, see the included documentation for a user guide.

With a few exceptions, this device follows ITU Recommendation [V.250](https://www.itu.int/rec/T-REC-V.250-200307-I/en) in regards to the AT command interpreter, AT command syntax and the chosen subset of AT commands.

The UART class had to be extended to emit bus messages for changes of its DTR and RTS hardware signals.

There is a slight ugliness in the Modem constructor: It needs to use the bus to send configuration messages to the UART device, but the bus/UART isn't ready at that point in time, so this is delayed until bus event "emulator-ready" is received. It works reliably, but is there a better pattern for this, perhaps move the Modem construction down in the v86 boot sequence to a later point in time, after the CPU has initialized? Or add and call a method Modem.initialize() that is called after CPU initialization?

The only open issue left is what to store in v86 state snapshots for this device, I thinks this needs to be talked over. For now I've left out Modem.get_state() and set_state() entirely.