### PR TITLE
[devcontainer] set devcontainer build platform

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,12 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			"VARIANT": "ubuntu"
-		}
+		},
+		"options": [
+			"--platform", "linux/amd64"
+		]
 	},
 	"features": {
-		"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},
 		"ghcr.io/jungaretti/features/ripgrep:1": {}
 	},
 	"customizations": {

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ src/rust/gen/jit.rs
 src/rust/gen/jit0f.rs
 bios/seabios
 bench-results
+.devcontainer/devcontainer-lock.json


### PR DESCRIPTION
By forcing the devcontainer to build a linux/amd64 image, this allows to be able to build the project on macOS Apple Silicon under Podman Desktop (applehv machine type) or Docker Desktop w/ Rosetta 2.

Additionally remove the curl feature as `curl` is installed by the Dockerfile already, and add the lock file to .gitignore.

NB: the reason it doesn't build on arm64 is because of the dependency on libc-i386 for tests - it may be possible to replace this with a full cross-compiler chain.