### PR TITLE
Mask VGA DAC indices to fix colors on some demoscene demos

### DIFF
--- a/src/vga.js
+++ b/src/vga.js
@@ -1641,7 +1641,7 @@ VGAScreen.prototype.port3C7_read = function()
 
 VGAScreen.prototype.port3C8_write = function(index)
 {
-    this.dac_color_index_write = index * 3;
+    this.dac_color_index_write = (index & 0xFF) * 3;
     this.dac_state |= 0x3;
 };
 
@@ -1658,7 +1658,7 @@ VGAScreen.prototype.port3C8_read = function()
  */
 VGAScreen.prototype.port3C9_write = function(color_byte)
 {
-    var index = this.dac_color_index_write / 3 | 0,
+    var index = this.dac_color_index_write / 3 & 0xFF,
         offset = this.dac_color_index_write % 3,
         color = this.vga256_palette[index];
 
@@ -1688,19 +1688,19 @@ VGAScreen.prototype.port3C9_write = function(color_byte)
         this.vga256_palette[index] = color;
         this.complete_redraw();
     }
-    this.dac_color_index_write++;
+    this.dac_color_index_write = (this.dac_color_index_write + 1) % (256 * 3);
 };
 
 VGAScreen.prototype.port3C9_read = function()
 {
     dbg_log("3C9 read", LOG_VGA);
 
-    var index = this.dac_color_index_read / 3 | 0;
+    var index = this.dac_color_index_read / 3 & 0xFF;
     var offset = this.dac_color_index_read % 3;
     var color = this.vga256_palette[index];
     var color8 = color >> (2 - offset) * 8 & 0xFF;
 
-    this.dac_color_index_read++;
+    this.dac_color_index_read = (this.dac_color_index_read + 1) % (256 * 3);
 
     if(this.dispi_enable_value & 0x20)
     {

--- a/src/vga.js
+++ b/src/vga.js
@@ -325,7 +325,7 @@ export function VGAScreen(cpu, bus, screen, vga_memory_size)
     io.register_write(0x3C6, this, this.port3C6_write);
     io.register_write(0x3C7, this, this.port3C7_write);
     io.register_read(0x3C7, this, this.port3C7_read);
-    io.register_write(0x3C8, this, this.port3C8_write);
+    io.register_write(0x3C8, this, this.port3C8_write, this.port3C8_write16);
     io.register_read(0x3C8, this, this.port3C8_read);
     io.register_write(0x3C9, this, this.port3C9_write);
     io.register_read(0x3C9, this, this.port3C9_read);
@@ -1643,6 +1643,12 @@ VGAScreen.prototype.port3C8_write = function(index)
 {
     this.dac_color_index_write = (index & 0xFF) * 3;
     this.dac_state |= 0x3;
+};
+
+VGAScreen.prototype.port3C8_write16 = function(data)
+{
+    this.port3C8_write(data & 0xFF);
+    this.port3C9_write(data >> 8 & 0xFF);
 };
 
 VGAScreen.prototype.port3C8_read = function()


### PR DESCRIPTION
Fixes https://github.com/copy/v86/issues/1596 by wrapping VGA DAC indices around at 255. 

I'm not sure any normal 13h application depends on this behavior, but I've noticed several tiny demoscene demos on Pouet triggering it. After wrapping the indices, colors match QEMU's output for me.

