### PR TITLE
iso9660: implement Joliet

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ list of emulated hardware:
 - A generic VGA card with SVGA support and Bochs VBE Extensions.
 - A PCI bus. This one is partly incomplete and not used by every device.
 - An IDE disk controller.
-  - A built-in ISO 9660 CD-ROM generator.
+  - A built-in ISO 9660 CD-ROM generator with Joliet support.
 - An NE2000 (RTL8390) PCI network card.
 - Various virtio devices: Filesystem, network and balloon.
 - A SoundBlaster 16 sound card.

--- a/src/iso9660.js
+++ b/src/iso9660.js
@@ -1,10 +1,11 @@
-// Source: https://wiki.osdev.org/ISO_9660
+// Source:
+// - ISO9660: https://wiki.osdev.org/ISO_9660
+// - Joliet: https://pismotec.com/cfs/jolspec.html
 
 // Limitations:
 // - can only generate iso files
 // - only supports a single directory, no file system hierarchy
 // - root directory entry is limited to 2 KiB (~42 files)
-// - filenames are normalised to 8.3 length and [A-Z0-9_.]
 
 import { dbg_assert } from "./log.js";
 
@@ -16,6 +17,9 @@ const FILE_FLAGS_ASSOCIATED_FILE = 1 << 2;
 const FILE_FLAGS_HAS_EXTENDED_ATTRIBUTE_RECORD = 1 << 3;
 const FILE_FLAGS_HAS_PERMISSIONS = 1 << 4;
 const FILE_FLAGS_NOT_FINAL = 1 << 7;
+
+const SYSTEM_ID = "V86";
+const VOLUME_ID = "CDROM";
 
 /**
  * @param {Array.<{ name: string, contents: Uint8Array}>} files
@@ -46,32 +50,52 @@ export function generate(files)
         write8(b, 0);
     };
     const skip = (b, len) => { b.offset += len; };
+    const write_utf16be = (b, v) => {
+        for(let i = 0; i < v.length; i++) write_be16(b, v.charCodeAt(i));
+        return v.length * 2;
+    };
+    const write_padded_utf16be = (b, len, v) => write_utf16be(b, v.padEnd(len / 2));
 
-    const write_record = (b, name, flags, is_special, lba, len) => {
-        if(!is_special) name = sanitise_filename(name) + ";1";
+    const write_record = (b, name, flags, is_special, lba, len, joliet) => {
         // write name first and get its length
-        const START = buffer.offset;
+        const START = b.offset;
         const NAME_OFFSET = 33;
-        const name_len = te.encodeInto(name, b.buffer.subarray(b.offset + NAME_OFFSET)).written;
+        let name_len = 0;
+        if(joliet)
+        {
+            // encode into utf16be
+            name = sanitise_filename_joliet(name);
+            let name_buffer = {
+                buffer: b.buffer,
+                offset: START + NAME_OFFSET,
+            };
+            name_len = write_utf16be(name_buffer, name);
+        }
+        else
+        {
+            if(!is_special) name = sanitise_filename(name) + ";1";
+            name_len = te.encodeInto(name, b.buffer.subarray(b.offset + NAME_OFFSET)).written;
+        }
         const pad = (name_len & 1) ? 0 : 1;
         const len_field = 33 + name_len + pad;
         dbg_assert(len_field < 256);
-        write8(buffer, len_field);      // Length of directory record
-        write8(buffer, 0);              // Extended Attribute Record length
-        write_lebe32(buffer, lba);      // Location of extent (LBA)
-        write_lebe32(buffer, len);      // Data length (size of extent)
-        write_date_compact(buffer);
-        write8(buffer, flags);
-        write8(buffer, 0);              // File unit size for files recorded in interleaved mode, zero otherwise
-        write8(buffer, 0);              // Interleave gap size for files recorded in interleaved mode, zero otherwise
-        write_lebe16(buffer, 1);        // Volume sequence number - the volume that this extent is recorded on
-        write8(buffer, name_len);       // length of file name
-        dbg_assert(buffer.offset === START + NAME_OFFSET);
-        skip(buffer, name_len + pad);   // File name: was already written
-        dbg_assert(buffer.offset === START + len_field);
+
+        write8(b, len_field);      // Length of directory record
+        write8(b, 0);              // Extended Attribute Record length
+        write_lebe32(b, lba);      // Location of extent (LBA)
+        write_lebe32(b, len);      // Data length (size of extent)
+        write_date_compact(b);
+        write8(b, flags);
+        write8(b, 0);              // File unit size for files recorded in interleaved mode, zero otherwise
+        write8(b, 0);              // Interleave gap size for files recorded in interleaved mode, zero otherwise
+        write_lebe16(b, 1);        // Volume sequence number - the volume that this extent is recorded on
+        write8(b, name_len);       // length of file name
+        dbg_assert(b.offset === START + NAME_OFFSET);
+        skip(b, name_len + pad);   // File name: was already written
+        dbg_assert(b.offset === START + len_field);
     };
-    const write_special_directory_record = (b, name, lba, len) => write_record(b, name, FILE_FLAGS_DIRECTORY, true, lba, len);
-    const write_file_record = (b, name, lba, len) => write_record(b, name, 0, false, lba, len);
+    const write_special_directory_record = (b, name, lba, len) => write_record(b, name, FILE_FLAGS_DIRECTORY, true, lba, len, false);
+    const write_file_record = (b, name, lba, len, joliet) => write_record(b, name, 0, false, lba, len, joliet);
 
     function round_byte_size_to_block_size(n)
     {
@@ -101,37 +125,145 @@ export function generate(files)
         return to_msdos_filename(name.toUpperCase().replace(/[^A-Z0-9_.]/g, ""));
     }
 
+    function sanitise_filename_joliet(name)
+    {
+        return name.replace(/[*\/:;?\\]/g, "");
+    }
+
     // layout:
     // (lba = one block of BLOCK_SIZE bytes)
     // LBA   | contents
     // ------+--------
     // 0..15 | System Area (could be used for mbr, but not used by us)
     //    16 | Primary Volume Descriptor
-    //    17 | Volume Descriptor Set Terminator
-    //    18 | empty
+    //    17 | Supplementary Volume Descriptor (Joliet)
+    //    18 | Volume Descriptor Set Terminator
     //    19 | Little Endian Path Table
-    //    20 | empty
+    //    20 | Little Endian Path Table (Joliet)
     //    21 | Big Endian Path Table
-    //    22 | empty
+    //    22 | Big Endian Path Table (Joliet)
     //    23 | Root directory
-    // 24..n | File contents
+    //    24 | Root directory (Joliet)
+    // 25..n | File contents
     const SYSTEM_AREA_SIZE = 16 * BLOCK_SIZE;
     const PRIMARY_VOLUME_LBA = 16;
-    const VOLUME_SET_TERMINATOR_LBA = 17;
+    const SUPPLEMENTARY_VOLUME_LBA = 17;
+    const VOLUME_SET_TERMINATOR_LBA = 18;
     const LE_PATH_TABLE_LBA = 19;
+    const LE_PATH_TABLE_JOLIET_LBA = 20;
     const BE_PATH_TABLE_LBA = 21;
+    const BE_PATH_TABLE_JOLIET_LBA = 22;
     const ROOT_DIRECTORY_LBA = 23;
+    const ROOT_DIRECTORY_JOLIET_LBA = 24;
     const LE_PATH_TABLE_SIZE = BLOCK_SIZE;
     const BE_PATH_TABLE_SIZE = BLOCK_SIZE;
     const ROOT_DIRECTORY_SIZE = BLOCK_SIZE;
 
-    let next_file_lba = 24;
-    files = files.map(({ name, contents }) => {
+    const write_volume_descriptor = (is_supplementary) => {
+        const VD_OFFSET = (is_supplementary ? SUPPLEMENTARY_VOLUME_LBA : PRIMARY_VOLUME_LBA) * BLOCK_SIZE;
+
+        write8(buffer, is_supplementary ? 0x02 : 0x01); // Volume Descriptor type: Primary/Supplementary Volume Descriptor
+        write_ascii(buffer, "CD001");               // Always CD001
+        write8(buffer, 0x01);                       // Version
+        write8(buffer, 0x00);                       // unused
+        if(is_supplementary)
+        {
+            write_padded_utf16be(buffer, 32, SYSTEM_ID);    // System Identifier
+            write_padded_utf16be(buffer, 32, VOLUME_ID);    // Identification of this volume
+        }
+        else
+        {
+            write_padded_ascii(buffer, 32, SYSTEM_ID);
+            write_padded_ascii(buffer, 32, VOLUME_ID);
+        }
+
+        skip(buffer, 8);                            // unused
+        write_lebe32(buffer, N_LBAS);
+
+        // Escape Sequence
+        if(is_supplementary)
+        {
+            write_ascii(buffer, "%/C"); // UTF-16BE
+            skip(buffer, 29);
+        }
+        else
+        {
+            skip(buffer, 32); // unused
+        }
+        dbg_assert(buffer.offset === VD_OFFSET + 120);
+
+        write_lebe16(buffer, 1); // Volume Set Size
+        write_lebe16(buffer, 1); // Volume Sequence Number
+        dbg_assert(buffer.offset === VD_OFFSET + 128);
+
+        write_lebe16(buffer, BLOCK_SIZE);
+
+        write_lebe32(buffer, 10);               // Path Table Size
+        write_le32(buffer, is_supplementary ? LE_PATH_TABLE_JOLIET_LBA : LE_PATH_TABLE_LBA);  // Location of Type-L Path Table
+        write_le32(buffer, 0);                  // Location of the Optional Type-L Path Table
+        write_be32(buffer, is_supplementary ? BE_PATH_TABLE_JOLIET_LBA : BE_PATH_TABLE_LBA);  // Location of Type-M Path Table
+        write_be32(buffer, 0);                  // Location of the Optional Type-M Path Table
+        dbg_assert(buffer.offset === VD_OFFSET + 156);
+
+        // Directory entry for the root directory
+        write_special_directory_record(buffer, "\x00", is_supplementary ? ROOT_DIRECTORY_JOLIET_LBA : ROOT_DIRECTORY_LBA, 0x800);
+        dbg_assert(buffer.offset === VD_OFFSET + 190);
+
+        fill(buffer, 128, 0x20); // Volume Set Identifier
+        fill(buffer, 128, 0x20); // Publisher Identifier
+        fill(buffer, 128, 0x20); // Data Preparer Identifier
+        fill(buffer, 128, 0x20); // Application Identifier
+        fill(buffer,  37, 0x20); // Copyright File Identifier
+        fill(buffer,  37, 0x20); // Abstract File Identifier
+        fill(buffer,  37, 0x20); // Bibliographic File Identifier
+
+        dbg_assert(buffer.offset === VD_OFFSET + 813);
+
+        write_dummy_date_ascii(buffer); // Volume Creation Date and Time
+        write_dummy_date_ascii(buffer); // Volume Modification Date and Time
+        write_dummy_date_ascii(buffer); // Volume Expiration Date and Time
+        write_dummy_date_ascii(buffer); // Volume Effective Date and Time
+
+        write8(buffer, 0x01); // File Structure Version
+        dbg_assert(buffer.offset === VD_OFFSET + 882);
+
+        write8(buffer, 0x00); // Unused
+        skip(buffer, 512);    // Application Used
+        skip(buffer, 653);    // Reserved
+    };
+
+    const write_path_table = (start_lba, root_lba, is_le) => {
+        buffer.offset = start_lba * BLOCK_SIZE;
+        write8(buffer, 0x01);                   // Length of Directory Identifier
+        write8(buffer, 0x00);                   // Extended Attribute Record Length
+        if(is_le)
+        {
+            write_le32(buffer, root_lba);       // Location of Extent (LBA) ROOT_DIRECTORY_LBA
+            write_le16(buffer, 1);              // Directory number of parent directory
+        }
+        else
+        {
+            write_be32(buffer, root_lba);
+            write_be16(buffer, 1);
+        }
+        write_ascii(buffer, "\x00");            // file name
+    };
+
+    let next_file_lba = 25;
+    const iso_files = files.map(({ name, contents }) => {
         const lba = next_file_lba;
         next_file_lba += round_byte_size_to_block_size(contents.length);
-        name = to_msdos_filename(name);
         return { name, contents, lba };
     });
+
+    const write_root_directory = (start_lba, joliet) => {
+        write_special_directory_record(buffer, "\x00", start_lba, 0x800);  // "."
+        write_special_directory_record(buffer, "\x01", start_lba, 0x800);  // ".."
+        for(const { name, contents, lba } of iso_files)
+        {
+            write_file_record(buffer, joliet ? name : to_msdos_filename(name), lba, contents.length, joliet);
+        }
+    };
 
     const N_LBAS = next_file_lba;
     const total_size = N_LBAS * BLOCK_SIZE;
@@ -143,94 +275,48 @@ export function generate(files)
 
     // LBA 16: Primary Volume Descriptor
     dbg_assert(buffer.offset === PRIMARY_VOLUME_LBA * BLOCK_SIZE);
-    write8(buffer, 0x01);                    // Volume Descriptor type: Primary Volume Descriptor
-    write_ascii(buffer, "CD001");            // Always CD001
-    write8(buffer, 0x01);                    // Version
-    write8(buffer, 0x00);                    // unused
-    write_padded_ascii(buffer, 32, "V86");   // System Identifier
-    write_padded_ascii(buffer, 32, "CDROM"); // Identification of this volume
-    skip(buffer, 8);                         // unused
-    write_lebe32(buffer, N_LBAS);
-    skip(buffer, 32);                        // unused
-    dbg_assert(buffer.offset === 0x8000 + 120);
+    write_volume_descriptor(false);
 
-    write_lebe16(buffer, 1); // Volume Set Size
-    write_lebe16(buffer, 1); // Volume Sequence Number
-    dbg_assert(buffer.offset === 0x8080);
+    // LBA 17: Supplementary Volume Descriptor
+    dbg_assert(buffer.offset === SUPPLEMENTARY_VOLUME_LBA * BLOCK_SIZE);
+    write_volume_descriptor(true);
 
-    write_lebe16(buffer, BLOCK_SIZE);
-
-    write_lebe32(buffer, 10);               // Path Table Size
-    write_le32(buffer, LE_PATH_TABLE_LBA);  // Location of Type-L Path Table
-    write_le32(buffer, 0);                  // Location of the Optional Type-L Path Table
-    write_be32(buffer, BE_PATH_TABLE_LBA);  // Location of Type-M Path Table
-    write_be32(buffer, 0);                  // Location of the Optional Type-M Path Table
-    dbg_assert(buffer.offset === 0x8000 + 156);
-
-    // Directory entry for the root directory
-    write_special_directory_record(buffer, "\x00", ROOT_DIRECTORY_LBA, 0x800);
-    dbg_assert(buffer.offset === 0x8000 + 190);
-
-    fill(buffer, 128, 0x20); // Volume Set Identifier
-    fill(buffer, 128, 0x20); // Publisher Identifier
-    fill(buffer, 128, 0x20); // Data Preparer Identifier
-    fill(buffer, 128, 0x20); // Application Identifier
-    fill(buffer,  37, 0x20); // Copyright File Identifier
-    fill(buffer,  37, 0x20); // Abstract File Identifier
-    fill(buffer,  37, 0x20); // Bibliographic File Identifier
-
-    dbg_assert(buffer.offset === 0x8000 + 813);
-
-    write_dummy_date_ascii(buffer); // Volume Creation Date and Time
-    write_dummy_date_ascii(buffer); // Volume Modification Date and Time
-    write_dummy_date_ascii(buffer); // Volume Expiration Date and Time
-    write_dummy_date_ascii(buffer); // Volume Effective Date and Time
-
-    write8(buffer, 0x01); // File Structure Version
-    dbg_assert(buffer.offset === 0x8000 + 882);
-
-    write8(buffer, 0x00); // Unused
-    skip(buffer, 512);    // Application Used
-    skip(buffer, 653);    // Reserved
-
-    // LBA 17: Volume Descriptor Set Terminator
+    // LBA 18: Volume Descriptor Set Terminator
     dbg_assert(buffer.offset === VOLUME_SET_TERMINATOR_LBA * BLOCK_SIZE);
     write8(buffer, 0xFF);           // 0xFF: Volume Descriptor Set Terminator
     write_ascii(buffer, "CD001");   // Always CD001
     write8(buffer, 0x01);           // Version
 
     // LBA 19: Little Endian Path Table
-    buffer.offset = LE_PATH_TABLE_LBA * BLOCK_SIZE;
-    write8(buffer, 0x01);                   // Length of Directory Identifier
-    write8(buffer, 0x00);                   // Extended Attribute Record Length
-    write_le32(buffer, ROOT_DIRECTORY_LBA); // Location of Extent (LBA)
-    write_le16(buffer, 1);                  // Directory number of parent directory
-    write_ascii(buffer, "\x00");            // file name
+    write_path_table(LE_PATH_TABLE_LBA, ROOT_DIRECTORY_LBA, true);
     dbg_assert(buffer.offset < LE_PATH_TABLE_LBA * BLOCK_SIZE + LE_PATH_TABLE_SIZE);
 
+    // LBA 20: Little Endian Path Table (Joliet)
+    write_path_table(LE_PATH_TABLE_JOLIET_LBA, ROOT_DIRECTORY_JOLIET_LBA, true);
+    dbg_assert(buffer.offset < LE_PATH_TABLE_JOLIET_LBA * BLOCK_SIZE + LE_PATH_TABLE_SIZE);
+
     // LBA 21: Big Endian Path Table
-    buffer.offset = BE_PATH_TABLE_LBA * BLOCK_SIZE;
-    write8(buffer, 0x01);                   // Length of Directory Identifier
-    write8(buffer, 0x00);                   // Extended Attribute Record Length
-    write_be32(buffer, ROOT_DIRECTORY_LBA); // Location of Extent (LBA)
-    write_be16(buffer, 1);                  // Directory number of parent directory
-    write_ascii(buffer, "\x00");            // file name
+    write_path_table(BE_PATH_TABLE_LBA, ROOT_DIRECTORY_LBA, false);
     dbg_assert(buffer.offset < BE_PATH_TABLE_LBA * BLOCK_SIZE + BE_PATH_TABLE_SIZE);
+
+    // LBA 22: Big Endian Path Table (Joliet)
+    write_path_table(BE_PATH_TABLE_JOLIET_LBA, ROOT_DIRECTORY_JOLIET_LBA, false);
+    dbg_assert(buffer.offset < BE_PATH_TABLE_JOLIET_LBA * BLOCK_SIZE + BE_PATH_TABLE_SIZE);
 
     // LBA 23: root directory
     buffer.offset = ROOT_DIRECTORY_LBA * BLOCK_SIZE;
-    write_special_directory_record(buffer, "\x00", ROOT_DIRECTORY_LBA, 0x800);  // "."
-    write_special_directory_record(buffer, "\x01", ROOT_DIRECTORY_LBA, 0x800);  // ".."
-    for(const { name, contents, lba } of files)
-    {
-        write_file_record(buffer, name, lba, contents.length);
-    }
+    write_root_directory(ROOT_DIRECTORY_LBA, false);
     // TODO: this assertion can fail if too many files are used as input
     // ROOT_DIRECTORY_SIZE should be choosen dynamically
     dbg_assert(buffer.offset < ROOT_DIRECTORY_LBA * BLOCK_SIZE + ROOT_DIRECTORY_SIZE);
 
+    // LBA 24: root directory (Joliet)
+    buffer.offset = ROOT_DIRECTORY_JOLIET_LBA * BLOCK_SIZE;
+    write_root_directory(ROOT_DIRECTORY_JOLIET_LBA, true);
+    dbg_assert(buffer.offset < ROOT_DIRECTORY_JOLIET_LBA * BLOCK_SIZE + ROOT_DIRECTORY_SIZE);
+
     // file contents
-    for(let { contents, lba } of files)
+    for(let { contents, lba } of iso_files)
     {
         buffer.buffer.set(contents, lba * BLOCK_SIZE);
     }


### PR DESCRIPTION
Adds the Joliet extension, which allows the use of UTF-16 file names. Tested on Windows 2000 and [chschnell/v86-buildroot v1.0.2](https://github.com/chschnell/v86-buildroot/releases/tag/v1.0.2).

<img width="438" height="224" alt="joliet-w2k" src="https://github.com/user-attachments/assets/e1f5ee3f-0652-4bba-a416-db98ec0dc523" />

<img width="543" height="94" alt="joliet-buildroot" src="https://github.com/user-attachments/assets/7571bf81-1671-4cb0-a68b-c01e35db65f9" />


