### PR TITLE
Disable browser's context menu on screen canvas

### DIFF
--- a/src/browser/screen.js
+++ b/src/browser/screen.js
@@ -39,6 +39,7 @@ export function ScreenAdapter(options, screen_fill_buffer)
         graphic_screen = document.createElement("canvas");
         screen_container.appendChild(graphic_screen);
     }
+    graphic_screen.addEventListener("contextmenu", (e) => { e.preventDefault(); });
     const graphic_context = graphic_screen.getContext("2d", { alpha: false });
 
     let text_screen = screen_container.getElementsByTagName("div")[0];


### PR DESCRIPTION
When absolute mouse positioning is enabled we no longer lock the mouse pointer to the screen canvas. This leads to the browser's context menu now popping up when right-clicking the canvas, hiding the guest's context menu underneath.

This PR fixes that by disabling the browser's context menu entirely on the canvas. I figured that we don't ever want to see it on the canvas (dosen't matter if relative or absolute positioning is enabled), is that ok or are there any exceptions I should consider?
