### PR TITLE
[sb16] correctly handle DSP commands that raise interrupts

### DIFF
--- a/src/sb16.js
+++ b/src/sb16.js
@@ -1095,10 +1095,16 @@ register_dsp_command([0xE8], 0, function()
     this.read_buffer.push(this.test_register);
 });
 
-// Trigger IRQ
-register_dsp_command([0xF2, 0xF3], 0, function()
+// Trigger IRQ - 8-bit
+register_dsp_command([0xF2], 0, function()
 {
-    this.raise_irq();
+    this.raise_irq(SB_IRQ_8BIT);
+});
+
+// Trigger IRQ - 16-bit
+register_dsp_command([0xF3], 0, function()
+{
+    this.raise_irq(SB_IRQ_16BIT);
 });
 
 // ASP - unknown function


### PR DESCRIPTION
Correctly handle Sound Blaster DSP commands that raise the interrupt.

This now means the interrupt can get cleared by later DSP commands and allows the Sound Blaster to be detected and work in e.g. Windows 3.1.