### PR TITLE
Update vga.js

### DIFF
--- a/src/vga.js
+++ b/src/vga.js
@@ -2536,10 +2536,14 @@ VGAScreen.prototype.screen_fill_buffer = function()
             // XXX: Doesn't take svga_offset into account
             const buffer = new Int32Array(this.cpu.wasm_memory.buffer, this.dest_buffet_offset, this.screen_width * this.screen_height);
             const svga_memory = new Uint8Array(this.cpu.wasm_memory.buffer, this.svga_memory.byteOffset, this.vga_memory_size);
+            // svga_offset selects which region of svga_memory is actually being shown, which programs use for double buffering / page flipping 
+            // This has to be applied here too to avoid the displayed image freezing on whatever was last written at offset 0 when a program flips away
+            // from it. (Master of Orion 2 640x480x256 VESA mode).
+            const base = this.svga_offset % this.vga_memory_size;
 
             for(var i = 0; i < buffer.length; i++)
             {
-                var color = this.vga256_palette[svga_memory[i]];
+                var color = this.vga256_palette[svga_memory[(base + i) % this.vga_memory_size]];
                 buffer[i] = color & 0xFF00 | color << 16 | color >> 16 | 0xFF000000;
             }
         }

--- a/src/vga.js
+++ b/src/vga.js
@@ -2533,17 +2533,15 @@ VGAScreen.prototype.screen_fill_buffer = function()
         if(this.svga_bpp === 8)
         {
             // XXX: Slow, should be ported to rust, but it doesn't have access to vga256_palette
-            // XXX: Doesn't take svga_offset into account
             const buffer = new Int32Array(this.cpu.wasm_memory.buffer, this.dest_buffet_offset, this.screen_width * this.screen_height);
             const svga_memory = new Uint8Array(this.cpu.wasm_memory.buffer, this.svga_memory.byteOffset, this.vga_memory_size);
-            // svga_offset selects which region of svga_memory is actually being shown, which programs use for double buffering / page flipping 
-            // This has to be applied here too to avoid the displayed image freezing on whatever was last written at offset 0 when a program flips away
-            // from it. (Master of Orion 2 640x480x256 VESA mode).
-            const base = this.svga_offset % this.vga_memory_size;
+            // svga_offset selects the visible part of svga_memory, used for page flipping (e.g. Master of Orion 2)
+            const base = this.svga_offset;
+            const end = Math.min(buffer.length, this.vga_memory_size - base);
 
-            for(var i = 0; i < buffer.length; i++)
+            for(var i = 0; i < end; i++)
             {
-                var color = this.vga256_palette[svga_memory[(base + i) % this.vga_memory_size]];
+                var color = this.vga256_palette[svga_memory[base + i]];
                 buffer[i] = color & 0xFF00 | color << 16 | color >> 16 | 0xFF000000;
             }
         }


### PR DESCRIPTION
fix: prevent image freezes caused by svga_offset

This PR fixes a screen freeze in some svga dependant games. 

The SVGA 8bpp fast path in `screen_fill_buffer` ignores `svga_offset`, causing permanent display freezes with page-flipped double buffering.

`VGAScreen.prototype.screen_fill_buffer`'s fast path for 8bpp SVGA modes reads the displayed frame starting at byte `0` of `svga_memory` always, which ignores `svga_offset` that `port1CF_write` sets from `VBE_DISPI_INDEX_X_OFFSET`/`VBE_DISPI_INDEX_Y_OFFSET`.

This is the standard VBE "Set Display Start" call that real VESA-aware software uses for page-flipped double buffering, it renders the next frame into a back buffer elsewhere in `svga_memory` and then flips the display-start offset to it instead of copying pixels.

Since this fast path always paints from offset `0`, any program that flips the display start away from `0` gets a display that silently freezes on whatever was last drawn at offset `0` while the program keeps rendering correctly into the buffer v86 no longer looks at. 

<img width="1154" height="805" alt="2026-08-21_11-23_1" src="https://github.com/user-attachments/assets/2495d71f-d952-4aba-b746-a1666721b820" />


Given that there is no error, it was really hard to debug from my side.

The existing code already has a comment to this fact:

```js
// XXX: Slow, should be ported to rust, but it doesn't have access to vga256_palette
// XXX: Doesn't take svga_offset into account
```

This PR fixes the second XXX.

I've tested it with Master of Orion 2 and display freeze is fully resolved.

<img width="1142" height="807" alt="2026-08-21_11-19" src="https://github.com/user-attachments/assets/9721e755-23b3-4341-b6d4-7c7839a2c5ae" />

This will help any 90s era game that uses page flipping.

Edit: Formatting.

