### PR TITLE
vmware: add GETTIME backdoor command (23)

### DIFF
--- a/src/vmware.js
+++ b/src/vmware.js
@@ -9,6 +9,7 @@ const VMWARE_PORT = 0x5658;
 const VMWARE_MAGIC = 0x564D5868;
 
 const CMD_GETVERSION = 10;
+const CMD_GETTIME = 23;
 const CMD_ABSPOINTER_DATA = 39;
 const CMD_ABSPOINTER_STATUS = 40;
 const CMD_ABSPOINTER_COMMAND = 41;
@@ -33,12 +34,14 @@ const RELATIVE_PACKET = 0x00010000;
 const QUEUE_MAX = 1024;
 
 /**
- * VMware mouse backdoor (port 0x5658). Lets a guest driver read absolute
- * pointer position so the guest cursor can track the host cursor 1:1 without
- * pointer lock. PS/2 still supplies the IRQ; the driver reads this port on
- * each IRQ12. While the host pointer is locked (e.g. for games), movement is
- * reported as relative packets instead, since no meaningful absolute position
- * exists.
+ * VMware backdoor (port 0x5658). Lets a guest driver read absolute pointer
+ * position so the guest cursor can track the host cursor 1:1 without pointer
+ * lock, and implements GETTIME (23) so a guest agent can keep the guest clock
+ * in sync with the host (guests only read the RTC at boot, so a restored
+ * state resumes with a stale clock). PS/2 still supplies the mouse IRQ; the
+ * driver reads this port on each IRQ12. While the host pointer is locked
+ * (e.g. for games), movement is reported as relative packets instead, since
+ * no meaningful absolute position exists.
  *
  * @constructor
  * @param {CPU} cpu
@@ -221,6 +224,22 @@ VMwareMouse.prototype.port_read32 = function()
         case CMD_GETVERSION:
             reg32[REG_EBX] = VMWARE_MAGIC;
             return 6;
+
+        case CMD_GETTIME:
+        {
+            // EAX = host time in seconds since the Unix epoch (UTC),
+            // EBX = remaining microseconds, ECX = maximum time lag in
+            // microseconds, EDX = host's offset from UTC in minutes (east
+            // positive). Deprecated upstream in favour of GETTIMEFULL because
+            // EAX overflows as a signed value in 2038, but it's the simplest
+            // command a 32-bit guest agent can consume — read unsigned it's
+            // good until 2106.
+            const now = Date.now();
+            reg32[REG_EBX] = now % 1000 * 1000;
+            reg32[REG_ECX] = 1000000;
+            reg32[REG_EDX] = -new Date(now).getTimezoneOffset();
+            return now / 1000 >>> 0;
+        }
 
         case CMD_ABSPOINTER_STATUS:
             return this.enabled ? this.queue.length : 0xFFFF0000 | 0;


### PR DESCRIPTION
Just like the other VMWare-related PRs, no hard feelings if you don't want them - I just want to upstream stuff I've done for Windows. This one implements implements VMware backdoor command 23 (`GETTIME`) on port 0x5658.

Return values in registers after the `IN EAX, DX`:

| Register | Value |
|----------|-------|
| EAX | Seconds since the Unix epoch (UTC), unsigned |
| EBX | Remaining microseconds (0–999 999) |
| ECX | Maximum time lag in microseconds (hardcoded 1 000 000) |
| EDX | Host's UTC offset in minutes, east positive |

Guests read the RTC only at boot. A VM resumed from a saved state continues running with whatever clock it was saved with, and the guest has no way to learn the correct time without rebooting.

With GETTIME, a small guest agent can issue a single backdoor call on a timer and compare its own `time()` against the host — no kernel driver, no full VMware Tools stack. The protocol is simple enough for a hand-rolled 16/32-bit DOS or Win9x TSR.

## Notes on GETTIMEFULL

VMware deprecated GETTIME in favour of command 35 (`GETTIMEFULL`) because EAX wraps as a *signed* value in 2038. Read as unsigned (which is what `>>> 0` gives JS, and what 32-bit C gives with `unsigned long`), EAX is valid until 2106. GETTIME is simpler for the guest to consume and is still the first thing open-vm-tools' `Backdoor_GetTime` wrapper tries. I think for our purposes her eis is probably fine :)