### PR TITLE
Fix graphical vga mode scaling on loading states

### DIFF
--- a/src/browser/dummy_screen.js
+++ b/src/browser/dummy_screen.js
@@ -48,6 +48,12 @@ export function DummyScreenAdapter(options)
     this.pause = function() {};
     this.continue = function() {};
 
+    this.clear_text_state = function()
+    {
+        text_mode_width = null;
+        text_mode_height = null;
+    };
+
     this.set_mode = function(graphical)
     {
         is_graphical = graphical;

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -337,7 +337,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
 
         // initialize display mode and size to 80x25 text with 9x16 font
         this.set_mode(false);
-        this.set_size_text(80, 25);
+        this.set_size_text(80, 25, true);
         if(mode === MODE_GRAPHICAL_TEXT)
         {
             this.set_size_graphical(720, 400, 720, 400);
@@ -545,7 +545,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
                 changed_rows.fill(1);
                 if(size_changed)
                 {
-                    this.set_size_graphical_text();
+                    this.set_size_graphical_text(true);
                 }
             }
         }
@@ -567,7 +567,10 @@ export function ScreenAdapter(options, screen_fill_buffer)
         graphic_context.fillRect(0, 0, graphic_screen.width, graphic_screen.height);
     };
 
-    this.set_size_graphical_text = function()
+    /**
+     * @param {boolean} force
+     */
+    this.set_size_graphical_text = function(force)
     {
         if(!font_context)
         {
@@ -578,7 +581,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
         const gfx_height = font_height * text_mode_height;
         const offscreen_extra_height = font_height * 2;
 
-        if(!offscreen_context || offscreen_context.canvas.width !== gfx_width ||
+        if(force || !offscreen_context || offscreen_context.canvas.width !== gfx_width ||
             offscreen_context.canvas.height !== gfx_height ||
             offscreen_extra_context.canvas.height !== offscreen_extra_height)
         {
@@ -608,10 +611,11 @@ export function ScreenAdapter(options, screen_fill_buffer)
     /**
      * @param {number} cols
      * @param {number} rows
+     * @param {boolean} force
      */
-    this.set_size_text = function(cols, rows)
+    this.set_size_text = function(cols, rows, force)
     {
-        if(cols === text_mode_width && rows === text_mode_height)
+        if(!force && cols === text_mode_width && rows === text_mode_height)
         {
             return;
         }
@@ -643,7 +647,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
         }
         else if(mode === MODE_GRAPHICAL_TEXT)
         {
-            this.set_size_graphical_text();
+            this.set_size_graphical_text(force);
         }
     };
 

--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -337,7 +337,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
 
         // initialize display mode and size to 80x25 text with 9x16 font
         this.set_mode(false);
-        this.set_size_text(80, 25, true);
+        this.set_size_text(80, 25);
         if(mode === MODE_GRAPHICAL_TEXT)
         {
             this.set_size_graphical(720, 400, 720, 400);
@@ -505,6 +505,21 @@ export function ScreenAdapter(options, screen_fill_buffer)
         cursor_element.classList.add("blinking-cursor");
     };
 
+    /**
+     * Invalidates text rendering state.  This means the next set of
+     * calls to set_font_bitmap, set_size_text, etc will be working
+     * from a fresh slate even if the dimensions of the loaded state
+     * differ from the current dimensions.
+     */
+    this.clear_text_state = function() {
+        font_width = null;
+        font_height = null;
+        text_mode_width = null;
+        text_mode_height = null;
+        font_page_a = null;
+        font_page_b = null;
+    };
+
     this.set_mode = function(graphical)
     {
         mode = graphical ? MODE_GRAPHICAL : (options.use_graphical_text ? MODE_GRAPHICAL_TEXT : MODE_TEXT);
@@ -545,7 +560,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
                 changed_rows.fill(1);
                 if(size_changed)
                 {
-                    this.set_size_graphical_text(true);
+                    this.set_size_graphical_text();
                 }
             }
         }
@@ -567,10 +582,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
         graphic_context.fillRect(0, 0, graphic_screen.width, graphic_screen.height);
     };
 
-    /**
-     * @param {boolean} force
-     */
-    this.set_size_graphical_text = function(force)
+    this.set_size_graphical_text = function()
     {
         if(!font_context)
         {
@@ -581,7 +593,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
         const gfx_height = font_height * text_mode_height;
         const offscreen_extra_height = font_height * 2;
 
-        if(force || !offscreen_context || offscreen_context.canvas.width !== gfx_width ||
+        if(!offscreen_context || offscreen_context.canvas.width !== gfx_width ||
             offscreen_context.canvas.height !== gfx_height ||
             offscreen_extra_context.canvas.height !== offscreen_extra_height)
         {
@@ -611,16 +623,16 @@ export function ScreenAdapter(options, screen_fill_buffer)
     /**
      * @param {number} cols
      * @param {number} rows
-     * @param {boolean} force
      */
-    this.set_size_text = function(cols, rows, force)
+    this.set_size_text = function(cols, rows)
     {
-        if(!force && cols === text_mode_width && rows === text_mode_height)
+        if(cols === text_mode_width && rows === text_mode_height)
         {
             return;
         }
 
         changed_rows = new Int8Array(rows);
+        changed_rows.fill(1);
         text_mode_data = new Int32Array(cols * rows * TEXT_BUF_COMPONENT_SIZE);
 
         text_mode_width = cols;
@@ -647,7 +659,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
         }
         else if(mode === MODE_GRAPHICAL_TEXT)
         {
-            this.set_size_graphical_text(force);
+            this.set_size_graphical_text();
         }
     };
 

--- a/src/vga.js
+++ b/src/vga.js
@@ -552,8 +552,9 @@ VGAScreen.prototype.set_state = function(state)
     }
     else
     {
+        this.screen.clear_text_state();
         this.set_font_bitmap(true);
-        this.set_size_text(this.max_cols, this.max_rows, true);
+        this.set_size_text(this.max_cols, this.max_rows);
         this.set_font_page();
         this.update_cursor_scanline();
         this.update_cursor();
@@ -1139,15 +1140,14 @@ VGAScreen.prototype.scan_line_to_screen_row = function(scan_line)
 /**
  * @param {number} cols_count
  * @param {number} rows_count
- * @param {boolean} force
  */
-VGAScreen.prototype.set_size_text = function(cols_count, rows_count, force)
+VGAScreen.prototype.set_size_text = function(cols_count, rows_count)
 {
     dbg_assert(!this.graphical_mode);
     this.max_cols = cols_count;
     this.max_rows = rows_count;
 
-    this.screen.set_size_text(cols_count, rows_count, force);
+    this.screen.set_size_text(cols_count, rows_count);
     this.bus.send("screen-set-size", [cols_count, rows_count, 0]);
 };
 
@@ -1265,7 +1265,7 @@ VGAScreen.prototype.update_vga_size = function()
 
         if(horizontal_characters && height)
         {
-            this.set_size_text(horizontal_characters, height, false);
+            this.set_size_text(horizontal_characters, height);
         }
     }
 };

--- a/src/vga.js
+++ b/src/vga.js
@@ -532,12 +532,12 @@ VGAScreen.prototype.set_state = function(state)
 
     this.screen.set_mode(this.graphical_mode);
 
+    // Ensure set_size_graphical/set_size_graphical_text will update
+    this.screen_width = 0;
+    this.screen_height = 0;
+
     if(this.graphical_mode)
     {
-        // Ensure set_size_graphical will update
-        this.screen_width = 0;
-        this.screen_height = 0;
-
         if(this.svga_enabled)
         {
             this.set_size_graphical(this.svga_width, this.svga_height, this.svga_width, this.svga_height, this.svga_bpp);
@@ -553,7 +553,7 @@ VGAScreen.prototype.set_state = function(state)
     else
     {
         this.set_font_bitmap(true);
-        this.set_size_text(this.max_cols, this.max_rows);
+        this.set_size_text(this.max_cols, this.max_rows, true);
         this.set_font_page();
         this.update_cursor_scanline();
         this.update_cursor();
@@ -1139,14 +1139,15 @@ VGAScreen.prototype.scan_line_to_screen_row = function(scan_line)
 /**
  * @param {number} cols_count
  * @param {number} rows_count
+ * @param {boolean} force
  */
-VGAScreen.prototype.set_size_text = function(cols_count, rows_count)
+VGAScreen.prototype.set_size_text = function(cols_count, rows_count, force)
 {
     dbg_assert(!this.graphical_mode);
     this.max_cols = cols_count;
     this.max_rows = rows_count;
 
-    this.screen.set_size_text(cols_count, rows_count);
+    this.screen.set_size_text(cols_count, rows_count, force);
     this.bus.send("screen-set-size", [cols_count, rows_count, 0]);
 };
 
@@ -1264,7 +1265,7 @@ VGAScreen.prototype.update_vga_size = function()
 
         if(horizontal_characters && height)
         {
-            this.set_size_text(horizontal_characters, height);
+            this.set_size_text(horizontal_characters, height, false);
         }
     }
 };


### PR DESCRIPTION
I encountered an issue similar to the one described in [PR 1123](https://github.com/copy/v86/pull/1123#discussion_r1784364390). While using VGA text mode, if I made  a save state during text mode and started a fullscreen game that was at a different resolution, then when I loaded the state the canvas size (notably its actual size, not its style) would still be set to a smaller value.  This is because the number of rows and columns did not actually change, so the text mode display was not refreshed.  I fixed this by adding a `force` parameter to the involved functions to give a way to ensure that the settings were refreshed even if it seemed locally to the screen code like a no-op.