### PR TITLE
Populate tag word after FST instruction

### DIFF
--- a/src/rust/cpu/fpu.rs
+++ b/src/rust/cpu/fpu.rs
@@ -605,7 +605,13 @@ pub unsafe fn fpu_load_tag_word() -> i32 {
     return tag_word;
 }
 #[no_mangle]
-pub unsafe fn fpu_fst(r: i32) { fpu_write_st(*fpu_stack_ptr as i32 + r & 7, fpu_get_st0()); }
+pub unsafe fn fpu_fst(r: i32) {
+    let index: i32 = *fpu_stack_ptr as i32 + r & 7;
+    fpu_write_st(index, fpu_get_st0());
+    if 0 == ((*fpu_stack_empty >> *fpu_stack_ptr) & 1) {
+        *fpu_stack_empty &= !(1 << index);
+    }
+}
 pub unsafe fn fpu_fst80p(addr: i32) {
     return_on_pagefault!(writable_or_pagefault(addr, 10));
     fpu_store_m80(addr, fpu_get_st0());

--- a/tests/nasm/fst-st-empty-tag.asm
+++ b/tests/nasm/fst-st-empty-tag.asm
@@ -1,0 +1,14 @@
+global _start
+
+%include "header.inc"
+
+    fldz
+    fst st1
+    fistp word [esp]
+    fadd dword [value]
+    fstp dword [esp + 4]
+
+value:
+    dd 3f800000h
+
+%include "footer.inc"

--- a/tests/nasm/fst-st-empty-tag.asm
+++ b/tests/nasm/fst-st-empty-tag.asm
@@ -1,5 +1,9 @@
 global _start
 
+section .data
+value:
+    dd 3f800000h
+
 %include "header.inc"
 
     fldz
@@ -7,8 +11,5 @@ global _start
     fistp word [esp]
     fadd dword [value]
     fstp dword [esp + 4]
-
-value:
-    dd 3f800000h
 
 %include "footer.inc"


### PR DESCRIPTION
Fixes https://github.com/copy/v86/issues/1599 .

The demo in question used FST to store a temporary variable, and FISTP to pop the value off the stack. The emulator copied the value after the FST instruction, but didn't update the tag word so nothing came back when it popped.

This commit updates "fpu_stack_empty" in the FST handler, which fixed the demo for me:
<img width="672" height="506" alt="Screenshot 2026-06-24 at 7 11 54 PM" src="https://github.com/user-attachments/assets/c597ae32-5b79-46d5-ab02-29f1c7cd9ed9" />
https://parkertomatoes.github.io/demo-parade/?which=1843 (again, apologies for the rude title)

Also added an llm-written regression test that uses FST/FISTP to put the FPU in a bad state if FST doesn't set the tag word. 