### PR TITLE
Fix: fake_network: copy TCP connection addresses out of NIC TX buffer

### DIFF
--- a/src/browser/fake_network.js
+++ b/src/browser/fake_network.js
@@ -265,12 +265,14 @@ function handle_fake_tcp(packet, adapter)
         conn.tuple = tuple;
         conn.last = packet;
 
-        conn.hsrc = packet.eth.dest;
-        conn.psrc = packet.ipv4.dest;
+        // packet.* address fields are subarrays of the NIC TX buffer; copy
+        // them so later guest TX doesn't silently retarget our replies.
+        conn.hsrc = new Uint8Array(packet.eth.dest);
+        conn.psrc = new Uint8Array(packet.ipv4.dest);
         conn.sport = packet.tcp.dport;
-        conn.hdest = packet.eth.src;
+        conn.hdest = new Uint8Array(packet.eth.src);
         conn.dport = packet.tcp.sport;
-        conn.pdest = packet.ipv4.src;
+        conn.pdest = new Uint8Array(packet.ipv4.src);
 
         adapter.bus.pair.send("tcp-connection", conn);
 


### PR DESCRIPTION
`handle_fake_tcp()` stores hsrc/hdest/psrc/pdest as zero-copy subarrays of the SYN frame, which for ne2k is a view into the device TX ring.

When the guest reuses that ring slot for traffic to a different peer, ipv4_reply() emits segments with the wrong source IP; the guest RSTs them and the connection wedges. Fix: new Uint8Array(...) the four address fields at construction.