### PR TITLE
Fix: prefer require() over dynamic import for fs in node loader

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -526,6 +526,18 @@ if(typeof XMLHttpRequest === "undefined" ||
 {
     let fs;
 
+    const get_fs = async function()
+    {
+        // Electron renderers with nodeIntegration have process.versions.node but
+        // a browser module loader, so dynamic import of node: URLs fails. require() works.
+        if(typeof require !== "undefined")
+        {
+            return require("fs")["promises"];
+        }
+        // string concat to work around closure compiler 'Invalid module path "node:fs/promises" for resolution mode'
+        return import("node:" + "fs/promises");
+    };
+
     /**
      * @param {string} filename
      * @param {Object} options
@@ -535,8 +547,7 @@ if(typeof XMLHttpRequest === "undefined" ||
     {
         if(!fs)
         {
-            // string concat to work around closure compiler 'Invalid module path "node:fs/promises" for resolution mode'
-            fs = await import("node:" + "fs/promises");
+            fs = await get_fs();
         }
 
         if(options.range)
@@ -581,8 +592,7 @@ if(typeof XMLHttpRequest === "undefined" ||
     {
         if(!fs)
         {
-            // string concat to work around closure compiler 'Invalid module path "node:fs/promises" for resolution mode'
-            fs = await import("node:" + "fs/promises");
+            fs = await get_fs();
         }
         const stat = await fs["stat"](path);
         return stat.size;


### PR DESCRIPTION
Electron renderers with nodeIntegration enabled have process.versions.node set, which correctly routes them into the node-path file loader. However, dynamic import() of node: URLs goes through the browser module loader, not Node's, and fails with 'Failed to fetch dynamically imported module'.

Prefer require() when available; pure ESM Node where require is unavailable falls through to import() as before.

| Environment | `typeof require` | Path taken | Result |
|---|---|---|---|
| Node CJS | `"function"` | `require` | `require("fs").promises` returns identical functions to `import("node:fs/promises")` — same refs |
| Node ESM (`.mjs`) | `"undefined"` | `import()` | unchanged from before |
| Electron renderer (`nodeIntegration`) | `"function"` | `require` | works — the bug being fixed |
| Browser / Worker | — | — | never enters this branch (no `process.versions.node`) |
| Bundler (`target: 'node'`) | bundler's `require` | `require` | resolves `"fs"` to real Node builtin |

