### PR TITLE
Fix .restart not resetting devices. (Fixes #1367)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -86,18 +86,7 @@ v86.prototype.destroy = function()
 
 v86.prototype.restart = function()
 {
-    this.cpu.reset_cpu();
-    this.cpu.load_bios();
-
-    const devices = this.cpu.devices;
-    for(const key in devices) {
-        if(Object.prototype.hasOwnProperty.call(devices, key)) {
-            const device = devices[key];
-            if(typeof device.reset === "function") {
-                device.reset();
-            }
-        }
-    }
+    this.cpu.reboot_internal();
 };
 
 v86.prototype.init = function(settings)

--- a/src/main.js
+++ b/src/main.js
@@ -88,6 +88,16 @@ v86.prototype.restart = function()
 {
     this.cpu.reset_cpu();
     this.cpu.load_bios();
+
+    const devices = this.cpu.devices;
+    for(const key in devices) {
+        if(Object.prototype.hasOwnProperty.call(devices, key)) {
+            const device = devices[key];
+            if(typeof device.reset === "function") {
+                device.reset();
+            }
+        }
+    }
 };
 
 v86.prototype.init = function(settings)


### PR DESCRIPTION
Hello!  
I have created a fix for #1367 and potentially other issues. This adds a loop to `.restart` that looks at all devices and calls `.reset` on them if they have a reset function.

This fixes freezing found when `.restart` is called and a key is pressed after in certain OSes like Windows 1.01 and 2.03 and Linux 4.16.13.

As a bonus, this also resets the `virtio_9p` device.