### PR TITLE
Use rounded quotient for remainder for FPREM1

### DIFF
--- a/src/rust/cpu/fpu.rs
+++ b/src/rust/cpu/fpu.rs
@@ -498,9 +498,9 @@ pub unsafe fn fpu_fprem(ieee: bool) {
     let exp1 = st1.log2();
     let d = (exp0 - exp1).abs();
     if !intel_compatibility || d < F80::of_f64(f64::to_bits(64.0)) {
-        let fprem_quotient =
-            (if ieee { (st0 / st1).round() } else { (st0 / st1).trunc() }).to_i32();
-        fpu_write_st(*fpu_stack_ptr as i32, st0 % st1);
+        let fprem_quotient = if ieee { (st0 / st1).round() } else { (st0 / st1).trunc() };
+        fpu_write_st(*fpu_stack_ptr as i32, st0 - st1 * fprem_quotient);
+        let fprem_quotient = fprem_quotient.to_i32();
         *fpu_status_word &= !(FPU_C0 | FPU_C1 | FPU_C3);
         if 0 != fprem_quotient & 1 {
             *fpu_status_word |= FPU_C1

--- a/tests/nasm/fprem-distinct.asm
+++ b/tests/nasm/fprem-distinct.asm
@@ -1,0 +1,19 @@
+global _start
+
+%include "header.inc"
+
+    ; FPREM1 rounds the quotient: round(5 / 3) = 2, remainder = -1.
+    mov dword [esp], 3
+    fild dword [esp]
+    mov dword [esp], 5
+    fild dword [esp]
+    fprem1
+
+    ; FPREM truncates the quotient: trunc(5 / 3) = 1, remainder = 2.
+    mov dword [esp], 3
+    fild dword [esp]
+    mov dword [esp], 5
+    fild dword [esp]
+    fprem
+
+%include "footer.inc"


### PR DESCRIPTION
Fixes https://github.com/copy/v86/issues/1601 .

Issue turned out to be FPREM1, which the demo uses for its graphics generation. The current implementation correctly rounds the quotient for FPREM1. But it uses an integer modulus for the remainder, effectively truncating the operands for both FPREM and FPREM1. This was enough to cause the effects in the demo. After applying this fix, it "remnants" renders correctly in V86 (albeit very slowly):

<img width="658" height="421" alt="Screenshot 2026-06-25 at 8 02 19 PM" src="https://github.com/user-attachments/assets/9d3fdb92-4ed7-4b14-9a9b-867263a45992" />


