### PR TITLE
clean up UART-related API documentation

### DIFF
--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -1224,7 +1224,10 @@ V86.prototype.serial_send_bytes = function(serial, data)
 };
 
 /**
- * Set the carrier detect status of a serial port.
+ * Set or clear the data carrier detect (DCD) status of a serial port.
+ *
+ * @param {number} serial
+ * @param {boolean} status
  */
 V86.prototype.serial_set_carrier_detect = function(serial, status)
 {
@@ -1232,7 +1235,10 @@ V86.prototype.serial_set_carrier_detect = function(serial, status)
 };
 
 /**
- * Set the ring indicator status of a serial port.
+ * Set or clear the ring indicator (RING) status of a serial port.
+ *
+ * @param {number} serial
+ * @param {boolean} status
  */
 V86.prototype.serial_set_ring_indicator = function(serial, status)
 {
@@ -1240,7 +1246,10 @@ V86.prototype.serial_set_ring_indicator = function(serial, status)
 };
 
 /**
- * Set the data set ready status of a serial port.
+ * Set or clear the data set ready (DSR) status of a serial port.
+ *
+ * @param {number} serial
+ * @param {boolean} status
  */
 V86.prototype.serial_set_data_set_ready = function(serial, status)
 {
@@ -1248,7 +1257,10 @@ V86.prototype.serial_set_data_set_ready = function(serial, status)
 };
 
 /**
- * Set the clear to send status of a serial port.
+ * Set or clear the clear to send (CTS) status of a serial port.
+ *
+ * @param {number} serial
+ * @param {boolean} status
  */
 V86.prototype.serial_set_clear_to_send = function(serial, status)
 {

--- a/v86.d.ts
+++ b/v86.d.ts
@@ -780,44 +780,36 @@ export class V86 {
     serial_send_bytes(serial: number, data: Uint8Array): void;
 
     /**
-     * Set the modem status of a serial port.
+     * Set or clear the data carrier detect (DCD) status of a serial port.
      *
      * @param serial the index of the serial port
-     * @param status
+     * @param status the new DCD signal status
      */
-    serial_set_modem_status(serial: number, status: number): void;
+    serial_set_carrier_detect(serial: number, status: boolean): void;
 
     /**
-     * Set the carrier detect status of a serial port.
+     * Set or clear the ring indicator (RING) status of a serial port.
      *
      * @param serial the index of the serial port
-     * @param status
+     * @param status the new RING signal status
      */
-    serial_set_carrier_detect(serial: number, status: number): void;
+    serial_set_ring_indicator(serial: number, status: boolean): void;
 
     /**
-     * Set the ring indicator status of a serial port.
+     * Set or clear the data set ready (DSR) status of a serial port.
      *
      * @param serial the index of the serial port
-     * @param status
+     * @param status the new DSR signal status
      */
-    serial_set_ring_indicator(serial: number, status: number): void;
+    serial_set_data_set_ready(serial: number, status: boolean): void;
 
     /**
-     * Set the data set ready status of a serial port.
+     * Set or clear the clear to send (CTS) status of a serial port.
      *
      * @param serial the index of the serial port
-     * @param status
+     * @param status the new CTS signal status
      */
-    serial_set_data_set_ready(serial: number, status: number): void;
-
-    /**
-     * Set the clear to send status of a serial port.
-     *
-     * @param serial the index of the serial port
-     * @param status
-     */
-    serial_set_clear_to_send(serial: number, status: number): void;
+    serial_set_clear_to_send(serial: number, status: boolean): void;
 
     /**
      * Write to a file in the 9p filesystem. Nothing happens if no filesystem has


### PR DESCRIPTION
Removed documentation of `V86.serial_set_modem_status()` from v86.d.ts which was recently dropped in commit db9768c.

Cleaned up a few other minor things around the UART-related V86 API.