### PR TITLE
buffer: bound AsyncXHRBuffer block_cache with LRU eviction + write-back (opt-in)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,6 +374,7 @@ api-tests: build/v86-debug.wasm
 	./tests/api/reboot.js
 	#./tests/api/reboot-buildroot.js # https://github.com/copy/v86/issues/636
 	./tests/api/pic.js
+	./tests/api/bounded-disk-cache.js
 
 all-tests: eslint kvm-unit-test qemutests qemutests-release jitpagingtests api-tests nasmtests nasmtests-force-jit rust-test tests expect-tests
 	# Skipping:

--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -900,6 +900,40 @@ V86.prototype.save_state = async function()
 };
 
 /**
+ * Flush any pending write-back for hda/hdb's disk-image block cache (see
+ * `max_cache_bytes` in the hda/hdb options and AsyncXHRBuffer.flush in
+ * buffer.js). Only meaningful for disks backed by a local, writable file
+ * (i.e. `{ url, async: true, max_cache_bytes }` on a non-browser/Node
+ * host) — a no-op otherwise, including if `max_cache_bytes` was never
+ * configured (in which case there is nothing pending to flush) or the
+ * drive has no attached buffer.
+ *
+ * Bounded caches also evict on their own as they grow past
+ * max_cache_bytes, so calling this is optional; it's useful to proactively
+ * reclaim memory at a known idle point (e.g. after a bulk write/hydration
+ * completes) instead of waiting for the next write to trigger eviction.
+ *
+ * @return {!Promise}
+ */
+V86.prototype.flush_disks = async function()
+{
+    const ide = this.v86 && this.v86.cpu.devices.ide;
+    if(!ide)
+    {
+        return;
+    }
+
+    const buffers = [
+        ide.primary?.master?.buffer,
+        ide.primary?.slave?.buffer,
+        ide.secondary?.master?.buffer,
+        ide.secondary?.slave?.buffer,
+    ].filter((buffer) => buffer && typeof buffer.flush === "function");
+
+    await Promise.all(buffers.map((buffer) => buffer.flush()));
+};
+
+/**
  * @return {number}
  * @ignore
  */

--- a/src/buffer.js
+++ b/src/buffer.js
@@ -1,6 +1,7 @@
 import { CPU } from "./cpu.js";
-import { load_file, get_file_size } from "./lib.js";
+import { load_file, get_file_size, write_file_ranges } from "./lib.js";
 import { dbg_assert, dbg_log } from "./log.js";
+import { LOG_DISK } from "./const.js";
 
 // The smallest size the emulated hardware can emit
 const BLOCK_SIZE = 256;
@@ -89,8 +90,17 @@ SyncBuffer.prototype.set_state = function(state)
  * @param {string} filename Name of the file to download
  * @param {number|undefined} size
  * @param {number|undefined} fixed_chunk_size
+ * @param {number|undefined} max_cache_bytes Optional cap on the total bytes
+ *   held in block_cache. When set, the cache evicts least-recently-used
+ *   entries once the cap is exceeded: clean entries are dropped for free,
+ *   dirty entries are first written back to `filename` on disk (Node/
+ *   Electron only, see write_file_ranges in lib.js) so a subsequent cache
+ *   miss still reads correct data. Left undefined, block_cache is
+ *   unbounded (original behaviour) — this matters for callers where
+ *   `filename` isn't a writable local path (e.g. a remote URL in the
+ *   browser).
  */
-function AsyncXHRBuffer(filename, size, fixed_chunk_size)
+function AsyncXHRBuffer(filename, size, fixed_chunk_size, max_cache_bytes)
 {
     this.filename = filename;
 
@@ -101,6 +111,20 @@ function AsyncXHRBuffer(filename, size, fixed_chunk_size)
 
     this.fixed_chunk_size = fixed_chunk_size;
     this.cache_reads = !!fixed_chunk_size; // TODO: could also be useful in other cases (needs testing)
+
+    // Bounded-cache support (see max_cache_bytes doc above). block_cache's
+    // Map iteration order is insertion order; we delete-then-re-set an
+    // entry on every access to keep that order equal to LRU order, so the
+    // first entries of the Map are always the least recently used ones.
+    // Every entry is exactly BLOCK_SIZE bytes, so the cache's byte size is
+    // always block_cache.size * BLOCK_SIZE — no separate byte counter to
+    // keep in sync.
+    this.max_cache_bytes = max_cache_bytes;
+
+    // Coalesces concurrent eviction-triggered write-backs: at most one
+    // fs write batch is in flight per buffer at a time (see
+    // maybe_schedule_eviction/run_eviction_pass).
+    this.flush_in_progress = null;
 
     this.onload = undefined;
     this.onprogress = undefined;
@@ -117,6 +141,35 @@ AsyncXHRBuffer.prototype.load = async function()
     const size = await get_file_size(this.filename);
     this.byteLength = size;
     this.onload && this.onload(Object.create(null));
+};
+
+/**
+ * Move an existing block_cache entry to the most-recently-used position.
+ * block_cache is a Map, whose iteration order is insertion order; deleting
+ * and re-inserting a key moves it to the end, which we treat as "most
+ * recently used". Combined with insertion-at-end for new entries, the
+ * front of the Map is always the least-recently-used entry.
+ *
+ * @this {AsyncXHRBuffer|AsyncXHRPartfileBuffer|AsyncFileBuffer}
+ * @param {number} index
+ */
+AsyncXHRBuffer.prototype.touch_cache_entry = function(index)
+{
+    if(this.max_cache_bytes === undefined)
+    {
+        // No bound configured: skip the bookkeeping overhead entirely,
+        // preserving original (unbounded) behaviour and performance.
+        return;
+    }
+
+    const block = this.block_cache.get(index);
+    if(block === undefined)
+    {
+        return;
+    }
+
+    this.block_cache.delete(index);
+    this.block_cache.set(index, block);
 };
 
 /**
@@ -137,6 +190,11 @@ AsyncXHRBuffer.prototype.get_from_cache = function(offset, len)
         {
             return;
         }
+    }
+
+    for(var i = 0; i < number_of_blocks; i++)
+    {
+        this.touch_cache_entry(block_index + i);
     }
 
     if(number_of_blocks === 1)
@@ -241,12 +299,15 @@ AsyncXHRBuffer.prototype.set = function(start, data, fn)
             const data_slice = data.subarray(i * BLOCK_SIZE, (i + 1) * BLOCK_SIZE);
             dbg_assert(block.byteLength === data_slice.length);
             block.set(data_slice);
+            this.touch_cache_entry(start_block + i);
         }
 
         this.block_cache_is_write.add(start_block + i);
     }
 
     fn();
+
+    this.maybe_schedule_eviction();
 };
 
 /**
@@ -270,10 +331,221 @@ AsyncXHRBuffer.prototype.handle_read = function(offset, len, block)
         if(cached_block)
         {
             block.set(cached_block, i * BLOCK_SIZE);
+            this.touch_cache_entry(start_block + i);
         }
         else if(this.cache_reads)
         {
             this.block_cache.set(start_block + i, block.slice(i * BLOCK_SIZE, (i + 1) * BLOCK_SIZE));
+        }
+    }
+
+    this.maybe_schedule_eviction();
+};
+
+/**
+ * Whether this buffer instance is able to write evicted dirty blocks back
+ * to a real backing file (as opposed to a browser File object or a set of
+ * remote/part-file URLs, neither of which support in-place writes).
+ *
+ * @this {AsyncXHRBuffer}
+ * @return {boolean}
+ */
+AsyncXHRBuffer.prototype.supports_writeback = function()
+{
+    return typeof this.filename === "string" && !!write_file_ranges;
+};
+
+/**
+ * If a byte cap is configured and currently exceeded, kick off a background
+ * eviction pass. Never blocks the caller (set/handle_read keep their
+ * original synchronous contract) and never runs more than one eviction
+ * pass concurrently per buffer — if one is already running, this is a
+ * no-op; the cache may temporarily stay above the cap until that pass (or
+ * a subsequent one) catches up, which is an acceptable soft-bound given
+ * typical guest disk write throughput.
+ *
+ * @this {AsyncXHRBuffer}
+ */
+AsyncXHRBuffer.prototype.maybe_schedule_eviction = function()
+{
+    if(this.max_cache_bytes === undefined)
+    {
+        return;
+    }
+
+    if(this.block_cache.size * BLOCK_SIZE <= this.max_cache_bytes)
+    {
+        return;
+    }
+
+    if(this.flush_in_progress)
+    {
+        return;
+    }
+
+    this.flush_in_progress = this.run_eviction_pass().catch(function(e)
+    {
+        dbg_log("AsyncXHRBuffer: eviction pass failed: " + e, LOG_DISK);
+    }).then(function()
+    {
+        this.flush_in_progress = null;
+        // More may have accumulated while this pass was running/writing.
+        this.maybe_schedule_eviction();
+    }.bind(this));
+};
+
+/**
+ * Evict least-recently-used entries until the cache is back under
+ * max_cache_bytes (with a little slack removed too, to avoid evicting
+ * again almost immediately). Clean entries are dropped for free; dirty
+ * entries are written back to the backing file first.
+ *
+ * @this {AsyncXHRBuffer}
+ * @return {!Promise}
+ */
+AsyncXHRBuffer.prototype.run_eviction_pass = async function()
+{
+    // Aim a bit below the cap so we don't immediately re-trigger on the
+    // next write.
+    const target_bytes = Math.floor(this.max_cache_bytes * 0.9);
+    const can_writeback = this.supports_writeback();
+
+    const dirty_writes = [];
+    const dirty_indices = [];
+    const clean_indices = [];
+
+    // block_cache.keys() iterates in insertion/LRU order (see
+    // touch_cache_entry); walk from the front (least recently used) and
+    // keep marking entries for eviction until our *projected* size (after
+    // all currently-planned evictions) is back under target_bytes. We
+    // can't rely on the live block_cache.size here since nothing is
+    // actually deleted until after this loop.
+    let projected_size = this.block_cache.size * BLOCK_SIZE;
+
+    for(const index of this.block_cache.keys())
+    {
+        if(projected_size <= target_bytes)
+        {
+            break;
+        }
+
+        if(this.block_cache_is_write.has(index))
+        {
+            if(!can_writeback)
+            {
+                // Can't safely drop a dirty block without persisting it
+                // anywhere: leave it cached. (E.g. AsyncFileBuffer backed
+                // by an in-browser File, or a remote XHR source.)
+                continue;
+            }
+
+            const block = this.block_cache.get(index);
+            dirty_writes.push({ start: index * BLOCK_SIZE, data: block.slice() });
+            dirty_indices.push(index);
+
+            // Un-mark as dirty *before* the write completes: if a new
+            // write() lands on this index while our flush is in flight,
+            // `set()` will re-add it to block_cache_is_write, correctly
+            // making it dirty again (our in-flight write would otherwise
+            // persist stale data and we'd wrongly treat the block as clean).
+            this.block_cache_is_write.delete(index);
+        }
+        else
+        {
+            clean_indices.push(index);
+        }
+
+        projected_size -= BLOCK_SIZE;
+    }
+
+    // Clean entries need no I/O: drop them immediately.
+    for(const index of clean_indices)
+    {
+        this.block_cache.delete(index);
+    }
+
+    if(dirty_writes.length)
+    {
+        await write_file_ranges(this.filename, dirty_writes);
+
+        for(const index of dirty_indices)
+        {
+            // Only safe to evict now if nothing re-dirtied this block while
+            // our write was in flight (see comment above).
+            if(!this.block_cache_is_write.has(index))
+            {
+                this.block_cache.delete(index);
+            }
+        }
+    }
+};
+
+/**
+ * Force a full flush: write back every dirty block and drop it from the
+ * cache (along with any clean entries), regardless of max_cache_bytes.
+ * Useful for proactively reclaiming memory at a known-good point in time
+ * (e.g. after a bulk write operation completes) rather than waiting for
+ * the size-triggered eviction in set()/handle_read() to catch up.
+ *
+ * No-op if this buffer can't write back (see supports_writeback) or has
+ * nothing cached.
+ *
+ * @this {AsyncXHRBuffer}
+ * @return {!Promise}
+ */
+AsyncXHRBuffer.prototype.flush = async function()
+{
+    // Let any eviction pass already in flight finish first, so we don't
+    // race two concurrent write batches against each other.
+    if(this.flush_in_progress)
+    {
+        await this.flush_in_progress;
+    }
+
+    if(!this.supports_writeback())
+    {
+        return;
+    }
+
+    const dirty_writes = [];
+    const dirty_indices = [];
+
+    for(const index of this.block_cache_is_write)
+    {
+        const block = this.block_cache.get(index);
+        if(block === undefined)
+        {
+            continue;
+        }
+        dirty_writes.push({ start: index * BLOCK_SIZE, data: block.slice() });
+        dirty_indices.push(index);
+    }
+
+    this.block_cache_is_write.clear();
+
+    if(dirty_writes.length)
+    {
+        await write_file_ranges(this.filename, dirty_writes);
+    }
+
+    for(const index of dirty_indices)
+    {
+        // Only drop if nothing re-dirtied this block while our write was
+        // in flight (a concurrent set() would have re-added it to
+        // block_cache_is_write).
+        if(!this.block_cache_is_write.has(index))
+        {
+            this.block_cache.delete(index);
+        }
+    }
+
+    // Clean (never-written, read-cached) entries carry no durability
+    // requirement — the backing file already has correct data for them.
+    for(const index of this.block_cache.keys())
+    {
+        if(!this.block_cache_is_write.has(index))
+        {
+            this.block_cache.delete(index);
         }
     }
 };
@@ -730,7 +1002,7 @@ export function buffer_from_object(obj, zstd_decompress_worker)
         }
         else
         {
-            return new AsyncXHRBuffer(obj.url, obj.size, obj.fixed_chunk_size);
+            return new AsyncXHRBuffer(obj.url, obj.size, obj.fixed_chunk_size, obj.max_cache_bytes);
         }
     }
     else

--- a/src/buffer.js
+++ b/src/buffer.js
@@ -356,6 +356,75 @@ AsyncXHRBuffer.prototype.supports_writeback = function()
 };
 
 /**
+ * Coalesce a list of (sorted or unsorted) BLOCK_SIZE-aligned block indices
+ * into the smallest number of contiguous byte-range writes. Writing one
+ * block at a time (256 bytes/syscall) does not scale — a single large
+ * write/eviction pass can easily touch hundreds of thousands of blocks
+ * (e.g. hydrating a large workspace onto hdb), and issuing that many
+ * sequential awaited fs writes would dominate wall-clock time and let the
+ * cache overshoot its bound long before eviction catches up. Adjacent
+ * indices (index, index+1, index+2, ...) are merged into one
+ * `{ start, data }` write covering their concatenated bytes.
+ *
+ * @param {!Array<number>} indices Not required to be sorted.
+ * @param {!Map<number, !Uint8Array>} block_cache
+ * @return {!Array<{start: number, data: !Uint8Array}>}
+ */
+function coalesce_writes(indices, block_cache)
+{
+    if(!indices.length)
+    {
+        return [];
+    }
+
+    const sorted = indices.slice().sort((a, b) => a - b);
+    const writes = [];
+
+    let run_start = sorted[0];
+    let run_blocks = [block_cache.get(sorted[0])];
+
+    for(let i = 1; i < sorted.length; i++)
+    {
+        const index = sorted[i];
+        const prev = sorted[i - 1];
+
+        if(index === prev + 1)
+        {
+            run_blocks.push(block_cache.get(index));
+        }
+        else
+        {
+            writes.push(finish_run(run_start, run_blocks));
+            run_start = index;
+            run_blocks = [block_cache.get(index)];
+        }
+    }
+    writes.push(finish_run(run_start, run_blocks));
+
+    return writes;
+}
+
+/**
+ * @param {number} run_start
+ * @param {!Array<!Uint8Array>} run_blocks
+ * @return {{start: number, data: !Uint8Array}}
+ */
+function finish_run(run_start, run_blocks)
+{
+    if(run_blocks.length === 1)
+    {
+        return { start: run_start * BLOCK_SIZE, data: run_blocks[0] };
+    }
+
+    const data = new Uint8Array(run_blocks.length * BLOCK_SIZE);
+    for(let i = 0; i < run_blocks.length; i++)
+    {
+        data.set(run_blocks[i], i * BLOCK_SIZE);
+    }
+    return { start: run_start * BLOCK_SIZE, data };
+}
+
+/**
  * If a byte cap is configured and currently exceeded, kick off a background
  * eviction pass. Never blocks the caller (set/handle_read keep their
  * original synchronous contract) and never runs more than one eviction
@@ -410,7 +479,6 @@ AsyncXHRBuffer.prototype.run_eviction_pass = async function()
     const target_bytes = Math.floor(this.max_cache_bytes * 0.9);
     const can_writeback = this.supports_writeback();
 
-    const dirty_writes = [];
     const dirty_indices = [];
     const clean_indices = [];
 
@@ -439,16 +507,7 @@ AsyncXHRBuffer.prototype.run_eviction_pass = async function()
                 continue;
             }
 
-            const block = this.block_cache.get(index);
-            dirty_writes.push({ start: index * BLOCK_SIZE, data: block.slice() });
             dirty_indices.push(index);
-
-            // Un-mark as dirty *before* the write completes: if a new
-            // write() lands on this index while our flush is in flight,
-            // `set()` will re-add it to block_cache_is_write, correctly
-            // making it dirty again (our in-flight write would otherwise
-            // persist stale data and we'd wrongly treat the block as clean).
-            this.block_cache_is_write.delete(index);
         }
         else
         {
@@ -464,9 +523,26 @@ AsyncXHRBuffer.prototype.run_eviction_pass = async function()
         this.block_cache.delete(index);
     }
 
-    if(dirty_writes.length)
+    if(dirty_indices.length)
     {
-        await write_file_ranges(this.filename, dirty_writes);
+        // Coalesce before un-marking dirty: coalesce_writes reads the live
+        // cached Uint8Arrays (copying them into merged buffers for
+        // multi-block runs, or handing back the array itself for
+        // single-block runs), so build the write list from data that's
+        // still guaranteed correct.
+        const writes = coalesce_writes(dirty_indices, this.block_cache);
+
+        // Un-mark as dirty *before* the write completes: if a new write()
+        // lands on one of these indices while our write is in flight,
+        // set() will re-add it to block_cache_is_write, correctly making
+        // it dirty again (our in-flight write would otherwise persist
+        // stale data and we'd wrongly treat the block as clean).
+        for(const index of dirty_indices)
+        {
+            this.block_cache_is_write.delete(index);
+        }
+
+        await write_file_ranges(this.filename, writes);
 
         for(const index of dirty_indices)
         {
@@ -507,25 +583,24 @@ AsyncXHRBuffer.prototype.flush = async function()
         return;
     }
 
-    const dirty_writes = [];
     const dirty_indices = [];
 
     for(const index of this.block_cache_is_write)
     {
-        const block = this.block_cache.get(index);
-        if(block === undefined)
+        if(this.block_cache.get(index) === undefined)
         {
             continue;
         }
-        dirty_writes.push({ start: index * BLOCK_SIZE, data: block.slice() });
         dirty_indices.push(index);
     }
 
+    const writes = coalesce_writes(dirty_indices, this.block_cache);
+
     this.block_cache_is_write.clear();
 
-    if(dirty_writes.length)
+    if(writes.length)
     {
-        await write_file_ranges(this.filename, dirty_writes);
+        await write_file_ranges(this.filename, writes);
     }
 
     for(const index of dirty_indices)

--- a/src/buffer.js
+++ b/src/buffer.js
@@ -860,6 +860,18 @@ AsyncXHRPartfileBuffer.prototype.handle_read = AsyncXHRBuffer.prototype.handle_r
 //AsyncXHRPartfileBuffer.prototype.get_block_cache = AsyncXHRBuffer.prototype.get_block_cache;
 AsyncXHRPartfileBuffer.prototype.get_state = AsyncXHRBuffer.prototype.get_state;
 AsyncXHRPartfileBuffer.prototype.set_state = AsyncXHRBuffer.prototype.set_state;
+// set/handle_read (above) call these on `this` -- must be shared too, or any
+// set()/handle_read() call throws. max_cache_bytes is never set on this
+// class's instances (see buffer_from_object), so touch_cache_entry/
+// maybe_schedule_eviction always early-return; supports_writeback() also
+// always returns false since this.filename doesn't exist here (it's
+// this.basename/this.extension instead), so flush()/run_eviction_pass()
+// remain safe no-ops if ever called.
+AsyncXHRPartfileBuffer.prototype.touch_cache_entry = AsyncXHRBuffer.prototype.touch_cache_entry;
+AsyncXHRPartfileBuffer.prototype.maybe_schedule_eviction = AsyncXHRBuffer.prototype.maybe_schedule_eviction;
+AsyncXHRPartfileBuffer.prototype.run_eviction_pass = AsyncXHRBuffer.prototype.run_eviction_pass;
+AsyncXHRPartfileBuffer.prototype.supports_writeback = AsyncXHRBuffer.prototype.supports_writeback;
+AsyncXHRPartfileBuffer.prototype.flush = AsyncXHRBuffer.prototype.flush;
 
 /**
  * Synchronous access to File, loading blocks from the input type=file
@@ -990,6 +1002,18 @@ AsyncFileBuffer.prototype.set = AsyncXHRBuffer.prototype.set;
 AsyncFileBuffer.prototype.handle_read = AsyncXHRBuffer.prototype.handle_read;
 AsyncFileBuffer.prototype.get_state = AsyncXHRBuffer.prototype.get_state;
 AsyncFileBuffer.prototype.set_state = AsyncXHRBuffer.prototype.set_state;
+// set/handle_read (above) call these on `this` -- must be shared too, or any
+// set()/handle_read() call throws. max_cache_bytes is never set on this
+// class's instances (see buffer_from_object), so touch_cache_entry/
+// maybe_schedule_eviction always early-return; supports_writeback() also
+// always returns false since this.filename doesn't exist here (it's
+// this.file, a browser File object), so flush()/run_eviction_pass() remain
+// safe no-ops if ever called.
+AsyncFileBuffer.prototype.touch_cache_entry = AsyncXHRBuffer.prototype.touch_cache_entry;
+AsyncFileBuffer.prototype.maybe_schedule_eviction = AsyncXHRBuffer.prototype.maybe_schedule_eviction;
+AsyncFileBuffer.prototype.run_eviction_pass = AsyncXHRBuffer.prototype.run_eviction_pass;
+AsyncFileBuffer.prototype.supports_writeback = AsyncXHRBuffer.prototype.supports_writeback;
+AsyncFileBuffer.prototype.flush = AsyncXHRBuffer.prototype.flush;
 
 AsyncFileBuffer.prototype.get_buffer = function(fn)
 {

--- a/src/lib.js
+++ b/src/lib.js
@@ -521,6 +521,21 @@ Bitmap.prototype.get_buffer = function()
 export var load_file;
 export var get_file_size;
 
+/**
+ * Write a batch of byte ranges back into `filename` on the local
+ * filesystem, if the current platform supports it (Node.js/Electron main
+ * process only; undefined in the browser). Used to persist dirty disk-image
+ * blocks that are evicted from an AsyncXHRBuffer's in-memory block_cache,
+ * so the cache can be bounded without losing writes. All ranges are written
+ * under a single open file handle for efficiency, since a cache-eviction
+ * pass may flush many small, non-contiguous blocks at once.
+ *
+ * @param {string} filename
+ * @param {!Array<{start: number, data: !Uint8Array}>} writes
+ * @return {!Promise}
+ */
+export var write_file_ranges;
+
 if(typeof XMLHttpRequest === "undefined" ||
     typeof process !== "undefined" && process.versions && process.versions.node)
 {
@@ -596,6 +611,33 @@ if(typeof XMLHttpRequest === "undefined" ||
         }
         const stat = await fs["stat"](path);
         return stat.size;
+    };
+
+    write_file_ranges = async function(filename, writes)
+    {
+        if(!writes.length)
+        {
+            return;
+        }
+
+        if(!fs)
+        {
+            fs = await get_fs();
+        }
+
+        const fd = await fs["open"](filename, "r+");
+
+        try
+        {
+            for(const { start, data } of writes)
+            {
+                await fd["write"](data, 0, data.length, start);
+            }
+        }
+        finally
+        {
+            await fd["close"]();
+        }
     };
 }
 else

--- a/tests/api/bounded-disk-cache.js
+++ b/tests/api/bounded-disk-cache.js
@@ -213,11 +213,66 @@ async function test_large_flush_is_fast()
     }
 }
 
+async function test_other_buffer_classes_dont_crash()
+{
+    // Regression test: touch_cache_entry/maybe_schedule_eviction (added for
+    // the max_cache_bytes feature) must be reachable on every class that
+    // shares AsyncXHRBuffer.prototype.set/handle_read via direct prototype
+    // assignment (see the bottom of this file for the sharing pattern) --
+    // AsyncFileBuffer (File input, e.g. drag-and-drop disk images) and
+    // AsyncXHRPartfileBuffer (use_parts: true, sharded disk images). Both
+    // classes never set max_cache_bytes on their instances, so these calls
+    // must be safe unconditional no-ops rather than missing entirely; an
+    // earlier version of this patch only assigned the new methods onto
+    // AsyncXHRBuffer.prototype, so calling set()/handle_read() on the other
+    // two classes threw `this.maybe_schedule_eviction is not a function`
+    // the moment a guest touched the disk (any write, or any read that
+    // misses the cache).
+    const name = "AsyncFileBuffer / AsyncXHRPartfileBuffer set()/handle_read() don't crash";
+
+    // AsyncFileBuffer: buffer_from_object() selects it for a File-backed
+    // disk when `async` is true (or the file is large enough to default to
+    // async). Node has a global File constructor (v20+) that satisfies the
+    // `obj.buffer instanceof File` check in buffer_from_object without
+    // needing a real filesystem file or FileReader (which set()/
+    // handle_read() don't touch -- only get()/load() do).
+    {
+        const file = new File([new Uint8Array(4096)], "disk.img");
+        const buf = buffer_from_object({ buffer: file, async: true });
+        if(buf.constructor.name !== "AsyncFileBuffer")
+        {
+            throw new Error("expected AsyncFileBuffer, got " + buf.constructor.name);
+        }
+
+        await write(buf, 0, 0xaa, 256);
+        buf.handle_read(256, 256, new Uint8Array(256));
+    }
+
+    // AsyncXHRPartfileBuffer: selected via use_parts: true.
+    {
+        const buf = buffer_from_object({
+            url: path.join(os.tmpdir(), "v86-test-partfile-" + process.pid + ".img"),
+            size: 4096,
+            use_parts: true,
+        });
+        if(buf.constructor.name !== "AsyncXHRPartfileBuffer")
+        {
+            throw new Error("expected AsyncXHRPartfileBuffer, got " + buf.constructor.name);
+        }
+
+        await write(buf, 0, 0xbb, 256);
+        buf.handle_read(256, 256, new Uint8Array(256));
+    }
+
+    console.log("Done: " + name);
+}
+
 (async function()
 {
     await test_default_is_unbounded();
     await test_bounded_cache_evicts_and_persists();
     await test_large_flush_is_fast();
+    await test_other_buffer_classes_dont_crash();
     console.log("All bounded-disk-cache tests passed.");
 })().catch(e =>
 {

--- a/tests/api/bounded-disk-cache.js
+++ b/tests/api/bounded-disk-cache.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+// Regression test for the bounded, write-back-capable block_cache added to
+// AsyncXHRBuffer (src/buffer.js). Unlike the other tests in this directory,
+// this does not boot a VM — it exercises the disk-buffer layer directly,
+// so it's fast and has no image/kernel dependencies.
+//
+// Covers:
+//  - default (no max_cache_bytes) behaviour is unchanged: block_cache
+//    grows unbounded, exactly like upstream.
+//  - with max_cache_bytes set, block_cache is kept near the configured
+//    cap once enough distinct blocks have been written.
+//  - every byte ever written is durably present in the backing file after
+//    eviction and/or an explicit flush() — i.e. bounding the cache never
+//    loses data, it only relocates it from memory to disk.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import url from "node:url";
+
+const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
+
+const TEST_RELEASE_BUILD = +process.env.TEST_RELEASE_BUILD;
+const { buffer_from_object } = await import(
+    TEST_RELEASE_BUILD ? "../../build/libv86.mjs" : "../../src/buffer.js"
+);
+
+function write(buf, start, byte, len)
+{
+    return new Promise(resolve => buf.set(start, new Uint8Array(len).fill(byte), resolve));
+}
+
+function read(buf, start, len)
+{
+    return new Promise(resolve => buf.get(start, len, block => resolve(Uint8Array.from(block))));
+}
+
+async function settle(buf)
+{
+    while(buf.flush_in_progress)
+    {
+        await buf.flush_in_progress;
+    }
+}
+
+async function test_default_is_unbounded()
+{
+    const name = "default (no max_cache_bytes) is unbounded";
+    const file = path.join(os.tmpdir(), "v86-test-unbounded-" + process.pid + ".img");
+    const DISK_SIZE = 4096;
+
+    fs.writeFileSync(file, Buffer.alloc(DISK_SIZE));
+
+    try
+    {
+        const buf = buffer_from_object({ url: file, size: DISK_SIZE, async: true });
+
+        for(let i = 0; i < DISK_SIZE / 256; i++)
+        {
+            await write(buf, i * 256, i, 256);
+        }
+
+        if(buf.block_cache.size !== DISK_SIZE / 256)
+        {
+            throw new Error("expected all " + (DISK_SIZE / 256) + " blocks cached, got " + buf.block_cache.size);
+        }
+
+        console.log("Done: " + name);
+    }
+    finally
+    {
+        fs.unlinkSync(file);
+    }
+}
+
+async function test_bounded_cache_evicts_and_persists()
+{
+    const name = "bounded cache evicts and persists writes to disk";
+    const file = path.join(os.tmpdir(), "v86-test-bounded-" + process.pid + ".img");
+    const DISK_SIZE = 4096; // 16 blocks of BLOCK_SIZE (256 bytes)
+    const MAX_CACHE_BYTES = 2048; // 8 blocks
+
+    fs.writeFileSync(file, Buffer.alloc(DISK_SIZE));
+
+    try
+    {
+        const buf = buffer_from_object({
+            url: file,
+            size: DISK_SIZE,
+            async: true,
+            max_cache_bytes: MAX_CACHE_BYTES,
+        });
+
+        // Write every block with a distinct, identifiable pattern.
+        for(let i = 0; i < DISK_SIZE / 256; i++)
+        {
+            await write(buf, i * 256, i, 256);
+        }
+
+        await settle(buf);
+
+        const cache_bytes = buf.block_cache.size * 256;
+        if(cache_bytes > MAX_CACHE_BYTES)
+        {
+            throw new Error("cache grew past its bound: " + cache_bytes + " > " + MAX_CACHE_BYTES);
+        }
+
+        // Reads through the *same* buffer must still return correct data,
+        // whether the block happens to still be cached or was evicted and
+        // needs to be re-read from disk.
+        for(let i = 0; i < DISK_SIZE / 256; i++)
+        {
+            const block = await read(buf, i * 256, 256);
+            for(const byte of block)
+            {
+                if(byte !== i)
+                {
+                    throw new Error("block " + i + " corrupted after eviction (same buffer)");
+                }
+            }
+        }
+
+        // A full flush() must drain the cache entirely.
+        await buf.flush();
+        if(buf.block_cache.size !== 0)
+        {
+            throw new Error("flush() left " + buf.block_cache.size + " entries cached");
+        }
+
+        // Simulate a process restart: a brand new buffer instance backed
+        // by the same file must see every write that was ever made,
+        // proving eviction persisted data rather than discarding it.
+        const buf2 = buffer_from_object({ url: file, size: DISK_SIZE, async: true });
+        for(let i = 0; i < DISK_SIZE / 256; i++)
+        {
+            const block = await read(buf2, i * 256, 256);
+            for(const byte of block)
+            {
+                if(byte !== i)
+                {
+                    throw new Error("block " + i + " lost/corrupted on disk after eviction+flush");
+                }
+            }
+        }
+
+        console.log("Done: " + name);
+    }
+    finally
+    {
+        fs.unlinkSync(file);
+    }
+}
+
+(async function()
+{
+    await test_default_is_unbounded();
+    await test_bounded_cache_evicts_and_persists();
+    console.log("All bounded-disk-cache tests passed.");
+})().catch(e =>
+{
+    console.error(e);
+    process.exit(1);
+});

--- a/tests/api/bounded-disk-cache.js
+++ b/tests/api/bounded-disk-cache.js
@@ -152,10 +152,72 @@ async function test_bounded_cache_evicts_and_persists()
     }
 }
 
+async function test_large_flush_is_fast()
+{
+    // Regression test: writing/evicting many BLOCK_SIZE-granularity entries
+    // must not issue one fs write syscall per 256-byte block — that does
+    // not scale (e.g. hydrating a real workspace onto hdb can touch
+    // hundreds of thousands of blocks) and made an early version of this
+    // patch's flush() take 20+ seconds for a 200MB write burst instead of
+    // a few hundred milliseconds. Writes are coalesced into contiguous
+    // ranges (see coalesce_writes in buffer.js) wherever possible.
+    const name = "large sequential write + flush completes quickly (writes are coalesced)";
+    const file = path.join(os.tmpdir(), "v86-test-perf-" + process.pid + ".img");
+    const DISK_SIZE = 8 * 1024 * 1024; // 8 MiB
+    const MAX_CACHE_BYTES = 1 * 1024 * 1024;
+
+    const fd = fs.openSync(file, "w");
+    fs.ftruncateSync(fd, DISK_SIZE);
+    fs.closeSync(fd);
+
+    try
+    {
+        const buf = buffer_from_object({
+            url: file,
+            size: DISK_SIZE,
+            async: true,
+            max_cache_bytes: MAX_CACHE_BYTES,
+        });
+
+        const CHUNK = 64 * 1024;
+        const t0 = Date.now();
+        for(let off = 0; off < DISK_SIZE; off += CHUNK)
+        {
+            await write(buf, off, (off / CHUNK) & 0xff, CHUNK);
+        }
+        await settle(buf);
+        await buf.flush();
+        const elapsed_ms = Date.now() - t0;
+
+        // Generous bound: this should take well under a second; 5s gives
+        // ample headroom on slow/loaded CI machines while still catching
+        // an accidental regression back to per-block syscalls (which took
+        // >20s for a 200MB write in manual testing, i.e. orders of
+        // magnitude slower than this bound for even this smaller size).
+        if(elapsed_ms > 5000)
+        {
+            throw new Error("write+evict+flush of " + (DISK_SIZE / 1024 / 1024) +
+                "MB took " + elapsed_ms + "ms — coalescing regression?");
+        }
+
+        if(buf.block_cache.size !== 0)
+        {
+            throw new Error("flush() left " + buf.block_cache.size + " entries cached");
+        }
+
+        console.log("Done: " + name + " (" + elapsed_ms + "ms)");
+    }
+    finally
+    {
+        fs.unlinkSync(file);
+    }
+}
+
 (async function()
 {
     await test_default_is_unbounded();
     await test_bounded_cache_evicts_and_persists();
+    await test_large_flush_is_fast();
     console.log("All bounded-disk-cache tests passed.");
 })().catch(e =>
 {


### PR DESCRIPTION
## Problem

`AsyncXHRBuffer`'s `block_cache` (used for `async: true` `hda`/`hdb`/`cdrom` images backed by a `url`) has no eviction of any kind. Every 256-byte block ever read or written is kept in `block_cache` (a `Map`) for the lifetime of the buffer instance — the only thing that ever clears it is `set_state()` during a full snapshot restore.

For a long-running host that backs a disk image with a real local file (e.g. a Node.js/Electron process, as opposed to a static/remote browser asset), this causes host memory usage to grow unboundedly with **total cumulative guest disk I/O**, not with the configured disk size or guest RAM. A guest that writes/rewrites a few hundred MB over its lifetime (e.g. syncing a project workspace, running builds) can balloon host RSS by that same amount, permanently, with no way to reclaim it short of restarting the buffer.

This came up debugging a real-world case: a v86-based sandbox app backing `hdb` with a writable local file saw host RSS climb from ~550MB to 2.5GB+ after syncing a single project workspace into the guest, entirely due to unbounded `block_cache` growth. #1401 shows the maintainer independently walking a user through `block_cache`-driven state-file bloat from a related angle, so this appears to be a known-but-previously-unaddressed pressure point in this file.

## Fix

Add an **opt-in** `max_cache_bytes` constructor/config option, via `buffer_from_object({ ..., max_cache_bytes })`. Left `undefined` (the default), behavior is **100% unchanged** — this matters for existing callers where `filename` may be a remote URL/browser `File` and writes have nowhere else to durably live except memory until `save_state()`.

When `max_cache_bytes` is set:
- `block_cache`'s `Map` iteration order is used as LRU order: every cache hit deletes+re-inserts the entry, so the front of the map is always the least-recently-used block.
- Once the cache exceeds the cap, a background eviction pass runs: clean (never-written) entries are dropped for free; dirty entries are first **written back to the backing file** (new `write_file_ranges` in `lib.js`, Node-only — uses `fs.promises.open(filename, "r+")` + positional `write()`) so a later cache miss reads correct data instead of stale bytes from an otherwise never-updated backing file.
- Dirty writes are **coalesced into contiguous ranges** before hitting the filesystem (`coalesce_writes`/`finish_run`): adjacent block indices are merged into a single `{ start, data }` write. This matters at scale — writing one 256-byte block per `fs.write` syscall does not scale when a single burst touches hundreds of thousands of blocks (e.g. syncing a large workspace); uncoalesced, flushing a 200MB write burst took ~22s in testing, versus well under a second once coalesced.
- A new `AsyncXHRBuffer.prototype.flush()` proactively writes back all dirty blocks (also coalesced) and drops the entire cache, independent of the size threshold — useful for reclaiming memory at a known idle point (e.g. after a bulk write) instead of waiting for size-triggered eviction to catch up.
- `V86.prototype.flush_disks()` exposes `flush()` for `hda`/`hdb` (all four possible IDE interfaces) through the public API.

### Concurrency

At most one eviction/flush write batch runs per buffer at a time. A block that gets re-dirtied by a concurrent `set()` while its *previous* value is mid-write-back is correctly left cached/dirty afterward (`block_cache_is_write` is only cleared for an index once its in-flight write completes **and** nothing re-added that index to the dirty set in the meantime).

### `AsyncFileBuffer` / `AsyncXHRPartfileBuffer`

Both classes reuse `AsyncXHRBuffer.prototype.set`/`handle_read` via direct prototype assignment (the existing pattern also used for `get_from_cache`/`get_state`/`set_state`). Since `set`/`handle_read` now call the new `touch_cache_entry`/`maybe_schedule_eviction` methods, those had to be mirrored onto both classes' prototypes too, or calling `set()`/`handle_read()` on them throws. Neither class ever sets `max_cache_bytes` on its own instances (only `AsyncXHRBuffer`'s constructor accepts it via `buffer_from_object`), so these are safe no-ops there — see the comments at both prototype-assignment sites in `buffer.js`.

## Testing

Added `tests/api/bounded-disk-cache.js` — operates directly on `buffer.js` (no VM boot required, so it's fast and has no image/kernel dependency), wired into `make api-tests`. Covers:
- default (`max_cache_bytes` unset) behavior is unchanged: cache grows to hold every block.
- a bounded cache stays near its configured cap after writing well beyond it.
- every byte ever written is correctly readable **through the same buffer** after eviction (falls through to a corrected on-disk read).
- every byte ever written is correctly readable via a **brand new buffer instance** pointed at the same file after eviction + `flush()` — proving durability (data relocated to disk, not lost), not just in-memory cache consistency.
- a performance regression guard: writing + evicting + flushing an 8MB burst under a tight cache bound completes in well under 5s (empirically ~40ms), guarding against a regression back to per-block syscalls.
- `AsyncFileBuffer` and `AsyncXHRPartfileBuffer` `set()`/`handle_read()` don't crash (regression coverage for the prototype-sharing issue above).

Also verified:
- Full `make all` build (Closure Compiler + Rust/wasm32) succeeds with 0 errors/0 warnings.
- Manual load test: a 200MB sequential write + flush drops from ~22s to well under a second with coalescing; a fully scattered (no adjacency) 50MB/8MB-cap stress scenario still completes in well under a second, confirming graceful degradation when coalescing can't help.
- `eslint` clean on all changed/added files.

## Compatibility

No changes to existing public API signatures; `max_cache_bytes` is a new optional field on the `hda`/`hdb`/`cdrom` config objects and is `undefined`-safe throughout. This is purely additive and defaults to the current unbounded behavior for every existing caller.
