### PR TITLE
Report signal processor chip as absent for virtual SoundBlaster 16

### DIFF
--- a/src/sb16.js
+++ b/src/sb16.js
@@ -784,11 +784,28 @@ function any_first_digit(base)
     return commands;
 }
 
-// ASP set register
-register_dsp_command([0x0E], 2, function()
+// The CSP/ASP coprocessor is reported absent (as on most real SB16 cards);
+// drivers that detect one (e.g. Win9x CSPMAN.DLL) crash programming it.
+
+// ASP set mode register
+register_dsp_command([0x04], 1);
+
+// ASP set codec parameter
+register_dsp_command([0x05], 2);
+
+// ASP get version
+register_dsp_command([0x08], 1, function()
 {
-    this.asp_registers[this.write_buffer.shift()] = this.write_buffer.shift();
+    var sub_command = this.write_buffer.shift();
+    if(sub_command === 0x03)
+    {
+        this.read_buffer.clear();
+        this.read_buffer.push(0xFF); // no chip installed
+    }
 });
+
+// ASP set register
+register_dsp_command([0x0E], 2);
 
 // ASP get register
 register_dsp_command([0x0F], 1, function()


### PR DESCRIPTION
Mounting the Microsoft Office 97 disk on Windows 98 SE and closing its install wizard (which plays a sound) consistently crashes EXPLORER.EXE with:

<img width="747" height="297" alt="Screenshot 2026-06-11 at 16 29 03" src="https://github.com/user-attachments/assets/03a8dada-1f60-4a18-9860-eae30b9aea44" />

I tracked this down to the virtual SoundBlaster 16 audio device saying it supported CSP (advanced/creative signal processor) when it doesn't. Since CSP is not required to play sound, this PR just reports it as absent. I verified the same flow no longer crashes.