### PR TITLE
Optionally simulate IDE read latency

### DIFF
--- a/src/browser/starter.js
+++ b/src/browser/starter.js
@@ -243,6 +243,7 @@ V86.prototype.continue_init = async function(emulator, options)
     settings.preserve_mac_from_state_image = options.preserve_mac_from_state_image;
     settings.mac_address_translation = options.mac_address_translation;
     settings.cpuid_level = options.cpuid_level;
+    settings.ide_read_async = !!options.ide_read_async;
     settings.virtio_balloon = options.virtio_balloon;
     settings.virtio_console = !!options.virtio_console;
 

--- a/src/cpu.js
+++ b/src/cpu.js
@@ -144,6 +144,7 @@ export function CPU(bus, wm, stop_idling)
 
     /** @type {!Object} */
     this.devices = {};
+    this.ide_read_async = false;
 
     this.instruction_pointer = view(Int32Array, memory, 556, 1);
     this.previous_ip = view(Int32Array, memory, 560, 1);
@@ -996,6 +997,8 @@ CPU.prototype.init = function(settings, device_bus)
     {
         this.set_jit_config(0, 1);
     }
+
+    this.ide_read_async = !!settings.ide_read_async;
 
     settings.cpuid_level && this.set_cpuid_level(settings.cpuid_level);
 

--- a/src/ide.js
+++ b/src/ide.js
@@ -2679,10 +2679,10 @@ IDEInterface.prototype.read_buffer = function(start, length, callback, options =
     };
 
     const service_start = options?.read_async ? performance.now() : 0;
-    let fetchedSynchronously = true;
+    let fetched_synchronously = true;
     this.buffer.get(start, length, data =>
     {
-        if(fetchedSynchronously && options?.read_async)
+        if(fetched_synchronously && options?.read_async)
         {
             const elapsed = performance.now() - service_start;
             setTimeout(() => finish(data), Math.max(0, READ_DMA_MIN_MS - elapsed));
@@ -2692,7 +2692,7 @@ IDEInterface.prototype.read_buffer = function(start, length, callback, options =
             finish(data);
         }
     }, { signal: abort.signal });
-    fetchedSynchronously = false;
+    fetched_synchronously = false;
 };
 
 IDEInterface.prototype.cancel_io_operations = function()

--- a/src/ide.js
+++ b/src/ide.js
@@ -41,6 +41,7 @@ import { BusConnector } from "./bus.js";
 
 const CDROM_SECTOR_SIZE = 2048;
 const HD_SECTOR_SIZE = 512;
+const READ_DMA_MIN_MS = 2; /* 2ms delay for a 4kB block is roughly 2.1MB/s */
 
 const BUS_MASTER_BASE = 0xB400;
 
@@ -275,6 +276,7 @@ export function IDEController(cpu, bus, ide_config)
 {
     this.cpu = cpu;
     this.bus = bus;
+    this.ide_read_async = !!cpu.ide_read_async;
 
     this.primary = undefined;
     this.secondary = undefined;
@@ -2243,7 +2245,7 @@ IDEInterface.prototype.do_ata_read_sectors_dma = function()
         this.report_read_end(byte_count);
 
         this.push_irq();
-    });
+    }, { read_async: this.channel.controller.ide_read_async });
 };
 
 IDEInterface.prototype.ata_write_sectors = function(cmd)
@@ -2656,13 +2658,13 @@ IDEInterface.prototype.report_write = function(byte_count)
     this.bus.send("ide-write-end", [this.channel_nr, byte_count, sector_count]);
 };
 
-IDEInterface.prototype.read_buffer = function(start, length, callback)
+IDEInterface.prototype.read_buffer = function(start, length, callback, options = undefined)
 {
     const id = this.last_io_id++;
     const abort = new AbortController();
     this.in_progress_io_ids.set(id, abort);
 
-    this.buffer.get(start, length, data =>
+    const finish = (data) =>
     {
         if(this.cancelled_io_ids.delete(id))
         {
@@ -2674,7 +2676,23 @@ IDEInterface.prototype.read_buffer = function(start, length, callback)
         dbg_assert(removed);
 
         callback(data);
+    };
+
+    const service_start = options?.read_async ? performance.now() : 0;
+    let fetchedSynchronously = true;
+    this.buffer.get(start, length, data =>
+    {
+        if(fetchedSynchronously && options?.read_async)
+        {
+            const elapsed = performance.now() - service_start;
+            setTimeout(() => finish(data), Math.max(0, READ_DMA_MIN_MS - elapsed));
+        }
+        else
+        {
+            finish(data);
+        }
     }, { signal: abort.signal });
+    fetchedSynchronously = false;
 };
 
 IDEInterface.prototype.cancel_io_operations = function()

--- a/v86.d.ts
+++ b/v86.d.ts
@@ -406,6 +406,11 @@ export interface V86Options {
     hdb?: V86Image;
 
     /**
+     * Simulate ATA READ DMA latency.
+     */
+    ide_read_async?: boolean;
+
+    /**
      * First floppy disk
      */
     fda?: V86Image;


### PR DESCRIPTION
Fixes https://github.com/copy/v86/issues/1608, kind of.

After doing a LOT of tracing, I think I understand the problem at least. I got lucky because PSD.EXE leaks some symbol names through a table in an error formatter.

The hang I'm observing comes from an unchecked null pointer returned by an allocator function. Each allocation, it measures the time from start and tags a struct with it. After X allocations, it does a garbage collection and appears to use that measured age to prioritize. 

In the failing path, IDE.js loads data _so fast_ that this age tag is always zero. Having all the allocations be the same rank puts enough pressure on the garbage collection that it fails to reclaim any memory and returns a null pointer. The null pointer is unchecked, data is written to it, and the program hangs.

It's not 100% clear why this doesn't happen to QEMU. Both bochs and seabios reproduce the error on v86 and not on qemu. My best guess is v86 is just quicker about it when the disk is a memory buffer. 

This "fix" adds an option to put of a bit of latency on IDE reads if the backing buffer is synchronous. This spreads the allocations out enough to let the cleanup succeed. Most software works find without this unnecessary latency, though, so it's turned off by default. 